### PR TITLE
css-images-4 and css-backgrounds-3

### DIFF
--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "ede53681be697eb4ee58261b0f8db96d",
+  "checksum": "c14fdfd2d6ecf16d2bce296f925b7bf8",
   "root": "styled-ppx@link-dev:./package.json",
   "node": {
     "styled-ppx@link-dev:./package.json": {
@@ -12,9 +12,9 @@
         "manifest": "package.json"
       },
       "overrides": [],
-      "dependencies": [],
+      "dependencies": [ "@opam/ppxlib@opam:0.14.0@c02ad40d" ],
       "devDependencies": [
-        "reason-css-parser@github:EduardoRFS/reason-css-parser:package.json#af422f9f3a7973b48ae92fe363221d7e17461450@d41d8cd9",
+        "reason-css-parser@github:EduardoRFS/reason-css-parser:package.json#99da696f761823b959214f89b1687d0c4b261538@d41d8cd9",
         "ocaml@4.10.0@d41d8cd9", "@reason-native/rely@3.2.1@d41d8cd9",
         "@opam/sedlex@opam:2.2@ffde36c0",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
@@ -51,16 +51,16 @@
       ],
       "devDependencies": []
     },
-    "reason-css-parser@github:EduardoRFS/reason-css-parser:package.json#af422f9f3a7973b48ae92fe363221d7e17461450@d41d8cd9": {
+    "reason-css-parser@github:EduardoRFS/reason-css-parser:package.json#99da696f761823b959214f89b1687d0c4b261538@d41d8cd9": {
       "id":
-        "reason-css-parser@github:EduardoRFS/reason-css-parser:package.json#af422f9f3a7973b48ae92fe363221d7e17461450@d41d8cd9",
+        "reason-css-parser@github:EduardoRFS/reason-css-parser:package.json#99da696f761823b959214f89b1687d0c4b261538@d41d8cd9",
       "name": "reason-css-parser",
       "version":
-        "github:EduardoRFS/reason-css-parser:package.json#af422f9f3a7973b48ae92fe363221d7e17461450",
+        "github:EduardoRFS/reason-css-parser:package.json#99da696f761823b959214f89b1687d0c4b261538",
       "source": {
         "type": "install",
         "source": [
-          "github:EduardoRFS/reason-css-parser:package.json#af422f9f3a7973b48ae92fe363221d7e17461450"
+          "github:EduardoRFS/reason-css-parser:package.json#99da696f761823b959214f89b1687d0c4b261538"
         ]
       },
       "overrides": [],
@@ -612,6 +612,39 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82"
       ]
     },
