### PR TITLE
check if text starts with "styled"

### DIFF
--- a/src/styled_ppx.re
+++ b/src/styled_ppx.re
@@ -47,6 +47,12 @@ let getAlias = (pattern, label) =>
   | _ => getLabel(label)
   };
 
+let isStyledTag = str =>
+  switch (String.split_on_char('.', str)) {
+  | ["styled", ..._] => true
+  | _ => false
+  };
+
 let getTag = str => {
   switch (String.split_on_char('.', str)) {
   | ["styled"] => "div"
@@ -455,10 +461,12 @@ let createMakeProps = (~loc, extraProps) => {
         createDomRefLabel(~loc),
         createChildrenLabel(~loc),
         ...List.map(
-             (domProp) =>
+             domProp =>
                switch (domProp) {
-                 | Event({ name, type_ }) => createRecordEventLabel(~loc, name, type_)
-                 | Attribute({ name, type_ }) => createRecordLabel(~loc, name, type_)
+               | Event({name, type_}) =>
+                 createRecordEventLabel(~loc, name, type_)
+               | Attribute({name, type_}) =>
+                 createRecordLabel(~loc, name, type_)
                },
              domPropsList,
            ),
@@ -599,7 +607,8 @@ let styledPpxMapper = (_, _) => {
             ]),
           )),
         _,
-      } =>
+      }
+        when isStyledTag(txt) =>
       let tag = getTag(txt);
 
       /* Fix getLabeledArgs, to stop ignoring the first arg */
@@ -717,7 +726,8 @@ let styledPpxMapper = (_, _) => {
           Pmod_extension(({txt, loc: txtLoc}, PStr([]))),
         pmod_loc: pexp_loc,
         _,
-      } =>
+      }
+        when isStyledTag(txt) =>
       let tag = getTag(txt);
 
       if (!List.exists(t => t == tag, Html.tags)) {
@@ -774,7 +784,8 @@ let styledPpxMapper = (_, _) => {
             ]),
           )),
         _,
-      } =>
+      }
+        when isStyledTag(txt) =>
       let tag = getTag(txt);
 
       if (!List.exists(t => t == tag, Html.tags)) {

--- a/test/native/lib/TestModule.re
+++ b/test/native/lib/TestModule.re
@@ -1,0 +1,29 @@
+open Migrate_parsetree;
+open Ast_410;
+open Setup;
+
+open Ppxlib.Ast_builder.Make({
+       let loc = Location.none;
+     });
+
+let compare = (result, expected, {expect, _}) => {
+  let result = Pprintast.string_of_structure([result]);
+  let expected = Pprintast.string_of_structure([expected]);
+  expect.string(result).toEqual(expected);
+};
+
+describe("transform module ppx", ({test, _}) => {
+  test(
+    "doesn't start with styled",
+    compare(
+      [%stri module X = [%graphql]],
+      // the AST needs to be here by hand otherwise we would will always have success
+      pstr_module(
+        module_binding(
+          ~name=Located.mk(Some("X")),
+          ~expr=pmod_extension((Located.mk("graphql"), PStr([]))),
+        ),
+      ),
+    ),
+  )
+});

--- a/test/native/lib/dune
+++ b/test/native/lib/dune
@@ -2,6 +2,6 @@
  (name StyledPpxTestNativeLib)
  (library_flags
   (-linkall -g))
- (libraries rely.lib styled-ppx.lib)
+ (libraries rely.lib styled-ppx.lib ppxlib)
  (preprocess
   (pps ppx_tools_versioned.metaquot_410 styled-ppx.lib)))


### PR DESCRIPTION
This PR adds some guards to prevent us from transforming code not starting with `styled`, as it would conflict with things like `graphql-ppx`

As described by #109