### PR TITLE
Fix examples on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,29 +17,30 @@ This is how you can write components in ReasonML or OCaml with this ppx:
 
 ### Standard styled component
 ```reason
-module StyledComponent = [%styled.div {|
-  display: flex;
-  justify-content: center;
+module StyledComponent = [%styled.div
+  {|
   align-items: center;
-
+  display: flex;
   height: 100vh;
+  justify-content: center;
   width: 100vw;
-|}];
+|}
+];
 
 ReactDOMRe.renderToElementWithId(
-  <StyledComponent>
-    {React.string("- Middle -")}
-  </StyledComponent>,
-  "app"
+  <StyledComponent> {React.string("- Middle -")} </StyledComponent>,
+  "app",
 );
 ```
 
 ### Dynamic styled component
 ```reason
-module Dynamic = [%styled (~color, ~background) => {j|
+module Dynamic = [%styled
+  (~color, ~background) => {j|
   color: $color;
   background-color: $background;
-|j}];
+|j}
+];
 
 ReactDOMRe.renderToElementWithId(
   <Dynamic color="#EB5757" background="#516CF0">
@@ -52,9 +53,7 @@ ReactDOMRe.renderToElementWithId(
 ### Inline css function
 ```reason
 ReactDOMRe.renderToElementWithId(
-  <span className=[%css "font-size: 34px"]>
-    {React.string("Hello!")}
-  </span>,
+  <span className=[%css "font-size: 32px"]> {React.string("Hello!")} </span>,
   "app",
 );
 ```

--- a/README.md
+++ b/README.md
@@ -36,26 +36,26 @@ ReactDOMRe.renderToElementWithId(
 
 ### Dynamic styled component
 ```reason
-module Dynamic = [%styled (~content, ~background) => {j|
-  color: $(content);
-  background-color: $(background);
+module Dynamic = [%styled (~color, ~background) => {j|
+  color: $color;
+  background-color: $background;
 |j}];
 
 ReactDOMRe.renderToElementWithId(
-  <Dynamic content="#EB5757" background="#516CF0" />
-      {React.string("Hello!")}
+  <Dynamic color="#EB5757" background="#516CF0">
+    {React.string("Hello!")}
   </Dynamic>,
-  "app"
+  "app",
 );
 ```
 
 ### Inline css function
 ```reason
 ReactDOMRe.renderToElementWithId(
-  <span className=[%css "font-size: 34px"]/>
+  <span className=[%css "font-size: 34px"]>
     {React.string("Hello!")}
   </span>,
-  "app"
+  "app",
 );
 ```
 


### PR DESCRIPTION
[Dynamic](https://github.com/davesnx/styled-ppx#dynamic-styled-component) and [Inline](https://github.com/davesnx/styled-ppx#dynamic-styled-component) examples has a unexpected close of their elements

By the way, I formatted the other examples too, if it was unnecessary let me know!