+    "@opam/ppxlib@opam:0.14.0@c02ad40d": {
+      "id": "@opam/ppxlib@opam:0.14.0@c02ad40d",
+      "name": "@opam/ppxlib",
+      "version": "opam:0.14.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/a1/a1a398f7c8f670d7de80468ff4639862b126f4dcac3de416e0c5c4d5860f3854#sha256:a1a398f7c8f670d7de80468ff4639862b126f4dcac3de416e0c5c4d5860f3854",
+          "archive:https://github.com/ocaml-ppx/ppxlib/releases/download/0.14.0/ppxlib-0.14.0.tbz#sha256:a1a398f7c8f670d7de80468ff4639862b126f4dcac3de416e0c5c4d5860f3854"
+        ],
+        "opam": {
+          "name": "ppxlib",
+          "version": "0.14.0",
+          "path": "esy.lock/opam/ppxlib.0.14.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.13.0@eb59d879",
+        "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
+        "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
+        "@opam/ocaml-compiler-libs@opam:v0.12.1@5c34eb0d",
+        "@opam/dune@opam:2.5.1@f38f376e", "@opam/base@opam:v0.13.2@c3150775",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/stdio@opam:v0.13.0@eb59d879",
+        "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
+        "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
+        "@opam/ocaml-compiler-libs@opam:v0.12.1@5c34eb0d",
+        "@opam/dune@opam:2.5.1@f38f376e", "@opam/base@opam:v0.13.2@c3150775"
+      ]
+    },
     "@opam/ppxfind@opam:1.4@1e01d2a5": {
       "id": "@opam/ppxfind@opam:1.4@1e01d2a5",
       "name": "@opam/ppxfind",
@@ -1030,6 +1063,31 @@
         "@opam/menhir@opam:20200211@26571604",
         "@opam/dune-build-info@opam:2.6.1@611bb155",
         "@opam/dune@opam:2.5.1@f38f376e"
+      ]
+    },
+    "@opam/ocaml-compiler-libs@opam:v0.12.1@5c34eb0d": {
+      "id": "@opam/ocaml-compiler-libs@opam:v0.12.1@5c34eb0d",
+      "name": "@opam/ocaml-compiler-libs",
+      "version": "opam:v0.12.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/2f/2f929af7c764a3f681a5671f271210c4#md5:2f929af7c764a3f681a5671f271210c4",
+          "archive:https://github.com/janestreet/ocaml-compiler-libs/archive/v0.12.1.tar.gz#md5:2f929af7c764a3f681a5671f271210c4"
+        ],
+        "opam": {
+          "name": "ocaml-compiler-libs",
+          "version": "v0.12.1",
+          "path": "esy.lock/opam/ocaml-compiler-libs.v0.12.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e"
       ]
     },
     "@opam/merlin-extend@opam:0.5@675b1611": {

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "cb4a1cc186122470c09471b5dd7ed409",
+  "checksum": "ede53681be697eb4ee58261b0f8db96d",
   "root": "styled-ppx@link-dev:./package.json",
   "node": {
     "styled-ppx@link-dev:./package.json": {
@@ -14,7 +14,7 @@
       "overrides": [],
       "dependencies": [],
       "devDependencies": [
-        "reason-css-parser@github:EduardoRFS/reason-css-parser:package.json#bba47cd3228cb6f71b9beac7673f3d31516521fe@d41d8cd9",
+        "reason-css-parser@github:EduardoRFS/reason-css-parser:package.json#af422f9f3a7973b48ae92fe363221d7e17461450@d41d8cd9",
         "ocaml@4.10.0@d41d8cd9", "@reason-native/rely@3.2.1@d41d8cd9",
         "@opam/sedlex@opam:2.2@ffde36c0",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
@@ -51,16 +51,16 @@
       ],
       "devDependencies": []
     },
-    "reason-css-parser@github:EduardoRFS/reason-css-parser:package.json#bba47cd3228cb6f71b9beac7673f3d31516521fe@d41d8cd9": {
+    "reason-css-parser@github:EduardoRFS/reason-css-parser:package.json#af422f9f3a7973b48ae92fe363221d7e17461450@d41d8cd9": {
       "id":
-        "reason-css-parser@github:EduardoRFS/reason-css-parser:package.json#bba47cd3228cb6f71b9beac7673f3d31516521fe@d41d8cd9",
+        "reason-css-parser@github:EduardoRFS/reason-css-parser:package.json#af422f9f3a7973b48ae92fe363221d7e17461450@d41d8cd9",
       "name": "reason-css-parser",
       "version":
-        "github:EduardoRFS/reason-css-parser:package.json#bba47cd3228cb6f71b9beac7673f3d31516521fe",
+        "github:EduardoRFS/reason-css-parser:package.json#af422f9f3a7973b48ae92fe363221d7e17461450",
       "source": {
         "type": "install",
         "source": [
-          "github:EduardoRFS/reason-css-parser:package.json#bba47cd3228cb6f71b9beac7673f3d31516521fe"
+          "github:EduardoRFS/reason-css-parser:package.json#af422f9f3a7973b48ae92fe363221d7e17461450"
         ]
       },
       "overrides": [],

--- a/esy.lock/opam/ocaml-compiler-libs.v0.12.1/opam
+++ b/esy.lock/opam/ocaml-compiler-libs.v0.12.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ocaml-compiler-libs"
+bug-reports: "https://github.com/janestreet/ocaml-compiler-libs/issues"
+dev-repo: "git+https://github.com/janestreet/ocaml-compiler-libs.git"
+license: "Apache-2.0"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "1.5.1"}
+]
+synopsis: "OCaml compiler libraries repackaged"
+description: """
+This packages exposes the OCaml compiler libraries repackages under
+the toplevel names Ocaml_common, Ocaml_bytecomp, Ocaml_optcomp, ..."""
+url {
+  src:
+    "https://github.com/janestreet/ocaml-compiler-libs/archive/v0.12.1.tar.gz"
+  checksum: "md5=2f929af7c764a3f681a5671f271210c4"
+}

--- a/esy.lock/opam/ppxlib.0.14.0/opam
+++ b/esy.lock/opam/ppxlib.0.14.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+license: "MIT"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.10" }
+]
+depends: [
+  "ocaml"                   {>= "4.04.1"}
+  "base"                    {>= "v0.11.0"}
+  "dune"                    {>= "1.11"}
+  "ocaml-compiler-libs"     {>= "v0.11.0"}
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "ppx_derivers"            {>= "1.0"}
+  "stdio"                   {>= "v0.11.0"}
+  "ocamlfind"               {with-test}
+  "cinaps"                  {with-test & >= "v0.12.1"}
+]
+synopsis: "Base library and tools for ppx rewriters"
+description: """
+A comprehensive toolbox for ppx development. It features:
+- a OCaml AST / parser / pretty-printer snapshot,to create a full
+   frontend independent of the version of OCaml;
+- a library for library for ppx rewriters in general, and type-driven
+  code generators in particular;
+- a feature-full driver for OCaml AST transformers;
+- a quotation mechanism allowing  to write values representing the
+   OCaml AST in the OCaml syntax;
+- a generator of open recursion classes from type definitions.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.14.0/ppxlib-0.14.0.tbz"
+  checksum: [
+    "sha256=a1a398f7c8f670d7de80468ff4639862b126f4dcac3de416e0c5c4d5860f3854"
+    "sha512=987062ecaa406a0bc4d87350947ab7da06b650c2f3c991a3aba470bd45c0a26619536bd50753de958a8a1f3b41f89fbcf7206bf3b5acc33002a9b2debd686d6c"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@opam/sedlex": "*",
     "@reason-native/rely": "^3.2.1",
     "@opam/ocaml-lsp-server": "ocaml/ocaml-lsp:ocaml-lsp-server.opam#fbc433e14035d520c7137916ae710b8ec3b415e9",
-    "reason-css-parser": "EduardoRFS/reason-css-parser:package.json#bba47cd3228cb6f71b9beac7673f3d31516521fe"
+    "reason-css-parser": "EduardoRFS/reason-css-parser:package.json#af422f9f3a7973b48ae92fe363221d7e17461450"
   },
   "resolutions": {
     "@esy-ocaml/reason": "facebook/reason:reason.json#773dbcd"

--- a/package.json
+++ b/package.json
@@ -6,31 +6,18 @@
   "license": "MIT",
   "homepage": "https://github.com/davesnx/styled-ppx",
   "keywords": [
-    "reason",
-    "ocaml",
-    "ppx",
-    "bucklescript",
-    "css",
-    "styled-components",
+    "reason", "ocaml", "ppx", "bucklescript", "css", "styled-components",
     "emotion"
   ],
-  "bugs": {
-    "url": "https://github.com/davesnx/styled-ppx/issues"
-  },
+  "bugs": { "url": "https://github.com/davesnx/styled-ppx/issues" },
   "repository": {
     "type": "git",
     "url": "https://github.com/davesnx/styled-ppx.git"
   },
   "esy": {
     "build": "dune build -p #{self.name}",
-    "buildEnv": {
-      "ODOC_SYNTAX": "re"
-    },
-    "release": {
-      "bin": [
-        "Bin"
-      ]
-    }
+    "buildEnv": { "ODOC_SYNTAX": "re" },
+    "release": { "bin": [ "Bin" ] }
   },
   "devDependencies": {
     "@opam/merlin": "*",
@@ -41,8 +28,10 @@
     "@opam/ocaml-migrate-parsetree": "^1.7.3",
     "@opam/sedlex": "*",
     "@reason-native/rely": "^3.2.1",
-    "@opam/ocaml-lsp-server": "ocaml/ocaml-lsp:ocaml-lsp-server.opam#fbc433e14035d520c7137916ae710b8ec3b415e9",
-    "reason-css-parser": "EduardoRFS/reason-css-parser:package.json#af422f9f3a7973b48ae92fe363221d7e17461450"
+    "@opam/ocaml-lsp-server":
+      "ocaml/ocaml-lsp:ocaml-lsp-server.opam#fbc433e14035d520c7137916ae710b8ec3b415e9",
+    "reason-css-parser":
+      "EduardoRFS/reason-css-parser:package.json#99da696f761823b959214f89b1687d0c4b261538"
   },
   "resolutions": {
     "@esy-ocaml/reason": "facebook/reason:reason.json#773dbcd"
@@ -58,5 +47,6 @@
     "format": "esy dune build @fmt --auto-promote",
     "watch": "esy dune build -p styled-ppx --watch",
     "utop": "esy dune utop lib -- -implicit-bindings"
-  }
+  },
+  "dependencies": { "@opam/ppxlib": "0.14.0" }
 }

--- a/src/dune
+++ b/src/dune
@@ -3,6 +3,7 @@
  (wrapped false)
  (public_name styled-ppx.lib)
  (kind ppx_rewriter)
- (libraries styled_ppx_parser ocaml-migrate-parsetree reason-css-parser.lib)
+ (libraries styled_ppx_parser ocaml-migrate-parsetree reason-css-parser.lib
+   ppxlib)
  (preprocess
   (pps ppx_tools_versioned.metaquot_410)))

--- a/test/bucklescript/src/__snapshots__/css_support_test.bs.js.snap
+++ b/test/bucklescript/src/__snapshots__/css_support_test.bs.js.snap
@@ -96,36 +96,66 @@ exports[`Component 46 renders 1`] = `"css-6cnn7x"`;
 
 exports[`Component 47 renders 1`] = `"css-18g2ogn"`;
 
-exports[`Component 48 renders 1`] = `"css-ayshjd"`;
+exports[`Component 48 renders 1`] = `"css-1a5bf0e"`;
 
-exports[`Component 49 renders 1`] = `"css-144vlu9"`;
+exports[`Component 49 renders 1`] = `"css-8b1hqd"`;
 
-exports[`Component 50 renders 1`] = `"css-xdees7"`;
+exports[`Component 50 renders 1`] = `"css-1lhzqyi"`;
 
-exports[`Component 51 renders 1`] = `"css-1ofy66z"`;
+exports[`Component 51 renders 1`] = `"css-1mqja40"`;
 
-exports[`Component 52 renders 1`] = `"css-bkj8c"`;
+exports[`Component 52 renders 1`] = `"css-n71mm4"`;
 
-exports[`Component 53 renders 1`] = `"css-bmjq4j"`;
+exports[`Component 53 renders 1`] = `"css-388kwc"`;
 
-exports[`Component 54 renders 1`] = `"css-10iahqc"`;
+exports[`Component 54 renders 1`] = `"css-1y0g9bi"`;
 
-exports[`Component 55 renders 1`] = `"css-1vw5a1r"`;
+exports[`Component 55 renders 1`] = `"css-1r57kyf"`;
 
-exports[`Component 56 renders 1`] = `"css-1nw2x84"`;
+exports[`Component 56 renders 1`] = `"css-k6sref"`;
 
-exports[`Component 57 renders 1`] = `"css-9x4jlj"`;
+exports[`Component 57 renders 1`] = `"css-1a7oyui"`;
 
-exports[`Component 58 renders 1`] = `"css-kilw6e"`;
+exports[`Component 58 renders 1`] = `"css-1qdoa0e"`;
 
-exports[`Component 59 renders 1`] = `"css-13brihr"`;
+exports[`Component 59 renders 1`] = `"css-kqez56"`;
 
-exports[`Component 60 renders 1`] = `"css-1ncsbtn"`;
+exports[`Component 60 renders 1`] = `"css-17923ty"`;
 
-exports[`Component 61 renders 1`] = `"css-ibk9g"`;
+exports[`Component 61 renders 1`] = `"css-1aeh5vx"`;
 
-exports[`Component 62 renders 1`] = `"css-ufkhx2"`;
+exports[`Component 62 renders 1`] = `"css-xwnadr"`;
 
-exports[`Component 63 renders 1`] = `"css-cgts8g"`;
+exports[`Component 63 renders 1`] = `"css-ayshjd"`;
 
-exports[`Component 64 renders 1`] = `"css-1x2q6ya"`;
+exports[`Component 64 renders 1`] = `"css-144vlu9"`;
+
+exports[`Component 65 renders 1`] = `"css-xdees7"`;
+
+exports[`Component 66 renders 1`] = `"css-1ofy66z"`;
+
+exports[`Component 67 renders 1`] = `"css-bkj8c"`;
+
+exports[`Component 68 renders 1`] = `"css-bmjq4j"`;
+
+exports[`Component 69 renders 1`] = `"css-10iahqc"`;
+
+exports[`Component 70 renders 1`] = `"css-1vw5a1r"`;
+
+exports[`Component 71 renders 1`] = `"css-1nw2x84"`;
+
+exports[`Component 72 renders 1`] = `"css-9x4jlj"`;
+
+exports[`Component 73 renders 1`] = `"css-kilw6e"`;
+
+exports[`Component 74 renders 1`] = `"css-13brihr"`;
+
+exports[`Component 75 renders 1`] = `"css-1ncsbtn"`;
+
+exports[`Component 76 renders 1`] = `"css-ibk9g"`;
+
+exports[`Component 77 renders 1`] = `"css-ufkhx2"`;
+
+exports[`Component 78 renders 1`] = `"css-cgts8g"`;
+
+exports[`Component 79 renders 1`] = `"css-1x2q6ya"`;

--- a/test/bucklescript/src/__snapshots__/css_support_test.bs.js.snap
+++ b/test/bucklescript/src/__snapshots__/css_support_test.bs.js.snap
@@ -92,36 +92,40 @@ exports[`Component 44 renders 1`] = `"css-1tzeee1"`;
 
 exports[`Component 45 renders 1`] = `"css-1vs9cou"`;
 
-exports[`Component 46 renders 1`] = `"css-ayshjd"`;
+exports[`Component 46 renders 1`] = `"css-6cnn7x"`;
 
-exports[`Component 47 renders 1`] = `"css-144vlu9"`;
+exports[`Component 47 renders 1`] = `"css-18g2ogn"`;
 
-exports[`Component 48 renders 1`] = `"css-xdees7"`;
+exports[`Component 48 renders 1`] = `"css-ayshjd"`;
 
-exports[`Component 49 renders 1`] = `"css-1ofy66z"`;
+exports[`Component 49 renders 1`] = `"css-144vlu9"`;
 
-exports[`Component 50 renders 1`] = `"css-bkj8c"`;
+exports[`Component 50 renders 1`] = `"css-xdees7"`;
 
-exports[`Component 51 renders 1`] = `"css-bmjq4j"`;
+exports[`Component 51 renders 1`] = `"css-1ofy66z"`;
 
-exports[`Component 52 renders 1`] = `"css-10iahqc"`;
+exports[`Component 52 renders 1`] = `"css-bkj8c"`;
 
-exports[`Component 53 renders 1`] = `"css-1vw5a1r"`;
+exports[`Component 53 renders 1`] = `"css-bmjq4j"`;
 
-exports[`Component 54 renders 1`] = `"css-1nw2x84"`;
+exports[`Component 54 renders 1`] = `"css-10iahqc"`;
 
-exports[`Component 55 renders 1`] = `"css-9x4jlj"`;
+exports[`Component 55 renders 1`] = `"css-1vw5a1r"`;
 
-exports[`Component 56 renders 1`] = `"css-kilw6e"`;
+exports[`Component 56 renders 1`] = `"css-1nw2x84"`;
 
-exports[`Component 57 renders 1`] = `"css-13brihr"`;
+exports[`Component 57 renders 1`] = `"css-9x4jlj"`;
 
-exports[`Component 58 renders 1`] = `"css-1ncsbtn"`;
+exports[`Component 58 renders 1`] = `"css-kilw6e"`;
 
-exports[`Component 59 renders 1`] = `"css-ibk9g"`;
+exports[`Component 59 renders 1`] = `"css-13brihr"`;
 
-exports[`Component 60 renders 1`] = `"css-ufkhx2"`;
+exports[`Component 60 renders 1`] = `"css-1ncsbtn"`;
 
-exports[`Component 61 renders 1`] = `"css-cgts8g"`;
+exports[`Component 61 renders 1`] = `"css-ibk9g"`;
 
-exports[`Component 62 renders 1`] = `"css-1x2q6ya"`;
+exports[`Component 62 renders 1`] = `"css-ufkhx2"`;
+
+exports[`Component 63 renders 1`] = `"css-cgts8g"`;
+
+exports[`Component 64 renders 1`] = `"css-1x2q6ya"`;

--- a/test/bucklescript/src/css_support_test.re
+++ b/test/bucklescript/src/css_support_test.re
@@ -112,6 +112,24 @@ let supportList = [
   // css-images-4
   [%css "object-fit: fill"],
   [%css "object-position: right bottom"],
+  // css-backgrounds-3
+  [%css "background-color: red"],
+  [%css "border-top-color: blue"],
+  [%css "border-right-color: green"],
+  [%css "border-bottom-color: purple"],
+  [%css "border-left-color: #fff"],
+  [%css "border-top-width: 15px"],
+  [%css "border-right-width: 16px"],
+  [%css "border-bottom-width: 17px"],
+  [%css "border-left-width: 18px"],
+  [%css "border-top-left-radius: 12%"],
+  [%css "border-top-right-radius: 15%"],
+  [%css "border-bottom-left-radius: 14%"],
+  [%css "border-bottom-right-radius: 13%"],
+  [%css "box-shadow: 12px 12px 2px 1px rgba(0, 0, 255, .2)"],
+  [%css
+    "box-shadow: 12px 12px 2px 1px rgba(0, 0, 255, .2), 13px 14px 5px 6px rgba(2, 1, 255, 50%)"
+  ],
   // css-overflow-3
   [%css "overflow-x: auto"],
   [%css "overflow-y: hidden"],

--- a/test/bucklescript/src/css_support_test.re
+++ b/test/bucklescript/src/css_support_test.re
@@ -109,6 +109,9 @@ let supportList = [
   [%css "color: hsl(120deg 100% 50%)"],
   [%css "opacity: 0.5"],
   [%css "opacity: 60%"],
+  // css-images-4
+  [%css "object-fit: fill"],
+  [%css "object-position: right bottom"],
   // css-overflow-3
   [%css "overflow-x: auto"],
   [%css "overflow-y: hidden"],

--- a/test/native/lib/TestEmitter.re
+++ b/test/native/lib/TestEmitter.re
@@ -185,6 +185,12 @@ let properties_static_css_tests = [
   ),
   ([%expr [%css "opacity: 0.5"]], [%expr [Css.opacity(0.5)]]),
   ([%expr [%css "opacity: 60%"]], [%expr [Css.opacity(0.6)]]),
+  // css-images-4
+  ([%expr [%css "object-fit: fill"]], [%expr [Css.objectFit(`fill)]]),
+  (
+    [%expr [%css "object-position: right bottom"]],
+    [%expr [Css.objectPosition(`hv((`right, `bottom)))]],
+  ),
   // css-overflow-3
   ([%expr [%css "overflow-x: auto"]], [%expr [Css.overflowX(`auto)]]),
   ([%expr [%css "overflow-y: hidden"]], [%expr [Css.overflowY(`hidden)]]),

--- a/test/native/lib/TestEmitter.re
+++ b/test/native/lib/TestEmitter.re
@@ -191,6 +191,102 @@ let properties_static_css_tests = [
     [%expr [%css "object-position: right bottom"]],
     [%expr [Css.objectPosition(`hv((`right, `bottom)))]],
   ),
+  // css-backgrounds-3
+  (
+    [%expr [%css "background-color: red"]],
+    [%expr [Css.backgroundColor(Css.red)]],
+  ),
+  (
+    [%expr [%css "border-top-color: blue"]],
+    [%expr [Css.borderTopColor(Css.blue)]],
+  ),
+  (
+    [%expr [%css "border-right-color: green"]],
+    [%expr [Css.borderRightColor(Css.green)]],
+  ),
+  (
+    [%expr [%css "border-bottom-color: purple"]],
+    [%expr [Css.borderBottomColor(Css.purple)]],
+  ),
+  (
+    [%expr [%css "border-left-color: #fff"]],
+    [%expr [Css.borderLeftColor(`hex("fff"))]],
+  ),
+  (
+    [%expr [%css "border-top-width: 15px"]],
+    [%expr [Css.borderTopWidth(`pxFloat(15.))]],
+  ),
+  (
+    [%expr [%css "border-right-width: 16px"]],
+    [%expr [Css.borderRightWidth(`pxFloat(16.))]],
+  ),
+  (
+    [%expr [%css "border-bottom-width: 17px"]],
+    [%expr [Css.borderBottomWidth(`pxFloat(17.))]],
+  ),
+  (
+    [%expr [%css "border-left-width: 18px"]],
+    [%expr [Css.borderLeftWidth(`pxFloat(18.))]],
+  ),
+  (
+    [%expr [%css "border-top-left-radius: 12%"]],
+    [%expr [Css.borderTopLeftRadius(`percent(12.))]],
+  ),
+  (
+    [%expr [%css "border-top-right-radius: 15%"]],
+    [%expr [Css.borderTopRightRadius(`percent(15.))]],
+  ),
+  (
+    [%expr [%css "border-bottom-left-radius: 14%"]],
+    [%expr [Css.borderBottomLeftRadius(`percent(14.))]],
+  ),
+  (
+    [%expr [%css "border-bottom-right-radius: 13%"]],
+    [%expr [Css.borderBottomRightRadius(`percent(13.))]],
+  ),
+  (
+    [%expr [%css "box-shadow: 12px 12px 2px 1px rgba(0, 0, 255, .2)"]],
+    [%expr
+      [
+        Css.boxShadows([
+          Css.Shadow.box(
+            ~x=`pxFloat(12.),
+            ~y=`pxFloat(12.),
+            ~blur=`pxFloat(2.),
+            ~spread=`pxFloat(1.),
+            `rgba((0, 0, 255, 0.2)),
+          ),
+        ]),
+      ]
+    ],
+  ),
+  (
+    [%expr
+      [%css
+        "box-shadow: 12px 12px 2px 1px rgba(0, 0, 255, .2), 13px 14px 5px 6px rgba(2, 1, 255, 50%)"
+      ]
+    ],
+    [%expr
+      [
+        Css.boxShadows([
+          Css.Shadow.box(
+            ~x=`pxFloat(12.),
+            ~y=`pxFloat(12.),
+            ~blur=`pxFloat(2.),
+            ~spread=`pxFloat(1.),
+            `rgba((0, 0, 255, 0.2)),
+          ),
+          Css.Shadow.box(
+            ~x=`pxFloat(13.),
+            ~y=`pxFloat(14.),
+            ~blur=`pxFloat(5.),
+            ~spread=`pxFloat(6.),
+            `rgba((2, 1, 255, 0.5)),
+          ),
+        ]),
+      ]
+    ],
+  ),
   // css-overflow-3
   ([%expr [%css "overflow-x: auto"]], [%expr [Css.overflowX(`auto)]]),
   ([%expr [%css "overflow-y: hidden"]], [%expr [Css.overflowY(`hidden)]]),

--- a/test/native/snapshot/pp.expected
+++ b/test/native/snapshot/pp.expected
@@ -1,6 +1,6 @@
 [@ocaml.ppx.context
   {
-    tool_name: "migrate_driver",
+    tool_name: "ppxlib_driver",
     include_dirs: [],
     load_path: [],
     open_modules: [],


### PR DESCRIPTION
## Not properties change

Switched to ppxlib, it has a lot of helpers and ocaml-migrate-parsetree driver will be removed

## Why so many unsupported?

Most of them aren't actually supported at all in `bs-css`, some of the `background-*` I will support in a future PR, as it is quite a lot of work to implement them, but with #103 it should be working