### PR TITLE
support variables on simple properties

### DIFF
--- a/test/native/lib/TestEmitter.re
+++ b/test/native/lib/TestEmitter.re
@@ -48,10 +48,14 @@ let properties_static_css_tests = [
   ([%expr [%css "opacity: 0.9"]], [%expr [Css.opacity(0.9)]]),
   ([%expr [%css "width: 100vw"]], [%expr [Css.width(Css.vw(100.))]]),
   ([%expr [%css "flex-wrap: wrap"]], [%expr [Css.flexWrap(`wrap)]]),
+  // TODO: generate tests with variables in the future
+  ([%expr [%css "flex-wrap: $var"]], [%expr [Css.flexWrap(var)]]),
+  ([%expr [%css "flex-wrap: $(var)"]], [%expr [Css.flexWrap(var)]]),
   (
     [%expr [%css "flex-flow: row nowrap"]],
     [%expr [Css.flexDirection(`row), Css.flexWrap(`nowrap)]],
   ),
+  // TODO: flex-flow + variables
   ([%expr [%css "order: 5"]], [%expr [Css.order(5)]]),
   ([%expr [%css "flex-grow: 2"]], [%expr [Css.flexGrow(2.)]]),
   ([%expr [%css "flex-grow: 2.5"]], [%expr [Css.flexGrow(2.5)]]),


### PR DESCRIPTION
This PR implements basic variable support to our new properties in the new parser. Mostly simple properties are supported, but they need to be handled manually, I'm still thinking on a more broader API to make it easier to handle complex properties.

It also supports an alternative syntax $(var), as that can carry additional information to use in the future.