### PR TITLE
fallback to unsupported properties by bs-css

### DIFF
--- a/src/declarations_to_emotion.re
+++ b/src/declarations_to_emotion.re
@@ -725,7 +725,13 @@ let align_self = variants(property_align_self, [%expr Css.alignSelf]);
 let align_content =
   variants(property_align_content, [%expr Css.alignContent]);
 
-let found = ({string_to_expr, _}) => string_to_expr;
+let found = ({ast_of_string, string_to_expr, _}) => {
+  let check_value = string => {
+    let.ok _ = ast_of_string(string);
+    Ok();
+  };
+  (check_value, string_to_expr);
+};
 let properties = [
   // css-sizing-3
   ("width", found(width)),
@@ -794,14 +800,30 @@ let properties = [
 
 let support_property = name =>
   properties |> List.exists(((key, _)) => key == name);
+
+let render_when_unsupported_features = (name, value) => {
+  let name = name |> Const.string |> Exp.constant;
+  let value = value |> Const.string |> Exp.constant;
+
+  id([%expr Css.unsafe([%e name], [%e value])]);
+};
 let parse_declarations = ((name, value)) => {
-  let.ok (_, string_to_expr) =
+  let map_parse_error = result =>
+    Result.map_error(str => `Invalid_value(str), result);
+
+  let.ok (_, (check_string, string_to_expr)) =
     properties
     |> List.find_opt(((key, _)) => key == name)
     |> Option.to_result(~none=`Not_found);
+
   switch (render_css_wide_keywords(name, value)) {
   | Ok(value) => Ok(value)
   | Error(_) =>
-    string_to_expr(value) |> Result.map_error(str => `Invalid_value(str))
+    let.ok () = check_string(value) |> map_parse_error;
+    switch (string_to_expr(value)) {
+    | result => map_parse_error(result)
+    | exception Unsupported_feature =>
+      Ok([render_when_unsupported_features(name, value)])
+    };
   };
 };

--- a/src/declarations_to_emotion.re
+++ b/src/declarations_to_emotion.re
@@ -802,7 +802,14 @@ let support_property = name =>
   properties |> List.exists(((key, _)) => key == name);
 
 let render_when_unsupported_features = (name, value) => {
-  let name = name |> Const.string |> Exp.constant;
+  let to_camel_case = name =>
+    name
+    |> String.split_on_char('-')
+    |> List.map(String.capitalize_ascii)
+    |> String.concat("")
+    |> String.uncapitalize_ascii;
+
+  let name = to_camel_case(name) |> Const.string |> Exp.constant;
   let value = value |> Const.string |> Exp.constant;
 
   id([%expr Css.unsafe([%e name], [%e value])]);

--- a/test/bucklescript/src/__snapshots__/css_support_test.bs.js.snap
+++ b/test/bucklescript/src/__snapshots__/css_support_test.bs.js.snap
@@ -64,36 +64,64 @@ exports[`Component 30 renders 1`] = `"css-9527m7"`;
 
 exports[`Component 31 renders 1`] = `"css-1w14jv3"`;
 
-exports[`Component 32 renders 1`] = `"css-ayshjd"`;
+exports[`Component 32 renders 1`] = `"css-7e64g9"`;
 
-exports[`Component 33 renders 1`] = `"css-144vlu9"`;
+exports[`Component 33 renders 1`] = `"css-5oqj5t"`;
 
-exports[`Component 34 renders 1`] = `"css-xdees7"`;
+exports[`Component 34 renders 1`] = `"css-1qkvgnl"`;
 
-exports[`Component 35 renders 1`] = `"css-1ofy66z"`;
+exports[`Component 35 renders 1`] = `"css-p2ykkr"`;
 
-exports[`Component 36 renders 1`] = `"css-bkj8c"`;
+exports[`Component 36 renders 1`] = `"css-uj3ky3"`;
 
-exports[`Component 37 renders 1`] = `"css-bmjq4j"`;
+exports[`Component 37 renders 1`] = `"css-thzv76"`;
 
-exports[`Component 38 renders 1`] = `"css-10iahqc"`;
+exports[`Component 38 renders 1`] = `"css-1wq4akx"`;
 
-exports[`Component 39 renders 1`] = `"css-1vw5a1r"`;
+exports[`Component 39 renders 1`] = `"css-169xr62"`;
 
-exports[`Component 40 renders 1`] = `"css-1nw2x84"`;
+exports[`Component 40 renders 1`] = `"css-nvmiwy"`;
 
-exports[`Component 41 renders 1`] = `"css-9x4jlj"`;
+exports[`Component 41 renders 1`] = `"css-169xr62"`;
 
-exports[`Component 42 renders 1`] = `"css-kilw6e"`;
+exports[`Component 42 renders 1`] = `"css-nvmiwy"`;
 
-exports[`Component 43 renders 1`] = `"css-13brihr"`;
+exports[`Component 43 renders 1`] = `"css-19whxpe"`;
 
-exports[`Component 44 renders 1`] = `"css-1ncsbtn"`;
+exports[`Component 44 renders 1`] = `"css-1tzeee1"`;
 
-exports[`Component 45 renders 1`] = `"css-ibk9g"`;
+exports[`Component 45 renders 1`] = `"css-1vs9cou"`;
 
-exports[`Component 46 renders 1`] = `"css-ufkhx2"`;
+exports[`Component 46 renders 1`] = `"css-ayshjd"`;
 
-exports[`Component 47 renders 1`] = `"css-cgts8g"`;
+exports[`Component 47 renders 1`] = `"css-144vlu9"`;
 
-exports[`Component 48 renders 1`] = `"css-1x2q6ya"`;
+exports[`Component 48 renders 1`] = `"css-xdees7"`;
+
+exports[`Component 49 renders 1`] = `"css-1ofy66z"`;
+
+exports[`Component 50 renders 1`] = `"css-bkj8c"`;
+
+exports[`Component 51 renders 1`] = `"css-bmjq4j"`;
+
+exports[`Component 52 renders 1`] = `"css-10iahqc"`;
+
+exports[`Component 53 renders 1`] = `"css-1vw5a1r"`;
+
+exports[`Component 54 renders 1`] = `"css-1nw2x84"`;
+
+exports[`Component 55 renders 1`] = `"css-9x4jlj"`;
+
+exports[`Component 56 renders 1`] = `"css-kilw6e"`;
+
+exports[`Component 57 renders 1`] = `"css-13brihr"`;
+
+exports[`Component 58 renders 1`] = `"css-1ncsbtn"`;
+
+exports[`Component 59 renders 1`] = `"css-ibk9g"`;
+
+exports[`Component 60 renders 1`] = `"css-ufkhx2"`;
+
+exports[`Component 61 renders 1`] = `"css-cgts8g"`;
+
+exports[`Component 62 renders 1`] = `"css-1x2q6ya"`;

--- a/test/bucklescript/src/__snapshots__/css_support_test.bs.js.snap
+++ b/test/bucklescript/src/__snapshots__/css_support_test.bs.js.snap
@@ -1,125 +1,99 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component 0 renders 1`] = `"css-cyc7w5"`;
+exports[`Component 0 renders 1`] = `"css-1th3fel"`;
 
-exports[`Component 1 renders 1`] = `"css-g393ep"`;
+exports[`Component 1 renders 1`] = `"css-cyc7w5"`;
 
-exports[`Component 2 renders 1`] = `"css-roynbj"`;
+exports[`Component 2 renders 1`] = `"css-g393ep"`;
 
-exports[`Component 3 renders 1`] = `"css-14y7xed"`;
+exports[`Component 3 renders 1`] = `"css-roynbj"`;
 
-exports[`Component 4 renders 1`] = `"css-mi7h12"`;
+exports[`Component 4 renders 1`] = `"css-14y7xed"`;
 
-exports[`Component 5 renders 1`] = `"css-bv5c0r"`;
+exports[`Component 5 renders 1`] = `"css-mi7h12"`;
 
-exports[`Component 6 renders 1`] = `"css-1e042ms"`;
+exports[`Component 6 renders 1`] = `"css-bv5c0r"`;
 
-exports[`Component 7 renders 1`] = `"css-68zbsl"`;
+exports[`Component 7 renders 1`] = `"css-1e042ms"`;
 
-exports[`Component 8 renders 1`] = `"css-196jqjz"`;
+exports[`Component 8 renders 1`] = `"css-68zbsl"`;
 
-exports[`Component 9 renders 1`] = `"css-1e3sj1t"`;
+exports[`Component 9 renders 1`] = `"css-196jqjz"`;
 
-exports[`Component 10 renders 1`] = `"css-h7gl5m"`;
+exports[`Component 10 renders 1`] = `"css-1e3sj1t"`;
 
-exports[`Component 11 renders 1`] = `"css-13tmvf7"`;
+exports[`Component 11 renders 1`] = `"css-h7gl5m"`;
 
-exports[`Component 12 renders 1`] = `"css-79p6ya"`;
+exports[`Component 12 renders 1`] = `"css-13tmvf7"`;
 
-exports[`Component 13 renders 1`] = `"css-fbrjo0"`;
+exports[`Component 13 renders 1`] = `"css-79p6ya"`;
 
-exports[`Component 14 renders 1`] = `"css-roynbj"`;
+exports[`Component 14 renders 1`] = `"css-fbrjo0"`;
 
-exports[`Component 15 renders 1`] = `"css-8xl60i"`;
+exports[`Component 15 renders 1`] = `"css-roynbj"`;
 
-exports[`Component 16 renders 1`] = `"css-1idpeqj"`;
+exports[`Component 16 renders 1`] = `"css-8xl60i"`;
 
-exports[`Component 17 renders 1`] = `"css-wlea3r"`;
+exports[`Component 17 renders 1`] = `"css-1idpeqj"`;
 
-exports[`Component 18 renders 1`] = `"css-9n3bbc"`;
+exports[`Component 18 renders 1`] = `"css-wlea3r"`;
 
-exports[`Component 19 renders 1`] = `"css-13d3w74"`;
+exports[`Component 19 renders 1`] = `"css-9n3bbc"`;
 
-exports[`Component 20 renders 1`] = `"css-8kui69"`;
+exports[`Component 20 renders 1`] = `"css-13d3w74"`;
 
-exports[`Component 21 renders 1`] = `"css-1y0h3u2"`;
+exports[`Component 21 renders 1`] = `"css-8kui69"`;
 
-exports[`Component 22 renders 1`] = `"css-aja1e7"`;
+exports[`Component 22 renders 1`] = `"css-1y0h3u2"`;
 
-exports[`Component 23 renders 1`] = `"css-1dacand"`;
+exports[`Component 23 renders 1`] = `"css-aja1e7"`;
 
-exports[`Component 24 renders 1`] = `"css-1o2slct"`;
+exports[`Component 24 renders 1`] = `"css-1dacand"`;
 
-exports[`Component 25 renders 1`] = `"css-1drbkg9"`;
+exports[`Component 25 renders 1`] = `"css-1o2slct"`;
 
-exports[`Component 26 renders 1`] = `"css-p1hdku"`;
+exports[`Component 26 renders 1`] = `"css-1drbkg9"`;
 
-exports[`Component 27 renders 1`] = `"css-5tigzz"`;
+exports[`Component 27 renders 1`] = `"css-p1hdku"`;
 
-exports[`Component 28 renders 1`] = `"css-1no595r"`;
+exports[`Component 28 renders 1`] = `"css-5tigzz"`;
 
-exports[`Component 29 renders 1`] = `"css-9527m7"`;
+exports[`Component 29 renders 1`] = `"css-1no595r"`;
 
-exports[`Component 30 renders 1`] = `"css-1w14jv3"`;
+exports[`Component 30 renders 1`] = `"css-9527m7"`;
 
-exports[`Component 31 renders 1`] = `"css-7e64g9"`;
+exports[`Component 31 renders 1`] = `"css-1w14jv3"`;
 
-exports[`Component 32 renders 1`] = `"css-5oqj5t"`;
+exports[`Component 32 renders 1`] = `"css-ayshjd"`;
 
-exports[`Component 33 renders 1`] = `"css-1qkvgnl"`;
+exports[`Component 33 renders 1`] = `"css-144vlu9"`;
 
-exports[`Component 34 renders 1`] = `"css-p2ykkr"`;
+exports[`Component 34 renders 1`] = `"css-xdees7"`;
 
-exports[`Component 35 renders 1`] = `"css-uj3ky3"`;
+exports[`Component 35 renders 1`] = `"css-1ofy66z"`;
 
-exports[`Component 36 renders 1`] = `"css-thzv76"`;
+exports[`Component 36 renders 1`] = `"css-bkj8c"`;
 
-exports[`Component 37 renders 1`] = `"css-1wq4akx"`;
+exports[`Component 37 renders 1`] = `"css-bmjq4j"`;
 
-exports[`Component 38 renders 1`] = `"css-169xr62"`;
+exports[`Component 38 renders 1`] = `"css-10iahqc"`;
 
-exports[`Component 39 renders 1`] = `"css-nvmiwy"`;
+exports[`Component 39 renders 1`] = `"css-1vw5a1r"`;
 
-exports[`Component 40 renders 1`] = `"css-169xr62"`;
+exports[`Component 40 renders 1`] = `"css-1nw2x84"`;
 
-exports[`Component 41 renders 1`] = `"css-nvmiwy"`;
+exports[`Component 41 renders 1`] = `"css-9x4jlj"`;
 
-exports[`Component 42 renders 1`] = `"css-19whxpe"`;
+exports[`Component 42 renders 1`] = `"css-kilw6e"`;
 
-exports[`Component 43 renders 1`] = `"css-1tzeee1"`;
+exports[`Component 43 renders 1`] = `"css-13brihr"`;
 
-exports[`Component 44 renders 1`] = `"css-1vs9cou"`;
+exports[`Component 44 renders 1`] = `"css-1ncsbtn"`;
 
-exports[`Component 45 renders 1`] = `"css-ayshjd"`;
+exports[`Component 45 renders 1`] = `"css-ibk9g"`;
 
-exports[`Component 46 renders 1`] = `"css-144vlu9"`;
+exports[`Component 46 renders 1`] = `"css-ufkhx2"`;
 
-exports[`Component 47 renders 1`] = `"css-xdees7"`;
+exports[`Component 47 renders 1`] = `"css-cgts8g"`;
 
-exports[`Component 48 renders 1`] = `"css-1ofy66z"`;
-
-exports[`Component 49 renders 1`] = `"css-bkj8c"`;
-
-exports[`Component 50 renders 1`] = `"css-bmjq4j"`;
-
-exports[`Component 51 renders 1`] = `"css-10iahqc"`;
-
-exports[`Component 52 renders 1`] = `"css-1vw5a1r"`;
-
-exports[`Component 53 renders 1`] = `"css-1nw2x84"`;
-
-exports[`Component 54 renders 1`] = `"css-9x4jlj"`;
-
-exports[`Component 55 renders 1`] = `"css-kilw6e"`;
-
-exports[`Component 56 renders 1`] = `"css-13brihr"`;
-
-exports[`Component 57 renders 1`] = `"css-1ncsbtn"`;
-
-exports[`Component 58 renders 1`] = `"css-ibk9g"`;
-
-exports[`Component 59 renders 1`] = `"css-ufkhx2"`;
-
-exports[`Component 60 renders 1`] = `"css-cgts8g"`;
-
-exports[`Component 61 renders 1`] = `"css-1x2q6ya"`;
+exports[`Component 48 renders 1`] = `"css-1x2q6ya"`;

--- a/test/bucklescript/src/css_support_test.re
+++ b/test/bucklescript/src/css_support_test.re
@@ -1,6 +1,7 @@
 open Jest;
 
 let supportList = [
+  [%css "overflow-x: clip"],
   [%css "opacity: 0.9"],
   /* [%css "box-shadow: 1px 54px 1px blue"], */
   /* [%css "box-shadow: 2px 3px blue"], */

--- a/test/native/lib/TestEmitter.re
+++ b/test/native/lib/TestEmitter.re
@@ -21,7 +21,7 @@ let properties_static_css_tests = [
   // unsupported
   (
     [%expr [%css "overflow-x: clip"]],
-    [%expr [Css.unsafe("overflow-x", "clip")]],
+    [%expr [Css.unsafe("overflowX", "clip")]],
   ),
   ([%expr [%css "align-items: center"]], [%expr [Css.alignItems(`center)]]),
   (

--- a/test/native/lib/TestEmitter.re
+++ b/test/native/lib/TestEmitter.re
@@ -18,6 +18,11 @@ let compare = (result, expected, {expect, _}) => {
 // TODO: ideas, selectors . properties, to have a bigger test matrix
 // somehow programatically generate strings to test css
 let properties_static_css_tests = [
+  // unsupported
+  (
+    [%expr [%css "overflow-x: clip"]],
+    [%expr [Css.unsafe("overflow-x", "clip")]],
+  ),
   ([%expr [%css "align-items: center"]], [%expr [Css.alignItems(`center)]]),
   (
     [%expr [%css "box-sizing: border-box"]],


### PR DESCRIPTION
As discussed on discord, we can fallback to `Css.unsafe` when there is something unsupported by `bs-css`, this PR does that.

## **Warning**

This currently doesn't support variables, as that would be string concatenation and our parser will not be able to check for that