### PR TITLE
Typechecking for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test": "esy test_snapshot",
     "test_snapshot": "dune runtest",
     "test_snapshot:promote": "dune runtest --auto-promote",
-    "test_native": "esy dune exec test/native/TestRunner.exe",
+    "test_native": "esy dune exec test/native/lib/TestRunner.exe",
     "test_bs": "cd test/bucklescript; yarn test",
     "doc": "esy dune build @doc",
     "doc-path": "esy echo #{self.target_dir}/default/_doc/_html/index.html",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test": "esy test_snapshot",
     "test_snapshot": "dune runtest",
     "test_snapshot:promote": "dune runtest --auto-promote",
-    "test_native": "esy dune exec test/native/lib/TestRunner.exe",
+    "test_native": "esy dune build @run_typecheck_test",
     "test_bs": "cd test/bucklescript; yarn test",
     "doc": "esy dune build @doc",
     "doc-path": "esy echo #{self.target_dir}/default/_doc/_html/index.html",

--- a/test/native/TestRunner.re
+++ b/test/native/TestRunner.re
@@ -1,2 +1,0 @@
-StyledPpxTestNativeLib.Setup.cli();
-

--- a/test/native/bs-css/Css_AtomicTypes.rei
+++ b/test/native/bs-css/Css_AtomicTypes.rei
@@ -1,0 +1,1277 @@
+// Docs copied from MDN
+
+module Cascading: {
+  type t = [ | `initial | `inherit_ | `unset];
+
+  let initial: [> t];
+  let inherit_: [> t];
+  let unset: [> t];
+
+  let toString: t => string;
+};
+
+module Time: {
+  /**
+   The <time> CSS data type represents a time value expressed in seconds or milliseconds.
+   It is used in animation, transition, and related properties.
+   */
+  type t = [ | `s(float) | `ms(float)];
+
+  let s: float => [> | `s(float)];
+  let ms: float => [> | `ms(float)];
+
+  let toString: t => string;
+};
+
+module Percentage: {
+  /**
+   The <percentage> CSS data type represents a percentage value.
+   It is often used to define a size as relative to an element's parent object.
+   */
+  type t = [ | `percent(float)];
+
+  let pct: float => [> t];
+
+  let toString: t => string;
+};
+
+module Url: {
+  /**
+   The <url> CSS data type denotes a pointer to a resource, such as an image or a font.
+   URLs can be used in numerous CSS properties, such as background-image, cursor, and list-style.
+   */
+  type t = [ | `url(string)];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/length
+ */
+module Length: {
+  // calc/percent are incorrect
+
+  /** The <length> CSS data type represents a distance value. */
+  type t = [
+    | `ch(float)
+    | `em(float)
+    | `ex(float)
+    | `rem(float)
+    | `vh(float)
+    | `vw(float)
+    | `vmin(float)
+    | `vmax(float)
+    | `px(int)
+    | `pxFloat(float)
+    | `cm(float)
+    | `mm(float)
+    | `inch(float)
+    | `pc(float)
+    | `pt(int)
+    | `zero
+    | `calc([ | `add | `sub], t, t)
+    | `percent(float)
+  ];
+
+  /** Represents the width, or more precisely the advance measure, of the glyph "0" (zero, the Unicode character U+0030) in the element's font. */
+  let ch: float => [> | `ch(float)];
+  /** Represents the calculated font-size of the element. If used on the font-size property itself, it represents the inherited font-size of the element. */
+  let em: float => [> | `em(float)];
+  /** Represents the x-height of the element's font. On fonts with the "x" letter, this is generally the height of lowercase letters in the font; 1ex ≈ 0.5em in many fonts. */
+  let ex: float => [> | `ex(float)];
+  /** Represents the font-size of the root element (typically <html>). When used within the root element font-size, it represents its initial value (a common browser default is 16px, but user-defined preferences may modify this) */
+  let rem: float => [> | `rem(float)];
+  /** Equal to 1% of the height of the viewport's initial containing block */
+  let vh: float => [> | `vh(float)];
+  /** Equal to 1% of the width of the viewport's initial containing block */
+  let vw: float => [> | `vw(float)];
+  /** Equal to the smaller of vw and vh */
+  let vmin: float => [> | `vmin(float)];
+  /** Equal to the larger of vw and vh */
+  let vmax: float => [> | `vmax(float)];
+  /** One pixel. For screen displays, it traditionally represents one device pixel (dot). However, for printers and high-resolution screens, one CSS pixel implies multiple device pixels. 1px = 1/96th of 1in */
+  let px: int => [> | `px(int)];
+  let pxFloat: float => [> | `pxFloat(float)];
+  /** One centimeter. 1cm = 96px/2.54 */
+  let cm: float => [> | `cm(float)];
+  /** One millimeter. 1mm = 1/10th of 1cm */
+  let mm: float => [> | `mm(float)];
+  /** One inch. 1in = 2.54cm = 96px */
+  let inch: float => [> | `inch(float)];
+  /** One pica. 1pc = 12pt = 1/6th of 1in */
+  let pc: float => [> | `pc(float)];
+  /** One point. 1pt = 1/72nd of 1in */
+  let pt: int => [> | `pt(int)];
+  /** The value 0 */
+  let zero: [> | `zero];
+
+  let toString: t => string;
+};
+
+module Angle: {
+  /**
+   The angle CSS data type represents an angle value expressed in degrees, gradians, radians, or turns.
+   It is used, for example, in <gradient>s and in some transform functions.
+   */
+  type t = [ | `deg(float) | `rad(float) | `grad(float) | `turn(float)];
+
+  let deg: float => t;
+  let rad: float => t;
+  let grad: float => t;
+  let turn: float => t;
+
+  let toString: t => string;
+};
+
+module Direction: {
+  type t = [ | `ltr | `rtl];
+
+  /** Text and other elements go from left to right. This is the default value. */
+  let ltr: [> t];
+  /** Text and other elements go from right to left. */
+  let rtl: [> t];
+
+  let toString: t => string;
+};
+
+module Position: {
+  type t = [ | `absolute | `relative | `static | `fixed | `sticky];
+
+  let absolute: [> t];
+  let relative: [> t];
+  let static: [> t];
+  let fixed: [> t];
+  let sticky: [> t];
+
+  let toString: t => string;
+};
+
+module Resize: {
+  type t = [ | `none | `both | `horizontal | `vertical | `block | `inline];
+
+  /** The element offers no user-controllable method for resizing it */
+  let none: [> t];
+  /** The element displays a mechanism for allowing the user to resize it, which may be resized both horizontally and vertically */
+  let both: [> t];
+  /** The element displays a mechanism for allowing the user to resize it in the horizontal direction */
+  let horizontal: [> t];
+  /** The element displays a mechanism for allowing the user to resize it in the vertical direction */
+  let vertical: [> t];
+  /** The element displays a mechanism for allowing the user to resize it in the block direction (either horizontally or vertically, depending on the writing-mode and direction value) */
+  let block: [> t];
+  /** The element displays a mechanism for allowing the user to resize it in the inline direction (either horizontally or vertically, depending on the writing-mode and direction value) */
+  let inline: [> t];
+
+  let toString: t => string;
+};
+
+module FontVariant: {
+  type t = [ | `normal | `smallCaps];
+
+  let normal: [> t];
+  let smallCaps: [> t];
+
+  let toString: t => string;
+};
+
+module FontStyle: {
+  type t = [ | `normal | `italic | `oblique];
+
+  let normal: [> t];
+  let italic: [> t];
+  let oblique: [> t];
+
+  let toString: t => string;
+};
+
+module FlexBasis: {
+  type t = [
+    | `auto
+    | `fill
+    | `content
+    | `maxContent
+    | `minContent
+    | `fitContent
+  ];
+
+  let fill: [> t];
+  let content: [> t];
+  let maxContent: [> t];
+  let minContent: [> t];
+  let fitContent: [> t];
+
+  let toString: t => string;
+};
+
+module Overflow: {
+  type t = [ | `hidden | `visible | `scroll | `auto];
+
+  let hidden: [> t];
+  let visible: [> t];
+  let scroll: [> t];
+  let auto: [> t];
+
+  let toString: t => string;
+};
+
+module Margin: {
+  type t = [ | `auto];
+
+  let auto: [> t];
+
+  let toString: t => string;
+};
+
+module GridAutoFlow: {
+  type t = [ | `column | `row | `columnDense | `rowDense];
+
+  let toString: t => string;
+};
+
+module GridColumnGap: {
+  type t = [ | `normal];
+
+  let toString: t => string;
+};
+
+module VerticalAlign: {
+  type t = [
+    | `baseline
+    | `sub
+    | `super
+    | `top
+    | `textTop
+    | `middle
+    | `bottom
+    | `textBottom
+  ];
+
+  let toString: t => string;
+};
+
+module TimingFunction: {
+  type t = [
+    | `linear
+    | `ease
+    | `easeIn
+    | `easeOut
+    | `easeInOut
+    | `stepStart
+    | `stepEnd
+    | `steps(int, [ | `start | `end_])
+    | `cubicBezier(float, float, float, float)
+  ];
+
+  let linear: [> t];
+  let ease: [> t];
+  let easeIn: [> t];
+  let easeOut: [> t];
+  let easeInOut: [> t];
+  let stepStart: [> t];
+  let stepEnd: [> t];
+  let steps: (int, [ | `start | `end_]) => [> t];
+  let cubicBezier: (float, float, float, float) => [> t];
+
+  let toString: t => string;
+};
+
+module RepeatValue: {
+  type t = [ | `autoFill | `autoFit | `num(int)];
+
+  let toString: t => string;
+};
+
+module ListStyleType: {
+  type t = [
+    | `disc
+    | `circle
+    | `square
+    | `decimal
+    | `lowerAlpha
+    | `upperAlpha
+    | `lowerGreek
+    | `lowerLatin
+    | `upperLatin
+    | `lowerRoman
+    | `upperRoman
+    | `none
+  ];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/list-style-position
+ */
+module ListStylePosition: {
+  type t = [ | `inside | `outside];
+
+  let toString: t => string;
+};
+
+module OutlineStyle: {
+  type t = [
+    | `none
+    | `hidden
+    | `dotted
+    | `dashed
+    | `solid
+    | `double
+    | `groove
+    | `ridge
+    | `inset
+    | `outset
+  ];
+
+  let toString: t => string;
+};
+
+module FontWeight: {
+  /* see https://developer.mozilla.org/docs/Web/CSS/font-weight#Common_weight_name_mapping */
+  type t = [
+    | `num(int)
+    | `thin
+    | `extraLight
+    | `light
+    | `normal
+    | `medium
+    | `semiBold
+    | `bold
+    | `extraBold
+    | `black
+    | `lighter
+    | `bolder
+  ];
+
+  let thin: [> t];
+  let extraLight: [> t];
+  let light: [> t];
+  let medium: [> t];
+  let semiBold: [> t];
+  let bold: [> t];
+  let extraBold: [> t];
+  let lighter: [> t];
+  let bolder: [> t];
+
+  let toString: t => string;
+};
+
+module Transform: {
+  type t = [
+    | `translate(Length.t, Length.t)
+    | `translate3d(Length.t, Length.t, Length.t)
+    | `translateX(Length.t)
+    | `translateY(Length.t)
+    | `translateZ(Length.t)
+    | `scale(float, float)
+    | `scale3d(float, float, float)
+    | `scaleX(float)
+    | `scaleY(float)
+    | `scaleZ(float)
+    | `rotate(Angle.t)
+    | `rotate3d(float, float, float, Angle.t)
+    | `rotateX(Angle.t)
+    | `rotateY(Angle.t)
+    | `rotateZ(Angle.t)
+    | `skew(Angle.t, Angle.t)
+    | `skewX(Angle.t)
+    | `skewY(Angle.t)
+    | `perspective(int)
+  ];
+
+  let translate: (Length.t, Length.t) => [> | `translate(Length.t, Length.t)];
+  let translate3d:
+    (Length.t, Length.t, Length.t) =>
+    [> | `translate3d(Length.t, Length.t, Length.t)];
+  let translateX: Length.t => [> t];
+  let translateY: Length.t => [> t];
+  let translateZ: Length.t => [> t];
+  let scale: (float, float) => [> t];
+  let scale3d: (float, float, float) => [> t];
+  let scaleX: float => [> t];
+  let scaleY: float => [> t];
+  let scaleZ: float => [> t];
+  let rotate: Angle.t => [> t];
+  let rotate3d: (float, float, float, Angle.t) => [> t];
+  let rotateX: Angle.t => [> t];
+  let rotateY: Angle.t => [> t];
+  let rotateZ: Angle.t => [> t];
+  let skew: (Angle.t, Angle.t) => [> t];
+  let skewX: Angle.t => [> t];
+  let skewY: Angle.t => [> t];
+
+  let toString: t => string;
+};
+
+module AnimationDirection: {
+  type t = [ | `normal | `reverse | `alternate | `alternateReverse];
+
+  let toString: t => string;
+};
+
+module AnimationFillMode: {
+  type t = [ | `none | `forwards | `backwards | `both];
+
+  let toString: t => string;
+};
+
+module AnimationIterationCount: {
+  type t = [ | `infinite | `count(int)];
+
+  let toString: t => string;
+};
+
+module AnimationPlayState: {
+  type t = [ | `paused | `running];
+
+  let toString: t => string;
+};
+
+module Cursor: {
+  type t = [
+    | `auto
+    | `default
+    | `none
+    | `contextMenu
+    | `help
+    | `pointer
+    | `progress
+    | `wait
+    | `cell
+    | `crosshair
+    | `text
+    | `verticalText
+    | `alias
+    | `copy
+    | `move
+    | `noDrop
+    | `notAllowed
+    | `grab
+    | `grabbing
+    | `allScroll
+    | `colResize
+    | `rowResize
+    | `nResize
+    | `eResize
+    | `sResize
+    | `wResize
+    | `neResize
+    | `nwResize
+    | `seResize
+    | `swResize
+    | `ewResize
+    | `nsResize
+    | `neswResize
+    | `nwseResize
+    | `zoomIn
+    | `zoomOut
+  ];
+
+  let auto: [> t];
+  let default: [> t];
+  let none: [> t];
+  let contextMenu: [> t];
+  let help: [> t];
+  let pointer: [> t];
+  let progress: [> t];
+  let wait: [> t];
+  let cell: [> t];
+  let crosshair: [> t];
+  let text: [> t];
+  let verticalText: [> t];
+  let alias: [> t];
+  let copy: [> t];
+  let move: [> t];
+  let noDrop: [> t];
+  let notAllowed: [> t];
+  let grab: [> t];
+  let grabbing: [> t];
+  let allScroll: [> t];
+  let colResize: [> t];
+  let rowResize: [> t];
+  let nResize: [> t];
+  let eResize: [> t];
+  let sResize: [> t];
+  let wResize: [> t];
+  let neResize: [> t];
+  let nwResize: [> t];
+  let seResize: [> t];
+  let swResize: [> t];
+  let ewResize: [> t];
+  let nsResize: [> t];
+  let neswResize: [> t];
+  let nwseResize: [> t];
+  let zoomIn: [> t];
+  let zoomOut: [> t];
+
+  let toString: t => string;
+};
+
+module Color: {
+  type t = [
+    | `rgb(int, int, int)
+    | `rgba(int, int, int, float)
+    | `hsl(Angle.t, [ | `percent(float)], [ | `percent(float)])
+    | `hsla(
+        Angle.t,
+        [ | `percent(float)],
+        [ | `percent(float)],
+        [ | `num(float) | `percent(float)],
+      )
+    | `hex(string)
+    | `transparent
+    | `currentColor
+  ];
+
+  let rgb: (int, int, int) => [> t];
+  let rgba: (int, int, int, float) => [> t];
+  let hsl: (Angle.t, float, float) => [> t];
+  let hsla:
+    (Angle.t, float, float, [ | `num(float) | `percent(float)]) => [> t];
+  let hex: string => [> t];
+  let transparent: [> t];
+  let currentColor: [> t];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/border-style
+ */
+module BorderStyle: {
+  type t = [
+    | `none
+    | `hidden
+    | `dotted
+    | `dashed
+    | `solid
+    | `double
+    | `groove
+    | `ridge
+    | `inset
+    | `outset
+  ];
+
+  let toString: t => string;
+};
+
+module PointerEvents: {
+  type t = [ | `auto | `none];
+
+  let toString: t => string;
+};
+
+module Perspective: {
+  type t = [ | `none];
+
+  let toString: t => string;
+};
+
+module LetterSpacing: {
+  type t = [ | `normal];
+
+  /**
+   The normal letter spacing for the current font.
+   Unlike a value of 0, this keyword allows the user agent to alter the space between characters in order to justify text.
+   */
+  let normal: [> t];
+
+  let toString: t => string;
+};
+
+module LineHeight: {
+  type t = [ | `normal | `abs(float)];
+
+  let toString: t => string;
+};
+
+module WordSpacing: {
+  type t = [ | `normal];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/display
+ */
+module DisplayOutside: {
+  type t = [ | `block | `inline | `runIn];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/display
+ */
+module DisplayInside: {
+  type t = [ | `table | `flex | `grid];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/display
+ */
+module DisplayListItem: {
+  type t = [ | `listItem];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/display
+ */
+module DisplayInternal: {
+  type t = [
+    | `tableRowGroup
+    | `tableHeaderGroup
+    | `tableFooterGroup
+    | `tableRow
+    | `tableCell
+    | `tableColumnGroup
+    | `tableColumn
+    | `tableCaption
+  ];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/display-box
+ */
+module DisplayBox: {
+  type t = [ | `contents | `none];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/display
+ */
+module DisplayLegacy: {
+  type t = [ | `inlineBlock | `inlineFlex | `inlineGrid | `inlineTable];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/justify-self
+ */
+module JustifySelf: {
+  type t = [ | `auto | `normal | `stretch];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/justify-self
+ https://developer.mozilla.org/docs/Web/CSS/justify-content
+ */
+module PositionalAlignment: {
+  type t = [
+    | `center
+    | `start
+    | `end_
+    | `flexStart
+    | `flexEnd
+    | `selfStart
+    | `selfEnd
+    | `left
+    | `right
+  ];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/justify-self
+ */
+module BaselineAlignment: {
+  type t = [ | `baseline];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/justify-content
+ */
+module NormalAlignment: {
+  type t = [ | `normal];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/justify-content
+ */
+module DistributedAlignment: {
+  type t = [ | `spaceBetween | `spaceAround | `spaceEvenly | `stretch];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/text-align
+ */
+module TextAlign: {
+  type t = [ | `left | `right | `center | `justify];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/word-break
+ */
+module WordBreak: {
+  type t = [ | `normal | `breakAll | `keepAll];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/white-space
+ */
+module WhiteSpace: {
+  type t = [ | `normal | `nowrap | `pre | `preLine | `preWrap | `breakSpaces];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/align-items
+ */
+module AlignItems: {
+  type t = [ | `normal | `stretch];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/align-self
+ */
+module AlignSelf: {
+  type t = [ | `auto | `normal | `stretch];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/align-content
+ */
+module AlignContent: {
+  type t = [ | `center | `start | `end_ | `flexStart | `flexEnd];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/object-fit
+ */
+module ObjectFit: {
+  type t = [ | `fill | `contain | `cover | `none | `scaleDown];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/clear
+ */
+module Clear: {
+  type t = [ | `none | `left | `right | `both | `inlineStart | `inlineEnd];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/float
+ */
+module Float: {
+  type t = [ | `left | `right | `none | `inlineStart | `inlineEnd];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/visibility
+ */
+module Visibility: {
+  type t = [ | `visible | `hidden | `collapse];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/table-layout
+ */
+module TableLayout: {
+  type t = [ | `auto | `fixed];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/border-collapse
+ */
+module BorderCollapse: {
+  type t = [ | `collapse | `separate];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/flex-wrap
+ */
+module FlexWrap: {
+  type t = [ | `nowrap | `wrap | `wrapReverse];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/flex-direction
+ */
+module FlexDirection: {
+  type t = [ | `row | `rowReverse | `column | `columnReverse];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/box-sizing
+ */
+module BoxSizing: {
+  type t = [ | `contentBox | `borderBox];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/box-sizing
+ */
+module ColumnCount: {
+  type t = [ | `auto | `count(int)];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/user-select
+ */
+module UserSelect: {
+  type t = [ | `none | `auto | `text | `contain | `all];
+
+  let toString: t => string;
+};
+
+module TextTransform: {
+  type t = [ | `none | `capitalize | `uppercase | `lowercase];
+
+  let toString: t => string;
+};
+
+module GridTemplateAreas: {
+  type t = [ | `none | `areas(list(string))];
+
+  let areas: list(string) => [> t];
+
+  let toString: t => string;
+};
+
+module GridArea: {
+  type t = [
+    | `auto
+    | `ident(string)
+    | `num(int)
+    | `numIdent(int, string)
+    | `span([ | `num(int) | `ident(string)])
+  ];
+
+  let auto: [> t];
+  let ident: string => [> t];
+  let num: int => [> t];
+  let numIdent: (int, string) => [> t];
+  let span: [ | `num(int) | `ident(string)] => [> t];
+
+  let toString: t => string;
+};
+
+/**
+  https://developer.mozilla.org/en-US/docs/Web/CSS/backdrop-filter
+  */
+module BackdropFilter: {
+  type t = [
+    | `blur(Length.t)
+    | `brightness([ | `num(int) | `percent(float)])
+    | `contrast([ | `num(int) | `percent(float)])
+    | `dropShadow([ | `num(int) | `percent(float)])
+    | `grayscale([ | `num(int) | `percent(float)])
+    | `hueRotate([ | Angle.t | `zero])
+    | `invert([ | `num(int) | `percent(float)])
+    | `none
+    | `opacity([ | `num(int) | `percent(float)])
+    | `saturate([ | `num(int) | `percent(float)])
+    | `sepia([ | `num(int) | `percent(float)])
+  ];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/background-attachment
+ */
+module BackgroundAttachment: {
+  type t = [ | `scroll | `fixed | `local];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/background-clip
+ */
+module BackgroundClip: {
+  type t = [ | `borderBox | `paddingBox | `contentBox];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/background-origin
+ */
+module BackgroundOrigin: {
+  type t = [ | `borderBox | `paddingBox | `contentBox];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/background-position
+ */
+module BackgroundPosition: {
+  module X: {
+    type t = [ | `left | `right | `center];
+
+    let toString: t => string;
+  };
+
+  module Y: {
+    type t = [ | `top | `bottom | `center];
+
+    let toString: t => string;
+  };
+
+  type t = [ X.t | Y.t];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/background-origin
+ */
+module BackgroundRepeat: {
+  type twoValue = [ | `repeat | `space | `round | `noRepeat];
+  type t = [ | `repeatX | `repeatY | twoValue];
+  type horizontal = twoValue;
+  type vertical = twoValue;
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/text-overflow
+ */
+module TextOverflow: {
+  type t = [ | `clip | `ellipsis | `string(string)];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/text-decoration-line
+ */
+module TextDecorationLine: {
+  type t = [ | `none | `underline | `overline | `lineThrough | `blink];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/text-decoration-style
+ */
+module TextDecorationStyle: {
+  type t = [ | `solid | `double | `dotted | `dashed | `wavy];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/width
+ */
+module Width: {
+  type t = [ | `auto | `fitContent];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/max-width
+ */
+module MaxWidth: {
+  type t = [ | `none];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/height
+ */
+module Height: {
+  type t = [ | `auto];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/max-height
+ */
+module MaxHeight: {
+  type t = [ | `none];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/overflow-wrap
+ */
+module OverflowWrap: {
+  type t = [ | `normal | `breakWord | `anywhere];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/gradient
+ */
+module Gradient: {
+  type t = [
+    | `linearGradient(Angle.t, list((Length.t, Color.t)))
+    | `repeatingLinearGradient(Angle.t, list((Length.t, Color.t)))
+    | `radialGradient(list((Length.t, Color.t)))
+    | `repeatingRadialGradient(list((Length.t, Color.t)))
+  ];
+
+  /** Linear gradients transition colors progressively along an imaginary line. */
+  let linearGradient: (Angle.t, list((Length.t, Color.t))) => [> t];
+  /** Radial gradients transition colors progressively from a center point (origin). */
+  let radialGradient: list((Length.t, Color.t)) => [> t];
+
+  /** Repeating gradients duplicate a gradient as much as necessary to fill a given area (linearGradient function). */
+  let repeatingLinearGradient: (Angle.t, list((Length.t, Color.t))) => [> t];
+  /** Repeating gradients duplicate a gradient as much as necessary to fill a given area (radialGradient function). */
+  let repeatingRadialGradient: list((Length.t, Color.t)) => [> t];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/background-image
+ */
+module BackgroundImage: {
+  type t = [ | `none];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/clip-path
+ */
+module GeometyBox: {
+  type t = [
+    | `marginBox
+    | `borderBox
+    | `paddingBox
+    | `contentBox
+    | `fillBox
+    | `strokeBox
+    | `viewBox
+  ];
+
+  /** Uses the margin box as the reference box. */
+  let marginBox: [> t];
+  /** Uses the border box as the reference box. */
+  let borderBox: [> t];
+  /** Uses the padding box as the reference box. */
+  let paddingBox: [> t];
+  /** Uses the content box as the reference box. */
+  let contentBox: [> t];
+  /** Uses the object bounding box as the reference box. */
+  let fillBox: [> t];
+  /** Uses the stroke bounding box as the reference box. */
+  let strokeBox: [> t];
+  /**
+   Uses the nearest SVG viewport as the reference box.
+   If a viewBox attribute is specified for the element creating the SVG viewport,
+   the reference box is positioned at the origin of the coordinate system established by the viewBox attribute and
+   the dimension of the size of the reference box is set to the width and height values of the viewBox attribute.
+   */
+  let viewBox: [> t];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/clip-path
+ */
+module ClipPath: {
+  type t = [ | `none];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/backface-visibility
+ */
+module BackfaceVisibility: {
+  type t = [ | `visible | `hidden];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/flex
+ */
+module Flex: {
+  type t = [ | `auto | `initial | `none];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/transform-style
+ */
+module TransformStyle: {
+  type t = [ | `preserve3d | `flat];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/list-style-image
+ */
+module ListStyleImage: {
+  type t = [ | `none];
+
+  let toString: t => string;
+};
+
+/**
+ https://developer.mozilla.org/docs/Web/CSS/font-family
+ */
+module FontFamilyName: {
+  type t = [
+    | `custom(string)
+    | `serif
+    | `sansSerif
+    | `cursive
+    | `fantasy
+    | `monospace
+    | `systemUi
+    | `emoji
+    | `math
+    | `fangsong
+  ];
+
+  let toString: t => string;
+};
+
+/**
+ * https://developer.mozilla.org/fr/docs/Web/CSS/@font-face/font-display
+ */
+module FontDisplay: {
+  type t = [ | `auto | `block | `swap | `fallback | `optional];
+
+  let toString: t => string;
+};
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/counters
+ */
+module CounterStyleType: {
+  type t = [ ListStyleType.t];
+
+  let toString: t => string;
+};
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/counter
+ */
+module Counter: {
+  type style = [ CounterStyleType.t | `unset];
+  type t = [ | `counter(string, style)];
+
+  let counter: (~style: style=?, string) => t;
+
+  let toString: t => string;
+};
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/counters
+ */
+module Counters: {
+  type style = [ CounterStyleType.t | `unset];
+  type t = [ | `counters(string, string, style)];
+
+  let counters: (~style: style=?, ~separator: string=?, string) => t;
+
+  let toString: t => string;
+};
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/counter-increment
+ */
+module CounterIncrement: {
+  type t = [ | `none | `increment(string, int)];
+
+  let increment: (~value: int=?, string) => t;
+
+  let toString: t => string;
+};
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/counter-reset
+ */
+module CounterReset: {
+  type t = [ | `none | `reset(string, int)];
+
+  let reset: (~value: int=?, string) => t;
+
+  let toString: t => string;
+};
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/counter-set
+ */
+module CounterSet: {
+  type t = [ | `none | `set(string, int)];
+
+  let set: (~value: int=?, string) => t;
+
+  let toString: t => string;
+};
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/content
+ */
+module Content: {
+  type t = [
+    | `none
+    | `normal
+    | `openQuote
+    | `closeQuote
+    | `noOpenQuote
+    | `noCloseQuote
+    | `attr(string)
+    | `text(string)
+  ];
+
+  let toString: t => string;
+};

--- a/test/native/bs-css/Css_Core.rei
+++ b/test/native/bs-css/Css_Core.rei
@@ -1,0 +1,1955 @@
+/* Css documentation is copy/pasted from mozilla mdn web docs */
+
+module Types = Css_AtomicTypes;
+
+module type CssImplementationIntf = {
+  let mergeStyles: (. array(string)) => string;
+  let injectRule: (. Js.Json.t) => unit;
+  let injectRaw: (. string) => unit;
+  let make: (. Js.Json.t) => string;
+  let makeKeyFrames: (. Js.Dict.t(Js.Json.t)) => string;
+};
+
+type rule;
+type animationName;
+
+module Make:
+  (CssImplementationIntf) =>
+   {
+    let global: (string, list(rule)) => unit;
+    let insertRule: string => unit;
+    let merge: list(string) => string;
+    let style: list(rule) => string;
+    let keyframes: list((int, list(rule))) => animationName;
+  };
+
+// let empty: list(rule);
+let toJson: list(rule) => Js.Json.t;
+
+let important: rule => rule;
+let label: string => rule;
+
+module Shadow: {
+  type value('a);
+  type box;
+  type text;
+
+  type t('a) = [ | `shadow(value('a)) | `none];
+
+  let box:
+    (
+      ~x: Types.Length.t=?,
+      ~y: Types.Length.t=?,
+      ~blur: Types.Length.t=?,
+      ~spread: Types.Length.t=?,
+      ~inset: bool=?,
+      Types.Color.t
+    ) =>
+    [> t(box)];
+
+  let text:
+    (
+      ~x: Types.Length.t=?,
+      ~y: Types.Length.t=?,
+      ~blur: Types.Length.t=?,
+      Types.Color.t
+    ) =>
+    [> t(text)];
+
+  let toString: t('a) => string;
+};
+
+/* ********
+ Properties
+ ********** */
+
+/** If nothing works, use this (unsafe) escape hatch */
+let unsafe: (string, string) => rule;
+
+/**
+ The CSS align-content property sets the distribution of space between and around content items along a flexbox's
+ cross-axis or a grid's block axis.
+ */
+let alignContent:
+  [<
+    Types.AlignContent.t
+    | Types.NormalAlignment.t
+    | Types.BaselineAlignment.t
+    | Types.DistributedAlignment.t
+    | Types.Cascading.t
+  ] =>
+  rule;
+
+/**
+ The CSS align-items property sets the align-self value on all direct children as a group.
+ In Flexbox, it controls the alignment of items on the Cross Axis.
+ In Grid Layout, it controls the alignment of items on the Block Axis within their grid area.
+ */
+let alignItems:
+  [<
+    Types.AlignItems.t
+    | Types.PositionalAlignment.t
+    | Types.BaselineAlignment.t
+    | Types.Cascading.t
+  ] =>
+  rule;
+
+/**
+ The align-self CSS property overrides a grid or flex item's align-items value.
+ In Grid, it aligns the item inside the grid area. In Flexbox, it aligns the item on the cross axis.
+ */
+let alignSelf:
+  [<
+    Types.AlignSelf.t
+    | Types.PositionalAlignment.t
+    | Types.BaselineAlignment.t
+    | Types.Cascading.t
+  ] =>
+  rule;
+
+/**
+ The animation-delay CSS property sets when an animation starts.
+ The animation can start later, immediately from its beginning, or immediately and partway through the animation.
+ */
+let animationDelay: int => rule;
+
+/**
+ The animation-direction CSS property sets whether an animation should play forwards, backwards,
+ or alternating back and forth.
+ */
+let animationDirection: Types.AnimationDirection.t => rule;
+
+/**
+ The animation-duration CSS property sets the length of time that an animation takes to complete one cycle.
+ */
+let animationDuration: int => rule;
+
+/**
+ The animation-fill-mode CSS property sets how a CSS animation applies styles to its target before and after
+ its execution.
+ */
+let animationFillMode: Types.AnimationFillMode.t => rule;
+
+/**
+ The animation-iteration-count CSS property sets the number of times an animation cycle should be played
+ before stopping.
+ */
+let animationIterationCount: Types.AnimationIterationCount.t => rule;
+
+/**
+ The animation-play-state CSS property sets whether an animation is running or paused.
+ */
+let animationPlayState: Types.AnimationPlayState.t => rule;
+
+/**
+ The animation-timing-function CSS property sets how an animation progresses through the duration of each cycle.
+ */
+let animationTimingFunction: Types.TimingFunction.t => rule;
+
+/**
+  The backdrop-filter CSS property lets you apply graphical effects such as blurring or color shifting to the
+  area behind an element. Because it applies to everything behind the element, to see the effect you must
+  make the element or its background at least partially transparent.
+  */
+let backdropFilter: list(Types.BackdropFilter.t) => rule;
+
+/* Warning: experimental */
+let backfaceVisibility:
+  [< Types.BackfaceVisibility.t | Types.Cascading.t] => rule;
+
+/**
+ The background-attachment CSS property sets whether a background image's position is fixed within the viewport,
+ or scrolls with its containing block.
+ */
+let backgroundAttachment:
+  [< Types.BackgroundAttachment.t | Types.Cascading.t] => rule;
+
+/**
+ The background-color CSS property sets the background color of an element.
+ */
+let backgroundColor: Types.Color.t => rule;
+
+/**
+ The background-clip CSS property sets whether an element's background extends underneath its border box,
+ padding box, or content box.
+ */
+let backgroundClip: [< Types.BackgroundClip.t | Types.Cascading.t] => rule;
+
+/**
+ The background-image CSS property sets one or more background images on an element.
+ */
+let backgroundImage:
+  [< Types.BackgroundImage.t | Types.Url.t | Types.Gradient.t] => rule;
+
+/**
+ The background-origin CSS property sets the background's origin: from the border start,
+ inside the border, or inside the padding.
+ */
+let backgroundOrigin: [< Types.BackgroundClip.t | Types.Cascading.t] => rule;
+
+/**
+ The background-position CSS property sets the initial position for each background image.
+ The position is relative to the position layer set by background-origin.
+ */
+let backgroundPosition:
+  [<
+    Types.BackgroundPosition.t
+    | `hv(
+        [ Types.BackgroundPosition.X.t | Types.Length.t],
+        [ Types.BackgroundPosition.Y.t | Types.Length.t],
+      )
+    | Types.Length.t
+    | Types.Cascading.t
+  ] =>
+  rule;
+
+let backgroundPositions:
+  list(
+    [<
+      Types.BackgroundPosition.t
+      | `hv(
+          [ Types.BackgroundPosition.X.t | Types.Length.t],
+          [ Types.BackgroundPosition.Y.t | Types.Length.t],
+        )
+      | Types.Length.t
+      | Types.Cascading.t
+    ],
+  ) =>
+  rule;
+
+let backgroundPosition4:
+  (
+    ~x: Types.BackgroundPosition.X.t,
+    ~offsetX: Types.Length.t,
+    ~y: Types.BackgroundPosition.Y.t,
+    ~offsetY: Types.Length.t
+  ) =>
+  rule;
+
+/**
+ The background-repeat CSS property sets how background images are repeated.
+ A background image can be repeated along the horizontal and vertical axes, or not repeated at all.
+ */
+let backgroundRepeat:
+  [<
+    Types.BackgroundRepeat.t
+    | `hv(Types.BackgroundRepeat.horizontal, Types.BackgroundRepeat.vertical)
+    | Types.Cascading.t
+  ] =>
+  rule;
+
+/**
+ The border-bottom shorthand CSS property sets an element's bottom border.
+ It sets the values of border-bottom-width, border-bottom-style and border-bottom-color.
+ */
+let borderBottom:
+  (
+    Types.Length.t,
+    [< Types.BorderStyle.t | Types.Cascading.t],
+    Types.Color.t
+  ) =>
+  rule;
+
+/**
+ The border-bottom-color CSS property sets the color of an element's bottom border.
+ It can also be set with the shorthand CSS properties border-color or border-bottom.
+ */
+let borderBottomColor: Types.Color.t => rule;
+
+/**
+ The border-bottom-left-radius CSS property rounds the bottom-left corner of an element.
+ */
+let borderBottomLeftRadius: Types.Length.t => rule;
+
+/**
+ The border-bottom-right-radius CSS property rounds the bottom-right corner of an element.
+ */
+let borderBottomRightRadius: Types.Length.t => rule;
+
+/**
+ The border-bottom-style CSS property sets the line style of an element's bottom border.
+ */
+let borderBottomStyle: [< Types.BorderStyle.t | Types.Cascading.t] => rule;
+
+/**
+ The border-bottom-width CSS property sets the width of the bottom border of an element.
+ */
+let borderBottomWidth: Types.Length.t => rule;
+
+/**
+ The border-collapse CSS property sets whether cells inside a <table> have shared or separate borders.
+ */
+let borderCollapse: [< Types.BorderCollapse.t | Types.Cascading.t] => rule;
+
+/**
+ The border-color shorthand CSS property sets the color of an element's border.
+ */
+let borderColor: Types.Color.t => rule;
+
+/**
+ The border-left shorthand CSS property set an element's left border.
+ */
+let borderLeft:
+  (
+    Types.Length.t,
+    [< Types.BorderStyle.t | Types.Cascading.t],
+    Types.Color.t
+  ) =>
+  rule;
+
+let borderLeftColor: Types.Color.t => rule;
+
+let borderLeftStyle: [< Types.BorderStyle.t | Types.Cascading.t] => rule;
+
+let borderLeftWidth: Types.Length.t => rule;
+
+let borderRight:
+  (
+    Types.Length.t,
+    [< Types.BorderStyle.t | Types.Cascading.t],
+    Types.Color.t
+  ) =>
+  rule;
+
+let borderRightColor: Types.Color.t => rule;
+
+let borderRightStyle: [< Types.BorderStyle.t | Types.Cascading.t] => rule;
+
+let borderRightWidth: Types.Length.t => rule;
+
+let borderRadius: Types.Length.t => rule;
+
+let borderSpacing: Types.Length.t => rule;
+
+/**
+ The border-style shorthand CSS property sets the line style for all four sides of an element's border.
+ */
+let borderStyle: [< Types.BorderStyle.t | Types.Cascading.t] => rule;
+
+let borderTopColor: Types.Color.t => rule;
+
+let borderTopLeftRadius: Types.Length.t => rule;
+
+let borderTopRightRadius: Types.Length.t => rule;
+
+let borderTopStyle: [< Types.BorderStyle.t | Types.Cascading.t] => rule;
+
+let borderTopWidth: Types.Length.t => rule;
+
+let borderWidth: Types.Length.t => rule;
+
+let bottom: [< Types.Length.t | Types.Cascading.t] => rule;
+
+/**
+ The box-sizing CSS property sets how the total width and height of an element is calculated.
+ */
+let boxSizing: [< Types.BoxSizing.t | Types.Cascading.t] => rule;
+
+let boxShadow: [< Shadow.t(Shadow.box) | Types.Cascading.t] => rule;
+
+let boxShadows: list([ Shadow.t(Shadow.box)]) => rule;
+
+/**
+ The clear CSS property sets whether an element must be moved below (cleared) floating elements that precede it.
+ The clear property applies to floating and non-floating elements.
+ */
+let clear: [< Types.Clear.t | Types.Cascading.t] => rule;
+
+/**
+ The clip-path CSS property creates a clipping region that sets what part of an element should be shown.
+ Parts that are inside the region are shown, while those outside are hidden.
+ */
+let clipPath:
+  [<
+    Types.ClipPath.t
+    | Types.Url.t
+    | Types.GeometyBox.t
+    | Types.Cascading.t
+  ] =>
+  rule;
+
+let color: Types.Color.t => rule;
+
+/**
+ The column-count CSS property breaks an element's content into the specified number of columns.
+ */
+let columnCount: [< Types.ColumnCount.t | Types.Cascading.t] => rule;
+
+let contentRule:
+  [<
+    Types.Content.t
+    | Types.Counter.t
+    | Types.Counters.t
+    | Types.Gradient.t
+    | Types.Url.t
+    | Types.Cascading.t
+  ] =>
+  rule;
+let contentRules:
+  list(
+    [<
+      Types.Content.t
+      | Types.Counter.t
+      | Types.Counters.t
+      | Types.Gradient.t
+      | Types.Url.t
+    ],
+  ) =>
+  rule;
+
+let counterIncrement: [< Types.CounterIncrement.t | Types.Cascading.t] => rule;
+let countersIncrement: list([< Types.CounterIncrement.t]) => rule;
+let counterReset: [< Types.CounterReset.t | Types.Cascading.t] => rule;
+let countersReset: list([< Types.CounterReset.t]) => rule;
+let counterSet: [< Types.CounterSet.t | Types.Cascading.t] => rule;
+let countersSet: list([< Types.CounterSet.t]) => rule;
+
+let cursor: Types.Cursor.t => rule;
+
+/**
+ The direction CSS property sets the direction of text, table columns, and horizontal overflow.
+ Use rtl for languages written from right to left (like Hebrew or Arabic),
+ and ltr for those written from left to right (like English and most other languages).
+ */
+let direction: [< Types.Direction.t | Types.Cascading.t] => rule;
+
+/**
+ The display CSS property sets whether an element is treated as a block or inline element
+ and the layout used for its children, such as grid or flex.
+ */
+let display:
+  [<
+    Types.DisplayOutside.t
+    | Types.DisplayInside.t
+    | Types.DisplayListItem.t
+    | Types.DisplayInternal.t
+    | Types.DisplayBox.t
+    | Types.DisplayLegacy.t
+    | Types.Cascading.t
+  ] =>
+  rule;
+
+/**
+ The flex CSS property sets how a flex item will grow or shrink to fit the space available in its flex container.
+ It is a shorthand for flex-grow, flex-shrink, and flex-basis.
+ */
+let flex: [< Types.Flex.t | `num(float)] => rule;
+
+/**
+ The flex-basis CSS property sets the initial main size of a flex item.
+ It sets the size of the content box unless otherwise set with box-sizing.
+ */
+let flexBasis:
+  [< Types.FlexBasis.t | Types.Percentage.t | Types.Length.t] => rule;
+
+/**
+ The flex-direction CSS property sets how flex items are placed in the flex container defining the main axis and the direction (normal or reversed).
+ */
+let flexDirection: [< Types.FlexDirection.t | Types.Cascading.t] => rule;
+
+let flexGrow: float => rule;
+
+let flexShrink: float => rule;
+
+/**
+ The flex-wrap CSS property sets whether flex items are forced onto one line or can wrap onto multiple lines.
+ If wrapping is allowed, it sets the direction that lines are stacked.
+ */
+let flexWrap: [< Types.FlexWrap.t | Types.Cascading.t] => rule;
+
+/**
+ The float CSS property places an element on the left or right side of its container,
+ allowing text and inline elements to wrap around it.
+ The element is removed from the normal flow of the page, though still remaining a part of the flow
+ (in contrast to absolute positioning).
+ */
+let float: [< Types.Float.t | Types.Cascading.t] => rule;
+
+/**
+ The font-family CSS property specifies a prioritized list of one or more font family names and/or generic family names
+ for the selected element.
+ */
+let fontFamily: [< Types.FontFamilyName.t | Types.Cascading.t] => rule;
+
+let fontFamilies: list([ Types.FontFamilyName.t]) => rule;
+
+/**
+ The font-size CSS property sets the size of the font. This property is also used to compute the size of em, ex, and
+ other relative <length> units.
+ */
+let fontSize: [< Types.Length.t | Types.Cascading.t] => rule;
+
+/**
+ The font-style CSS property sets whether a font should be styled with a normal, italic, or oblique face from its
+ font-family.
+ */
+let fontStyle: [< Types.FontStyle.t | Types.Cascading.t] => rule;
+
+/**
+ The font-variant CSS property is a shorthand for the longhand properties font-variant-caps, font-variant-numeric,
+ font-variant-alternates, font-variant-ligatures, and font-variant-east-asian.
+ You can also set the CSS Level 2 (Revision 1) values of font-variant, (that is, normal or small-caps),
+ by using the font shorthand.
+ */
+let fontVariant: [< Types.FontVariant.t | Types.Cascading.t] => rule;
+
+/**
+ The font-weight CSS property sets the weight (or boldness) of the font. The weights available depend on the
+ font-family you are using.
+ */
+let fontWeight: [< Types.FontWeight.t | Types.Cascading.t] => rule;
+
+/**
+ The grid-area CSS property is a shorthand property for grid-row-start, grid-column-start, grid-row-end and
+ grid-column-end, specifying a grid item’s size and location within the grid by contributing a line, a span,
+ or nothing (automatic) to its grid placement, thereby specifying the edges of its grid area.
+ */
+let gridArea: [< Types.GridArea.t | Types.Cascading.t] => rule;
+let gridArea2: (Types.GridArea.t, Types.GridArea.t) => rule;
+let gridArea3: (Types.GridArea.t, Types.GridArea.t, Types.GridArea.t) => rule;
+let gridArea4:
+  (Types.GridArea.t, Types.GridArea.t, Types.GridArea.t, Types.GridArea.t) =>
+  rule;
+
+/**
+ The grid-auto-flow CSS property controls how the auto-placement algorithm works,
+ specifying exactly how auto-placed items get flowed into the grid.
+ */
+let gridAutoFlow: [< Types.GridAutoFlow.t | Types.Cascading.t] => rule;
+
+/**
+ The grid-column CSS property is a shorthand property for grid-column-start and grid-column-end
+ specifying a grid item's size and location within the grid column by contributing a line, a span,
+ or nothing (automatic) to its grid placement, thereby specifying the inline-start and
+ inline-end edge of its grid area.
+ */
+let gridColumn: (int, int) => rule;
+
+/**
+ The grid-column-end CSS property specifies a grid item’s end position within the grid column by contributing a line,
+ a span, or nothing (automatic) to its grid placement, thereby specifying the block-end edge of its grid area.
+ */
+let gridColumnEnd: int => rule;
+
+/**
+ The column-gap CSS property sets the size of the gap (gutter) between an element's columns.
+ */
+let gridColumnGap:
+  [<
+    Types.GridColumnGap.t
+    | Types.Percentage.t
+    | Types.Length.t
+    | Types.Cascading.t
+  ] =>
+  rule;
+
+/**
+ The grid-column-start CSS property specifies a grid item’s start position within the grid column
+ by contributing a line, a span, or nothing (automatic) to its grid placement.
+ This start position defines the block-start edge of the grid area.
+ */
+let gridColumnStart: int => rule;
+
+/**
+ The gap CSS property sets the gaps (gutters) between rows and columns. It is a shorthand for row-gap and column-gap.
+ */
+let gridGap:
+  [< Types.Percentage.t | Types.Length.t | Types.Cascading.t] => rule;
+
+/**
+ The grid-row CSS property is a shorthand property for grid-row-start and grid-row-end specifying a grid item’s size
+ and location within the grid row by contributing a line, a span, or nothing (automatic) to its grid placement,
+ thereby specifying the inline-start and inline-end edge of its grid area.
+ */
+let gridRow: (int, int) => rule;
+
+/**
+ The grid-row-end CSS property specifies a grid item’s end position within the grid row by contributing a line, a span,
+ or nothing (automatic) to its grid placement, thereby specifying the inline-end edge of its grid area.
+ */
+let gridRowEnd: int => rule;
+
+/**
+ The row-gap CSS property sets the size of the gap (gutter) between an element's grid rows.
+ */
+let gridRowGap:
+  [< Types.Percentage.t | Types.Length.t | Types.Cascading.t] => rule;
+
+/**
+ The grid-row-start CSS property specifies a grid item’s start position within the grid row by contributing a line,
+ a span, or nothing (automatic) to its grid placement, thereby specifying the inline-start edge of its grid area.
+ */
+let gridRowStart: int => rule;
+
+/**
+ The grid-template-areas CSS property specifies named grid areas.
+ */
+let gridTemplateAreas:
+  [< Types.GridTemplateAreas.t | Types.Cascading.t] => rule;
+
+/**
+ The height CSS property specifies the height of an element.
+ By default, the property defines the height of the content area.
+ If box-sizing is set to border-box, however, it instead determines the height of the border area.
+ */
+let height:
+  [<
+    Types.Height.t
+    | Types.Percentage.t
+    | Types.Length.t
+    | Types.Cascading.t
+  ] =>
+  rule;
+
+/**
+ The CSS justify-content property defines how the browser distributes space between and around content items
+ along the main-axis of a flex container, and the inline axis of a grid container.
+ */
+let justifyContent:
+  [<
+    Types.PositionalAlignment.t
+    | Types.NormalAlignment.t
+    | Types.DistributedAlignment.t
+    | Types.Cascading.t
+  ] =>
+  rule;
+
+/**
+ The CSS justify-self property sets the way a box is justified inside its alignment container along the appropriate axis.
+ */
+let justifySelf:
+  [<
+    Types.JustifySelf.t
+    | Types.PositionalAlignment.t
+    | Types.BaselineAlignment.t
+    | Types.Cascading.t
+  ] =>
+  rule;
+
+let left: [< Types.Length.t | Types.Cascading.t] => rule;
+
+/**
+ The letter-spacing CSS property sets the spacing behavior between text characters
+ */
+let letterSpacing:
+  [< Types.LetterSpacing.t | Types.Length.t | Types.Cascading.t] => rule;
+
+/**
+ The line-height CSS property sets the height of a line box. It's commonly used to set the distance between lines of text.
+ On block-level elements, it specifies the minimum height of line boxes within the element.
+ On non-replaced inline elements, it specifies the height that is used to calculate line box height.
+ */
+let lineHeight:
+  [< Types.LineHeight.t | Types.Length.t | Types.Cascading.t] => rule;
+
+/**
+ The list-style CSS property is a shorthand to set list style properties list-style-type,
+ list-style-image, and list-style-position.
+ */
+let listStyle:
+  (
+    Types.ListStyleType.t,
+    Types.ListStylePosition.t,
+    [< Types.ListStyleImage.t | Types.Url.t]
+  ) =>
+  rule;
+
+/**
+ The list-style-image CSS property sets an image to be used as the list item marker.
+ It is often more convenient to use the shorthand list-style.
+ */
+let listStyleImage:
+  [< Types.ListStyleImage.t | Types.Url.t | Types.Cascading.t] => rule;
+
+/**
+ The list-style-type CSS property sets the marker (such as a disc, character, or custom counter style) of a list item element.
+ */
+let listStyleType: [< Types.ListStyleType.t | Types.Cascading.t] => rule;
+
+/**
+ The list-style-position CSS property sets the position of the ::marker relative to a list item.
+ */
+let listStylePosition:
+  [< Types.ListStylePosition.t | Types.Cascading.t] => rule;
+
+let margin: [< Types.Length.t | Types.Margin.t] => rule;
+let margin2:
+  (
+    ~v: [< Types.Length.t | Types.Margin.t],
+    ~h: [< Types.Length.t | Types.Margin.t]
+  ) =>
+  rule;
+let margin3:
+  (
+    ~top: [< Types.Length.t | Types.Margin.t],
+    ~h: [< Types.Length.t | Types.Margin.t],
+    ~bottom: [< Types.Length.t | Types.Margin.t]
+  ) =>
+  rule;
+let margin4:
+  (
+    ~top: [< Types.Length.t | Types.Margin.t],
+    ~right: [< Types.Length.t | Types.Margin.t],
+    ~bottom: [< Types.Length.t | Types.Margin.t],
+    ~left: [< Types.Length.t | Types.Margin.t]
+  ) =>
+  rule;
+
+let marginLeft: [< Types.Length.t | Types.Margin.t] => rule;
+
+let marginRight: [< Types.Length.t | Types.Margin.t] => rule;
+
+let marginTop: [< Types.Length.t | Types.Margin.t] => rule;
+
+let marginBottom: [< Types.Length.t | Types.Margin.t] => rule;
+
+/**
+ The max-height CSS property sets the maximum height of an element.
+ It prevents the used value of the height property from becoming larger than the value specified for max-height.
+ */
+let maxHeight:
+  [<
+    Types.MaxHeight.t
+    | Types.Percentage.t
+    | Types.Length.t
+    | Types.Cascading.t
+  ] =>
+  rule;
+
+/**
+ The max-width CSS property sets the maximum width of an element.
+ It prevents the used value of the width property from becoming larger than the value specified by max-width.
+ */
+let maxWidth:
+  [<
+    Types.MaxWidth.t
+    | Types.Percentage.t
+    | Types.Length.t
+    | Types.Cascading.t
+  ] =>
+  rule;
+
+/**
+ The min-height CSS property sets the minimum height of an element.
+ It prevents the used value of the height property from becoming smaller than the value specified for min-height.
+ */
+let minHeight:
+  [<
+    Types.Height.t
+    | Types.Percentage.t
+    | Types.Length.t
+    | Types.Cascading.t
+  ] =>
+  rule;
+
+/**
+ The min-width CSS property sets the minimum width of an element.
+ It prevents the used value of the width property from becoming smaller than the value specified for min-width.
+ */
+let minWidth:
+  [<
+    Types.Width.t
+    | Types.Percentage.t
+    | Types.Length.t
+    | Types.Cascading.t
+  ] =>
+  rule;
+
+/**
+ The object-fit CSS property sets how the content of a replaced element,
+ such as an <img> or <video>, should be resized to fit its container.
+ */
+let objectFit: [< Types.ObjectFit.t | Types.Cascading.t] => rule;
+
+let objectPosition:
+  [<
+    Types.BackgroundPosition.t
+    | `hv(
+        [ Types.BackgroundPosition.X.t | Types.Length.t],
+        [ Types.BackgroundPosition.Y.t | Types.Length.t],
+      )
+    | Types.Length.t
+    | Types.Cascading.t
+  ] =>
+  rule;
+
+let opacity: float => rule;
+
+let order: int => rule;
+
+let outline: (Types.Length.t, Types.OutlineStyle.t, Types.Color.t) => rule;
+
+let outlineColor: Types.Color.t => rule;
+
+let outlineOffset: Types.Length.t => rule;
+
+let outlineStyle: Types.OutlineStyle.t => rule;
+
+let outlineWidth: Types.Length.t => rule;
+
+let overflow: Types.Overflow.t => rule;
+
+let overflowX: Types.Overflow.t => rule;
+
+let overflowY: Types.Overflow.t => rule;
+
+/**
+ The overflow-wrap CSS property applies to inline elements, setting whether the browser
+ should insert line breaks within an otherwise unbreakable string to prevent text
+ from overflowing its line box.
+ */
+let overflowWrap: [< Types.OverflowWrap.t | Types.Cascading.t] => rule;
+
+let padding: Types.Length.t => rule;
+let padding2: (~v: Types.Length.t, ~h: Types.Length.t) => rule;
+let padding3:
+  (~top: Types.Length.t, ~h: Types.Length.t, ~bottom: Types.Length.t) => rule;
+let padding4:
+  (
+    ~top: Types.Length.t,
+    ~right: Types.Length.t,
+    ~bottom: Types.Length.t,
+    ~left: Types.Length.t
+  ) =>
+  rule;
+
+let paddingLeft: Types.Length.t => rule;
+
+let paddingRight: Types.Length.t => rule;
+
+let paddingTop: Types.Length.t => rule;
+
+let paddingBottom: Types.Length.t => rule;
+
+/**
+ The perspective CSS property determines the distance between the z=0 plane and the user in order
+ to give a 3D-positioned element some perspective.
+ Each 3D element with z>0 becomes larger; each 3D-element with z<0 becomes smaller.
+ The strength of the effect is determined by the value of this property.
+ */
+let perspective:
+  [< Types.Perspective.t | Types.Length.t | Types.Cascading.t] => rule;
+
+/**
+ The perspective-origin CSS property determines the position at which the viewer is looking.
+ It is used as the vanishing point by the perspective property.
+ */
+let perspectiveOrigin:
+  (
+    [< Types.Perspective.t | Types.Length.t],
+    [< Types.Perspective.t | Types.Length.t]
+  ) =>
+  rule;
+
+/**
+ The pointer-events CSS property sets under what circumstances (if any) a particular graphic element can become the target of pointer events.
+ */
+let pointerEvents: [< Types.PointerEvents.t | Types.Cascading.t] => rule;
+
+/**
+ The position CSS property sets how an element is positioned in a document.
+ The top, right, bottom, and left properties determine the final location of positioned elements.
+ */
+let position: [< Types.Position.t | Types.Cascading.t] => rule;
+
+/**
+ The resize CSS property sets whether an element is resizable, and if so,
+ in which directions.
+ */
+let resize: [< Types.Resize.t | Types.Cascading.t] => rule;
+
+let right: [< Types.Length.t | Types.Cascading.t] => rule;
+
+/**
+ The table-layout CSS property sets the algorithm used to lay out <table> cells, rows, and columns.
+ */
+let tableLayout: [< Types.TableLayout.t | Types.Cascading.t] => rule;
+
+/**
+ The text-align CSS property sets the horizontal alignment of a block element or table-cell box.
+ This means it works like vertical-align but in the horizontal direction.
+ */
+let textAlign: [< Types.TextAlign.t | Types.Cascading.t] => rule;
+
+/**
+ The text-decoration-color CSS property sets the color of decorations added to text by text-decoration-line.
+ */
+let textDecorationColor: [< Types.Color.t | Types.Cascading.t] => rule;
+
+/**
+ The text-decoration-line CSS property sets the kind of decoration
+ that is used on text in an element, such as an underline or overline.
+ */
+let textDecorationLine:
+  [< Types.TextDecorationLine.t | Types.Cascading.t] => rule;
+
+/**
+ The text-decoration-style CSS property sets the style of the lines specified by text-decoration-line.
+ The style applies to all lines that are set with text-decoration-line.
+ */
+let textDecorationStyle:
+  [< Types.TextDecorationStyle.t | Types.Cascading.t] => rule;
+
+/**
+ The text-indent CSS property sets the length of empty space (indentation)
+ that is put before lines of text in a block.
+ */
+let textIndent:
+  [< Types.Percentage.t | Types.Length.t | Types.Cascading.t] => rule;
+
+/**
+ The text-overflow CSS property sets how hidden overflow content is signaled to users.
+ It can be clipped, display an ellipsis ('…'), or display a custom string.
+ */
+let textOverflow: [< Types.TextOverflow.t | Types.Cascading.t] => rule;
+
+/**
+ The text-shadow CSS property adds shadows to text.
+ It accepts a comma-separated list of shadows to be applied to the text and any of its decorations.
+ Each shadow is described by some combination of X and Y offsets from the element, blur radius, and color.
+ */
+let textShadow: [< Shadow.t(Shadow.text) | Types.Cascading.t] => rule;
+let textShadows: list([ Shadow.t(Shadow.text)]) => rule;
+
+/**
+ The text-transform CSS property specifies how to capitalize an element's text.
+ It can be used to make text appear in all-uppercase or all-lowercase, or with each word capitalized.
+ */
+let textTransform: [< Types.TextTransform.t | Types.Cascading.t] => rule;
+
+let top: [< Types.Length.t | Types.Cascading.t] => rule;
+
+let transform: Types.Transform.t => rule;
+
+let transforms: list(Types.Transform.t) => rule;
+
+/**
+ The transform-origin CSS property sets the origin for an element's transformations.
+ */
+let transformOrigin: (Types.Length.t, Types.Length.t) => rule;
+let transformOrigin3d:
+  (Types.Length.t, Types.Length.t, Types.Length.t) => rule;
+
+let transitionDelay: int => rule;
+
+let transitionDuration: int => rule;
+
+let transitionProperty: string => rule;
+
+let transformStyle: [< Types.TransformStyle.t | Types.Cascading.t] => rule;
+
+let transitionTimingFunction: Types.TimingFunction.t => rule;
+
+/**
+ The user-select CSS property controls whether the user can select text.
+ This doesn't have any effect on content loaded as chrome, except in textboxes.
+ */
+let userSelect: [< Types.UserSelect.t | Types.Cascading.t] => rule;
+
+/**
+ The vertical-align CSS property sets vertical alignment of an inline or table-cell box.
+ */
+let verticalAlign:
+  [< Types.VerticalAlign.t | Types.Length.t | Types.Cascading.t] => rule;
+
+/**
+ The visibility CSS property shows or hides an element without changing the layout of a document.
+ The property can also hide rows or columns in a <table>.
+ */
+let visibility: [< Types.Visibility.t | Types.Cascading.t] => rule;
+
+/**
+ The width CSS property sets an element's width.
+ By default, it sets the width of the content area, but if box-sizing is set to border-box,
+ it sets the width of the border area.
+ */
+let width:
+  [<
+    Types.Width.t
+    | Types.Percentage.t
+    | Types.Length.t
+    | Types.Cascading.t
+  ] =>
+  rule;
+
+/**
+ The white-space CSS property sets how white space inside an element is handled.
+ */
+let whiteSpace: [< Types.WhiteSpace.t | Types.Cascading.t] => rule;
+
+/**
+ The word-break CSS property sets whether line breaks appear wherever the text would otherwise overflow its content box.
+ */
+let wordBreak: [< Types.WordBreak.t | Types.Cascading.t] => rule;
+
+/**
+ The word-spacing CSS property sets the length of space between words and between tags
+ */
+let wordSpacing:
+  [<
+    Types.WordSpacing.t
+    | Types.Length.t
+    | Types.Percentage.t
+    | Types.Cascading.t
+  ] =>
+  rule;
+
+/**
+ see overflowWrap
+ */
+let wordWrap: [< Types.OverflowWrap.t | Types.Cascading.t] => rule;
+
+/**
+ The z-index CSS property sets the z-order of a positioned element and its descendants or flex items.
+ Overlapping elements with a larger z-index cover those with a smaller one.
+ */
+let zIndex: int => rule;
+
+/* *******
+ selectors
+ ********* */
+
+let selector: (string, list(rule)) => rule;
+let media: (string, list(rule)) => rule;
+
+/** type selector */
+
+/*
+ Pseudo-classes selectors
+
+ A CSS pseudo-class is a keyword added to a selector that specifies a special state of the selected element(s).
+ */
+
+/**
+ The :active CSS pseudo-class represents an element (such as a button) that is being activated by the user.
+ When using a mouse, "activation" typically starts when the user presses down the primary mouse button.
+ */
+let active: list(rule) => rule;
+
+/**
+ The :checked CSS pseudo-class selector represents any radio (<input type="radio">), checkbox (<input type="checkbox">),
+ or option (<option> in a <select>) element that is checked or toggled to an on state.
+ */
+let checked: list(rule) => rule;
+
+/**
+ The :default CSS pseudo-class selects form elements that are the default in a group of related elements.
+ */
+let default: list(rule) => rule;
+
+/**
+ The :defined CSS pseudo-class represents any element that has been defined.
+ This includes any standard element built in to the browser, and custom elements that have been successfully defined
+ (i.e. with the CustomElementRegistry.define() method).
+ */
+let defined: list(rule) => rule;
+
+/**
+ The :disabled CSS pseudo-class represents any disabled element.
+ An element is disabled if it can't be activated (selected, clicked on, typed into, etc.) or accept focus.
+ The element also has an enabled state, in which it can be activated or accept focus.
+ */
+let disabled: list(rule) => rule;
+
+/**
+ The :empty CSS pseudo-class represents any element that has no children.
+ Children can be either element nodes or text (including whitespace).
+ Comments, processing instructions, and CSS content do not affect whether an element is considered empty.
+ */
+let empty: list(rule) => rule;
+
+/**
+ The :enabled CSS pseudo-class represents any enabled element.
+ An element is enabled if it can be activated (selected, clicked on, typed into, etc.) or accept focus.
+ The element also has a disabled state, in which it can't be activated or accept focus.
+ */
+let enabled: list(rule) => rule;
+
+/**
+ The :first CSS pseudo-class, used with the  @page at-rule, represents the first page of a printed document.
+ */
+let first: list(rule) => rule;
+
+/**
+ The :first-child CSS pseudo-class represents the first element among a group of sibling elements.
+ */
+let firstChild: list(rule) => rule;
+
+/**
+ The :first-of-type CSS pseudo-class represents the first element of its type among a group of sibling elements.
+ */
+let firstOfType: list(rule) => rule;
+
+/**
+ The :focus CSS pseudo-class represents an element (such as a form input) that has received focus.
+ It is generally triggered when the user clicks or taps on an element or selects it with the keyboard's "tab" key.
+ */
+let focus: list(rule) => rule;
+
+/**
+ The :focus-within CSS pseudo-class represents an element that has received focus or contains an element
+ that has received focus. In other words, it represents an element that is itself matched by the :focus pseudo-class or has a descendant that is matched by :focus.
+  (This includes descendants in shadow trees.)
+ */
+let focusWithin: list(rule) => rule;
+
+/**
+ The :host CSS pseudo-class selects the shadow host of the shadow DOM containing the CSS it is used inside
+ — in other words, this allows you to select a custom element from inside its shadow DOM.
+ */
+let host: (~selector: string=?, list(rule)) => rule;
+
+/**
+ The :hover CSS pseudo-class matches when the user interacts with an element with a pointing device,
+ but does not necessarily activate it.
+ It is generally triggered when the user hovers over an element with the cursor (mouse pointer).
+ */
+let hover: list(rule) => rule;
+
+/**
+ The :indeterminate CSS pseudo-class represents any form element whose state is indeterminate.
+ */
+let indeterminate: list(rule) => rule;
+
+/**
+ The :in-range CSS pseudo-class represents an <input> element whose current value is
+ within the range limits specified by the min and max attributes.
+ */
+let inRange: list(rule) => rule;
+
+/**
+ The :invalid CSS pseudo-class represents any <input> or other <form> element whose contents fail to validate.
+ */
+let invalid: list(rule) => rule;
+
+/**
+ The :lang() CSS pseudo-class matches elements based on the language they are determined to be in.
+ */
+let lang: (string, list(rule)) => rule;
+
+/**
+ The :last-child CSS pseudo-class represents the last element among a group of sibling elements.
+ */
+let lastChild: list(rule) => rule;
+
+/**
+ The :last-of-type CSS pseudo-class represents the last element of its type among a group of sibling elements.
+ */
+let lastOfType: list(rule) => rule;
+
+//let left: list(rule) => rule;
+
+/**
+ The :link CSS pseudo-class represents an element that has not yet been visited.
+ It matches every unvisited <a>, <area>, or <link> element that has an href attribute.
+ */
+let link: list(rule) => rule;
+
+/**
+ The :not() CSS pseudo-class represents elements that do not match a list of selectors.
+ Since it prevents specific items from being selected, it is known as the negation pseudo-class.
+ */
+let not_: (string, list(rule)) => rule;
+
+module Nth: {
+  type t = [ | `odd | `even | `n(int) | `add(int, int)];
+  let toString: t => string;
+};
+
+/**
+ The :nth-child() CSS pseudo-class matches elements based on their position in a group of siblings.
+ */
+let nthChild: (Nth.t, list(rule)) => rule;
+
+/**
+ The :nth-last-child() CSS pseudo-class matches elements based on their position among a group of siblings,
+ counting from the end.
+ */
+let nthLastChild: (Nth.t, list(rule)) => rule;
+
+/**
+ The :nth-last-of-type() CSS pseudo-class matches elements of a given type,
+ based on their position among a group of siblings, counting from the end.
+ */
+let nthLastOfType: (Nth.t, list(rule)) => rule;
+
+/**
+ The :nth-of-type() CSS pseudo-class matches elements of a given type,
+ based on their position among a group of siblings.
+ */
+let nthOfType: (Nth.t, list(rule)) => rule;
+
+/**
+ The :only-child CSS pseudo-class represents an element without any siblings.
+ This is the same as :first-child:last-child or :nth-child(1):nth-last-child(1),
+ but with a lower specificity.
+ */
+let onlyChild: list(rule) => rule;
+
+/**
+ The :only-of-type CSS pseudo-class represents an element that has no siblings of the same type.
+ */
+let onlyOfType: list(rule) => rule;
+
+/**
+ The :optional CSS pseudo-class represents any <input>, <select>,
+ or <textarea> element that does not have the required attribute set on it.
+ */
+let optional: list(rule) => rule;
+
+/**
+ The :out-of-range CSS pseudo-class represents an <input> element whose current value
+ is outside the range limits specified by the min and max attributes.
+ */
+let outOfRange: list(rule) => rule;
+
+/**
+ The :read-only CSS pseudo-class represents an element (such as input or textarea)
+ that is not editable by the user.
+ */
+let readOnly: list(rule) => rule;
+
+/**
+ The :read-write CSS pseudo-class represents an element (such as input or textarea)
+ that is editable by the user.
+ */
+let readWrite: list(rule) => rule;
+
+/**
+ The :required CSS pseudo-class represents any <input>, <select>, or <textarea> element
+ that has the required attribute set on it.
+ */
+let required: list(rule) => rule;
+
+//let right: list(rule) => rule;
+
+/**
+ The :root CSS pseudo-class matches the root element of a tree representing the document.
+ In HTML, :root represents the <html> element and is identical to the selector html,
+ except that its specificity is higher.
+ */
+let root: list(rule) => rule;
+
+/**
+ The :scope CSS pseudo-class represents elements that are a reference point for selectors to match against.
+ */
+let scope: list(rule) => rule;
+
+/**
+ The :target CSS pseudo-class represents a unique element (the target element) with an id matching
+ the URL's fragment.
+ */
+let target: list(rule) => rule;
+
+/**
+ The :valid CSS pseudo-class represents any <input> or other <form> element whose contents validate successfully.
+ This allows to easily make valid fields adopt an appearance that helps the user confirm that their data is formatted properly.
+ */
+let valid: list(rule) => rule;
+
+/**
+ The :visited CSS pseudo-class represents links that the user has already visited.
+ For privacy reasons, the styles that can be modified using this selector are very limited.
+ */
+let visited: list(rule) => rule;
+
+/*
+ Pseudo-elements selectors
+
+ A CSS pseudo-element is a keyword added to a selector that lets you style a specific part of the selected element(s).
+ */
+
+/**
+ ::after creates a pseudo-element that is the last child of the selected element.
+ It is often used to add cosmetic content to an element with the content property. It is inline by default.
+ */
+let after: list(rule) => rule;
+
+/**
+ ::before creates a pseudo-element that is the first child of the selected element.
+ It is often used to add cosmetic content to an element with the content property. It is inline by default.
+ */
+let before: list(rule) => rule;
+
+/**
+ The ::first-letter CSS pseudo-element applies styles to the first letter of the first line of a block-level element,
+ but only when not preceded by other content (such as images or inline tables).
+ */
+let firstLetter: list(rule) => rule;
+
+/**
+ The ::first-line CSS pseudo-element applies styles to the first line of a block-level element.
+ Note that the length of the first line depends on many factors, including the width of the element,
+ the width of the document, and the font size of the text.
+ */
+let firstLine: list(rule) => rule;
+
+/**
+ The ::placeholder CSS pseudo-element represents the placeholder text in an <input> or <textarea> element.
+ */
+let placeholder: list(rule) => rule;
+
+/**
+ The ::selection CSS pseudo-element applies styles to the part of a document that has been highlighted by the user
+ (such as clicking and dragging the mouse across text).
+ */
+let selection: list(rule) => rule;
+
+/**
+ Combinators selectors
+ */
+
+/**
+ The > combinator selects nodes that are direct children of the first element.
+ */
+let child: (string, list(rule)) => rule;
+
+/**
+ The > * combinator selects all nodes that are direct children of the first element.
+ */
+let children: list(rule) => rule;
+
+/**
+ The + combinator selects adjacent siblings.
+ This means that the second element directly follows the first, and both share the same parent.
+ */
+let directSibling: list(rule) => rule;
+
+/**
+ The ~ combinator selects siblings.
+ This means that the second element follows the first (though not necessarily immediately),
+ and both share the same parent.
+ */
+let siblings: list(rule) => rule;
+
+/* !experimental! */
+
+let anyLink: list(rule) => rule;
+
+/* **************************************************
+ Constructor aliases, for ease of use.
+ Refer to the equivalent function in the type module.
+ **************************************************** */
+
+let initial: [> Types.Cascading.t];
+let inherit_: [> Types.Cascading.t];
+let unset: [> Types.Cascading.t];
+
+// shared
+let auto: [> | `auto];
+let none: [> | `none];
+let text: [> | `text];
+
+let pct: float => [> Types.Percentage.t];
+
+let ch: float => [> | `ch(float)];
+let cm: float => [> | `cm(float)];
+let em: float => [> | `em(float)];
+let ex: float => [> | `ex(float)];
+let mm: float => [> | `mm(float)];
+let pt: int => [> | `pt(int)];
+let px: int => [> | `px(int)];
+let pxFloat: float => [> | `pxFloat(float)];
+let rem: float => [> | `rem(float)];
+let vh: float => [> | `vh(float)];
+let vmin: float => [> | `vmin(float)];
+let vmax: float => [> | `vmax(float)];
+let zero: [> | `zero];
+
+let deg: float => Types.Angle.t;
+let rad: float => Types.Angle.t;
+let grad: float => Types.Angle.t;
+let turn: float => Types.Angle.t;
+
+let ltr: [> Types.Direction.t];
+let rtl: [> Types.Direction.t];
+
+let absolute: [> Types.Position.t];
+let relative: [> Types.Position.t];
+let static: [> Types.Position.t];
+let fixed: [> | `fixed];
+let sticky: [> Types.Position.t];
+
+let horizontal: [> Types.Resize.t];
+let vertical: [> Types.Resize.t];
+
+let smallCaps: [> Types.FontVariant.t];
+
+/* let normal: [> | Types.FontStyle.t]*/
+let italic: [> Types.FontStyle.t];
+let oblique: [> Types.FontStyle.t];
+
+let hidden: [> | `hidden];
+let visible: [> | `visible];
+let scroll: [> | `scroll];
+
+let rgb: (int, int, int) => [> Types.Color.t];
+let rgba: (int, int, int, float) => [> Types.Color.t];
+let hsl: (Types.Angle.t, float, float) => [> Types.Color.t];
+let hsla:
+  (Types.Angle.t, float, float, [ | `num(float) | `percent(float)]) =>
+  [> Types.Color.t];
+let hex: string => [> Types.Color.t];
+let transparent: [> Types.Color.t];
+let currentColor: [> Types.Color.t];
+
+let local: [> | `local];
+
+let paddingBox: [> | `paddingBox];
+let borderBox: [> | `borderBox];
+let contentBox: [> | `contentBox];
+
+let noRepeat: [> | `noRepeat];
+let space: [> | `space];
+let repeat: [> | `repeat];
+let minmax: [> | `minmax];
+let repeatX: [> | `repeatX];
+let repeatY: [> | `repeatY];
+let contain: [> | `contain];
+let cover: [> | `cover];
+
+let row: [> | `row];
+let rowReverse: [> | `rowReverse];
+let column: [> | `column];
+let columnReverse: [> | `columnReverse];
+let wrap: [> | `wrap];
+let nowrap: [> | `nowrap];
+let wrapReverse: [> | `wrapReverse];
+
+let inline: [> | `inline];
+let block: [> | `block];
+let contents: [> | `contents];
+let flexBox: [> | `flex];
+let grid: [> | `grid];
+let inlineBlock: [> | `inlineBlock];
+let inlineFlex: [> | `inlineFlex];
+let inlineGrid: [> | `inlineGrid];
+let inlineTable: [> | `inlineTable];
+let listItem: [> | `listItem];
+let runIn: [> | `runIn];
+let table: [> | `table];
+let tableCaption: [> | `tableCaption];
+let tableColumnGroup: [> | `tableColumnGroup];
+let tableHeaderGroup: [> | `tableHeaderGroup];
+let tableFooterGroup: [> | `tableFooterGroup];
+let tableRowGroup: [> | `tableRowGroup];
+let tableCell: [> | `tableCell];
+let tableColumn: [> | `tableColumn];
+let tableRow: [> | `tableRow];
+
+let flexStart: [> | `flexStart];
+let flexEnd: [> | `flexEnd];
+let center: [> | `center];
+let stretch: [> | `stretch];
+let spaceBetween: [> | `spaceBetween];
+let spaceAround: [> | `spaceAround];
+let spaceEvenly: [> | `spaceEvenly];
+let baseline: [> | `baseline];
+
+let forwards: [> | `forwards];
+let backwards: [> | `backwards];
+let both: [> | `both];
+let infinite: [> | `infinite];
+let count: int => [> | `count(int)];
+let paused: [> | `paused];
+let running: [> | `running];
+
+let inside: [> | `inside];
+let outside: [> | `outside];
+
+let solid: [> | `solid];
+let dotted: [> | `dotted];
+let dashed: [> | `dashed];
+
+let underline: [> | `underline];
+let overline: [> | `overline];
+let lineThrough: [> | `lineThrough];
+
+let clip: [> | `clip];
+let ellipsis: [> | `ellipsis];
+
+let wavy: [> | `wavy];
+let double: [> | `double];
+
+let uppercase: [> | `uppercase];
+let lowercase: [> | `lowercase];
+let capitalize: [> | `capitalize];
+
+let sub: [> | `sub];
+let super: [> | `super];
+let textTop: [> | `textTop];
+let textBottom: [> | `textBottom];
+let middle: [> | `middle];
+
+let normal: [> | `normal];
+
+let breakAll: [> | `breakAll];
+let keepAll: [> | `keepAll];
+let breakWord: [> | `breakWord];
+
+let reverse: [> | `reverse];
+let alternate: [> | `alternate];
+let alternateReverse: [> | `alternateReverse];
+
+let fill: [> | `fill];
+let content: [> | `content];
+let maxContent: [> | `maxContent];
+let minContent: [> | `minContent];
+let fitContent: [> | `fitContent];
+
+let all: [> | `all];
+
+let round: [> | `round];
+let miter: [> | `miter];
+let bevel: [> | `bevel];
+let butt: [> | `butt];
+let square: [> | `square];
+
+let thin: [> Types.FontWeight.t];
+let extraLight: [> Types.FontWeight.t];
+let light: [> Types.FontWeight.t];
+let medium: [> Types.FontWeight.t];
+let semiBold: [> Types.FontWeight.t];
+let bold: [> Types.FontWeight.t];
+let extraBold: [> Types.FontWeight.t];
+let lighter: [> Types.FontWeight.t];
+let bolder: [> Types.FontWeight.t];
+
+let fr: float => [> | `fr(float)];
+let vw: float => [> | `vw(float)];
+
+let localUrl: string => [> | `localUrl(string)];
+let url: string => [> | `url(string)];
+
+let linear: [> Types.TimingFunction.t];
+let ease: [> Types.TimingFunction.t];
+let easeIn: [> Types.TimingFunction.t];
+let easeOut: [> Types.TimingFunction.t];
+let easeInOut: [> Types.TimingFunction.t];
+let stepStart: [> Types.TimingFunction.t];
+let stepEnd: [> Types.TimingFunction.t];
+let steps: (int, [ | `start | `end_]) => [> Types.TimingFunction.t];
+let cubicBezier: (float, float, float, float) => [> Types.TimingFunction.t];
+
+let marginBox: [> Types.GeometyBox.t];
+//let borderBox: [> Types.GeometyBox.t];
+//let paddingBox: [> Types.GeometyBox.t];
+//let contentBox: [> Types.GeometyBox.t];
+let fillBox: [> Types.GeometyBox.t];
+let strokeBox: [> Types.GeometyBox.t];
+let viewBox: [> Types.GeometyBox.t];
+
+let translate: (Types.Length.t, Types.Length.t) => [> Types.Transform.t];
+let translate3d:
+  (Types.Length.t, Types.Length.t, Types.Length.t) => [> Types.Transform.t];
+let translateX: Types.Length.t => [> Types.Transform.t];
+let translateY: Types.Length.t => [> Types.Transform.t];
+let translateZ: Types.Length.t => [> Types.Transform.t];
+let scale: (float, float) => [> Types.Transform.t];
+let scale3d: (float, float, float) => [> Types.Transform.t];
+let scaleX: float => [> Types.Transform.t];
+let scaleY: float => [> Types.Transform.t];
+let scaleZ: float => [> Types.Transform.t];
+let rotate: Types.Angle.t => [> Types.Transform.t];
+let rotate3d: (float, float, float, Types.Angle.t) => [> Types.Transform.t];
+let rotateX: Types.Angle.t => [> Types.Transform.t];
+let rotateY: Types.Angle.t => [> Types.Transform.t];
+let rotateZ: Types.Angle.t => [> Types.Transform.t];
+let skew: (Types.Angle.t, Types.Angle.t) => [> Types.Transform.t];
+let skewX: Types.Angle.t => [> Types.Transform.t];
+let skewY: Types.Angle.t => [> Types.Transform.t];
+
+let linearGradient:
+  (Types.Angle.t, list((Types.Length.t, Types.Color.t))) =>
+  [> Types.Gradient.t];
+let repeatingLinearGradient:
+  (Types.Angle.t, list((Types.Length.t, Types.Color.t))) =>
+  [> Types.Gradient.t];
+let radialGradient:
+  list((Types.Length.t, Types.Color.t)) => [> Types.Gradient.t];
+let repeatingRadialGradient:
+  list((Types.Length.t, Types.Color.t)) => [> Types.Gradient.t];
+
+let areas: list(string) => [> Types.GridTemplateAreas.t];
+let ident: string => [> Types.GridArea.t];
+let numIdent: (int, string) => [> Types.GridArea.t];
+
+// cursor aliases
+//let auto: [> Types.Cursor.t];
+//let default: [> Types.Cursor.t];
+//let none: [> Types.Cursor.t];
+let contextMenu: [> Types.Cursor.t];
+let help: [> Types.Cursor.t];
+let pointer: [> Types.Cursor.t];
+let progress: [> Types.Cursor.t];
+let wait: [> Types.Cursor.t];
+let cell: [> Types.Cursor.t];
+let crosshair: [> Types.Cursor.t];
+//let text: [> Types.Cursor.t];
+let verticalText: [> Types.Cursor.t];
+let alias: [> Types.Cursor.t];
+let copy: [> Types.Cursor.t];
+let move: [> Types.Cursor.t];
+let noDrop: [> Types.Cursor.t];
+let notAllowed: [> Types.Cursor.t];
+let grab: [> Types.Cursor.t];
+let grabbing: [> Types.Cursor.t];
+let allScroll: [> Types.Cursor.t];
+let colResize: [> Types.Cursor.t];
+let rowResize: [> Types.Cursor.t];
+let nResize: [> Types.Cursor.t];
+let eResize: [> Types.Cursor.t];
+let sResize: [> Types.Cursor.t];
+let wResize: [> Types.Cursor.t];
+let neResize: [> Types.Cursor.t];
+let nwResize: [> Types.Cursor.t];
+let seResize: [> Types.Cursor.t];
+let swResize: [> Types.Cursor.t];
+let ewResize: [> Types.Cursor.t];
+let nsResize: [> Types.Cursor.t];
+let neswResize: [> Types.Cursor.t];
+let nwseResize: [> Types.Cursor.t];
+let zoomIn: [> Types.Cursor.t];
+let zoomOut: [> Types.Cursor.t];
+
+/********************************************************
+ ********************************************************
+ ********************************************************/
+
+let flex3:
+  (
+    ~grow: float,
+    ~shrink: float,
+    ~basis: [< Types.Length.t | Types.FlexBasis.t]
+  ) =>
+  rule;
+
+let border:
+  (
+    Types.Length.t,
+    [< Types.BorderStyle.t | Types.Cascading.t],
+    Types.Color.t
+  ) =>
+  rule;
+let borderTop:
+  (
+    Types.Length.t,
+    [< Types.BorderStyle.t | Types.Cascading.t],
+    Types.Color.t
+  ) =>
+  rule;
+let backgroundSize:
+  [ | `size(Types.Length.t, Types.Length.t) | `auto | `cover | `contain] =>
+  rule;
+
+let textDecoration:
+  [ | `none | `underline | `overline | `lineThrough | Types.Cascading.t] =>
+  rule;
+
+let background:
+  [< Types.Color.t | Types.Url.t | Types.Gradient.t | `none] => rule;
+let backgrounds:
+  list([< Types.Color.t | Types.Url.t | Types.Gradient.t | `none]) => rule;
+
+type minmax = [
+  | `fr(float)
+  | `minContent
+  | `maxContent
+  | `auto
+  | Types.Length.t
+];
+
+type trackLength = [
+  Types.Length.t
+  | `fr(float)
+  | `minContent
+  | `maxContent
+  | `minmax(minmax, minmax)
+];
+type gridLength = [ trackLength | `repeat(Types.RepeatValue.t, trackLength)];
+
+let gridAutoColumns: [< trackLength | `auto] => rule;
+let gridAutoRows: [< trackLength | `auto] => rule;
+let gridTemplateColumns: list([< gridLength | `auto]) => rule;
+let gridTemplateRows: list([< gridLength | `auto]) => rule;
+
+module Calc: {
+  let (-): (Types.Length.t, Types.Length.t) => [> Types.Length.t];
+  let (+): (Types.Length.t, Types.Length.t) => [> Types.Length.t];
+};
+
+let size:
+  (Types.Length.t, Types.Length.t) =>
+  [> | `size(Types.Length.t, Types.Length.t)];
+
+type filter = [
+  | `blur(Types.Length.t)
+  | `brightness(float)
+  | `contrast(float)
+  | `dropShadow(Types.Length.t, Types.Length.t, Types.Length.t, Types.Color.t)
+  | `grayscale(float)
+  | `hueRotate(Types.Angle.t)
+  | `invert(float)
+  | `opacity(float)
+  | `saturate(float)
+  | `sepia(float)
+  | `none
+  | Types.Url.t
+  | Types.Cascading.t
+];
+
+let filter: list(filter) => rule;
+
+let fontFace:
+  (
+    ~fontFamily: string,
+    ~src: list([< | `localUrl(string) | Types.Url.t]),
+    ~fontStyle: Types.FontStyle.t=?,
+    ~fontWeight: [< Types.FontWeight.t | Types.Cascading.t]=?,
+    ~fontDisplay: Types.FontDisplay.t=?,
+    unit
+  ) =>
+  string;
+
+/**
+  * Transition
+  */
+
+module Transition: {
+  type t = [ | `value(string)];
+
+  let shorthand:
+    (
+      ~duration: int=?,
+      ~delay: int=?,
+      ~timingFunction: Types.TimingFunction.t=?,
+      string
+    ) =>
+    [> t];
+
+  let toString: t => string;
+};
+
+let transitionValue: Transition.t => rule;
+let transitionList: list([ Transition.t]) => rule;
+
+let transition:
+  (
+    ~duration: int=?,
+    ~delay: int=?,
+    ~timingFunction: Types.TimingFunction.t=?,
+    string
+  ) =>
+  rule;
+let transitions: list([ Transition.t]) => rule;
+
+/**
+ * Animation
+ */
+
+module Animation: {
+  type t = [ | `value(string)];
+
+  let shorthand:
+    (
+      ~duration: int=?,
+      ~delay: int=?,
+      ~direction: Types.AnimationDirection.t=?,
+      ~timingFunction: Types.TimingFunction.t=?,
+      ~fillMode: Types.AnimationFillMode.t=?,
+      ~playState: Types.AnimationPlayState.t=?,
+      ~iterationCount: Types.AnimationIterationCount.t=?,
+      animationName
+    ) =>
+    [> t];
+
+  let toString: t => string;
+};
+
+let animationValue: Animation.t => rule;
+let animation:
+  (
+    ~duration: int=?,
+    ~delay: int=?,
+    ~direction: Types.AnimationDirection.t=?,
+    ~timingFunction: Types.TimingFunction.t=?,
+    ~fillMode: Types.AnimationFillMode.t=?,
+    ~playState: Types.AnimationPlayState.t=?,
+    ~iterationCount: Types.AnimationIterationCount.t=?,
+    animationName
+  ) =>
+  rule;
+let animations: list([ Animation.t]) => rule;
+
+let animationName: animationName => rule;
+
+/* *
+ SVG
+ *** */
+
+module SVG: {
+  let fill: Types.Color.t => rule;
+  let fillRule: [ | `nonzero | `evenodd] => rule;
+  let fillOpacity: float => rule;
+  let stroke: Types.Color.t => rule;
+  let strokeLinecap: [ | `butt | `round | `square] => rule;
+  let strokeLinejoin: [ | `miter | `round | `bevel] => rule;
+  let strokeMiterlimit: float => rule;
+  let strokeWidth: Types.Length.t => rule;
+  let strokeOpacity: float => rule;
+  let stopColor: Types.Color.t => rule;
+  let stopOpacity: float => rule;
+};
+
+/* ****
+ Colors
+ ****** */
+
+let aliceblue: [> Types.Color.t];
+let antiquewhite: [> Types.Color.t];
+let aqua: [> Types.Color.t];
+let aquamarine: [> Types.Color.t];
+let azure: [> Types.Color.t];
+let beige: [> Types.Color.t];
+let bisque: [> Types.Color.t];
+let black: [> Types.Color.t];
+let blanchedalmond: [> Types.Color.t];
+let blue: [> Types.Color.t];
+let blueviolet: [> Types.Color.t];
+let brown: [> Types.Color.t];
+let burlywood: [> Types.Color.t];
+let cadetblue: [> Types.Color.t];
+let chartreuse: [> Types.Color.t];
+let chocolate: [> Types.Color.t];
+let coral: [> Types.Color.t];
+let cornflowerblue: [> Types.Color.t];
+let cornsilk: [> Types.Color.t];
+let crimson: [> Types.Color.t];
+let cyan: [> Types.Color.t];
+let darkblue: [> Types.Color.t];
+let darkcyan: [> Types.Color.t];
+let darkgoldenrod: [> Types.Color.t];
+let darkgray: [> Types.Color.t];
+let darkgrey: [> Types.Color.t];
+let darkgreen: [> Types.Color.t];
+let darkkhaki: [> Types.Color.t];
+let darkmagenta: [> Types.Color.t];
+let darkolivegreen: [> Types.Color.t];
+let darkorange: [> Types.Color.t];
+let darkorchid: [> Types.Color.t];
+let darkred: [> Types.Color.t];
+let darksalmon: [> Types.Color.t];
+let darkseagreen: [> Types.Color.t];
+let darkslateblue: [> Types.Color.t];
+let darkslategray: [> Types.Color.t];
+let darkslategrey: [> Types.Color.t];
+let darkturquoise: [> Types.Color.t];
+let darkviolet: [> Types.Color.t];
+let deeppink: [> Types.Color.t];
+let deepskyblue: [> Types.Color.t];
+let dimgray: [> Types.Color.t];
+let dimgrey: [> Types.Color.t];
+let dodgerblue: [> Types.Color.t];
+let firebrick: [> Types.Color.t];
+let floralwhite: [> Types.Color.t];
+let forestgreen: [> Types.Color.t];
+let fuchsia: [> Types.Color.t];
+let gainsboro: [> Types.Color.t];
+let ghostwhite: [> Types.Color.t];
+let gold: [> Types.Color.t];
+let goldenrod: [> Types.Color.t];
+let gray: [> Types.Color.t];
+let grey: [> Types.Color.t];
+let green: [> Types.Color.t];
+let greenyellow: [> Types.Color.t];
+let honeydew: [> Types.Color.t];
+let hotpink: [> Types.Color.t];
+let indianred: [> Types.Color.t];
+let indigo: [> Types.Color.t];
+let ivory: [> Types.Color.t];
+let khaki: [> Types.Color.t];
+let lavender: [> Types.Color.t];
+let lavenderblush: [> Types.Color.t];
+let lawngreen: [> Types.Color.t];
+let lemonchiffon: [> Types.Color.t];
+let lightblue: [> Types.Color.t];
+let lightcoral: [> Types.Color.t];
+let lightcyan: [> Types.Color.t];
+let lightgoldenrodyellow: [> Types.Color.t];
+let lightgray: [> Types.Color.t];
+let lightgrey: [> Types.Color.t];
+let lightgreen: [> Types.Color.t];
+let lightpink: [> Types.Color.t];
+let lightsalmon: [> Types.Color.t];
+let lightseagreen: [> Types.Color.t];
+let lightskyblue: [> Types.Color.t];
+let lightslategray: [> Types.Color.t];
+let lightslategrey: [> Types.Color.t];
+let lightsteelblue: [> Types.Color.t];
+let lightyellow: [> Types.Color.t];
+let lime: [> Types.Color.t];
+let limegreen: [> Types.Color.t];
+let linen: [> Types.Color.t];
+let magenta: [> Types.Color.t];
+let maroon: [> Types.Color.t];
+let mediumaquamarine: [> Types.Color.t];
+let mediumblue: [> Types.Color.t];
+let mediumorchid: [> Types.Color.t];
+let mediumpurple: [> Types.Color.t];
+let mediumseagreen: [> Types.Color.t];
+let mediumslateblue: [> Types.Color.t];
+let mediumspringgreen: [> Types.Color.t];
+let mediumturquoise: [> Types.Color.t];
+let mediumvioletred: [> Types.Color.t];
+let midnightblue: [> Types.Color.t];
+let mintcream: [> Types.Color.t];
+let mistyrose: [> Types.Color.t];
+let moccasin: [> Types.Color.t];
+let navajowhite: [> Types.Color.t];
+let navy: [> Types.Color.t];
+let oldlace: [> Types.Color.t];
+let olive: [> Types.Color.t];
+let olivedrab: [> Types.Color.t];
+let orange: [> Types.Color.t];
+let orangered: [> Types.Color.t];
+let orchid: [> Types.Color.t];
+let palegoldenrod: [> Types.Color.t];
+let palegreen: [> Types.Color.t];
+let paleturquoise: [> Types.Color.t];
+let palevioletred: [> Types.Color.t];
+let papayawhip: [> Types.Color.t];
+let peachpuff: [> Types.Color.t];
+let peru: [> Types.Color.t];
+let pink: [> Types.Color.t];
+let plum: [> Types.Color.t];
+let powderblue: [> Types.Color.t];
+let purple: [> Types.Color.t];
+let rebeccapurple: [> Types.Color.t];
+let red: [> Types.Color.t];
+let rosybrown: [> Types.Color.t];
+let royalblue: [> Types.Color.t];
+let saddlebrown: [> Types.Color.t];
+let salmon: [> Types.Color.t];
+let sandybrown: [> Types.Color.t];
+let seagreen: [> Types.Color.t];
+let seashell: [> Types.Color.t];
+let sienna: [> Types.Color.t];
+let silver: [> Types.Color.t];
+let skyblue: [> Types.Color.t];
+let slateblue: [> Types.Color.t];
+let slategray: [> Types.Color.t];
+let slategrey: [> Types.Color.t];
+let snow: [> Types.Color.t];
+let springgreen: [> Types.Color.t];
+let steelblue: [> Types.Color.t];
+let tan: [> Types.Color.t];
+let teal: [> Types.Color.t];
+let thistle: [> Types.Color.t];
+let tomato: [> Types.Color.t];
+let turquoise: [> Types.Color.t];
+let violet: [> Types.Color.t];
+let wheat: [> Types.Color.t];
+let white: [> Types.Color.t];
+let whitesmoke: [> Types.Color.t];
+let yellow: [> Types.Color.t];
+let yellowgreen: [> Types.Color.t];

--- a/test/native/bs-css/Css_Core.rei
+++ b/test/native/bs-css/Css_Core.rei
@@ -13,17 +13,27 @@ module type CssImplementationIntf = {
 type rule;
 type animationName;
 
-module Make:
-  (CssImplementationIntf) =>
-   {
-    let global: (string, list(rule)) => unit;
-    let insertRule: string => unit;
-    let merge: list(string) => string;
-    let style: list(rule) => string;
-    let keyframes: list((int, list(rule))) => animationName;
-  };
+/* original */
+/*
+ module Make:
+   (CssImplementationIntf) =>
+    {
+     let global: (string, list(rule)) => unit;
+     let insertRule: string => unit;
+     let merge: list(string) => string;
+     let style: list(rule) => string;
+     let keyframes: list((int, list(rule))) => animationName;
+   };
 
-// let empty: list(rule);
+ let empty: list(rule);
+ */
+
+let global: (string, list(rule)) => unit;
+let insertRule: string => unit;
+let merge: list(string) => string;
+let style: list(rule) => string;
+let keyframes: list((int, list(rule))) => animationName;
+
 let toJson: list(rule) => Js.Json.t;
 
 let important: rule => rule;

--- a/test/native/bs-css/Js.rei
+++ b/test/native/bs-css/Js.rei
@@ -1,0 +1,2 @@
+module Json: {type t;};
+module Dict: {type t('a);};

--- a/test/native/bs-css/StyledPpxTestNativeBSCSS.re
+++ b/test/native/bs-css/StyledPpxTestNativeBSCSS.re
@@ -1,0 +1,1 @@
+module Css = Css_Core;

--- a/test/native/bs-css/dune
+++ b/test/native/bs-css/dune
@@ -1,0 +1,3 @@
+(library
+ (name StyledPpxTestNativeBSCSS)
+ (modules_without_implementation js css_AtomicTypes css_Core))

--- a/test/native/dune
+++ b/test/native/dune
@@ -1,7 +1,0 @@
-(executable
-  (name TestRunner)
-  (public_name StyledPpxTestRunner)
-  (libraries
-    StyledPpxTestNativeLib
-  )
-)

--- a/test/native/dune-project
+++ b/test/native/dune-project
@@ -1,1 +1,1 @@
-(lang dune 1.6)
+(lang dune 2.0)

--- a/test/native/lib/TestEmitter.re
+++ b/test/native/lib/TestEmitter.re
@@ -19,6 +19,16 @@ let extract_tests = array_expr => {
     ),
   );
 };
+let write_tests_to_file = (tests, file) => {
+  let code =
+    tests
+    |> List.map(((expected, _)) => [%stri let _ = [%e expected]])
+    |> List.append([[%stri open StyledPpxTestNativeBSCSS]])
+    |> Pprintast.string_of_structure;
+  let fd = open_out(file);
+  output_string(fd, code);
+  close_out(fd);
+};
 
 let compare = (result, expected, {expect, _}) => {
   open Parsetree;
@@ -309,6 +319,9 @@ describe("emit bs-css from static [%css]", ({test, _}) => {
   let properties_static_css_tests =
     extract_tests(properties_static_css_tests);
   let selectors_static_css_tests = extract_tests(selectors_static_css_tests);
+
+  write_tests_to_file(properties_static_css_tests, "static_css_tests.ml");
+  write_tests_to_file(selectors_static_css_tests, "selectors_css_tests.ml");
 
   List.iteri(test("properties static: "), properties_static_css_tests);
   List.iteri(test("selectors static: "), selectors_static_css_tests);

--- a/test/native/lib/TestEmitter.re
+++ b/test/native/lib/TestEmitter.re
@@ -250,7 +250,8 @@ let properties_static_css_tests = [%expr
     ([%css "word-break: keep-all"], [Css.wordBreak(`keepAll)]),
     ([%css "overflow-wrap: anywhere"], [Css.overflowWrap(`anywhere)]),
     ([%css "word-wrap: normal"], [Css.wordWrap(`normal)]),
-    ([%css "text-align: start"], [Css.textAlign(`start)]),
+    // ([%css "text-align: start"], [Css.textAlign(`start)]),
+    ([%css "text-align: left"], [Css.textAlign(`left)]),
     ([%css "word-spacing: normal"], [Css.wordSpacing(`normal)]),
     ([%css "word-spacing: 5px"], [Css.wordSpacing(`pxFloat(5.))]),
     ([%css "letter-spacing: normal"], [Css.letterSpacing(`normal)]),
@@ -259,8 +260,8 @@ let properties_static_css_tests = [%expr
     // css-flexbox-1
     ([%css "flex-wrap: wrap"], [Css.flexWrap(`wrap)]),
     // TODO: generate tests with variables in the future
-    ([%css "flex-wrap: $var"], [Css.flexWrap(var)]),
-    ([%css "flex-wrap: $(var)"], [Css.flexWrap(var)]),
+    // ([%css "flex-wrap: $var"], [Css.flexWrap(var)]),
+    // ([%css "flex-wrap: $(var)"], [Css.flexWrap(var)]),
     (
       [%css "flex-flow: row nowrap"],
       [Css.flexDirection(`row), Css.flexWrap(`nowrap)],

--- a/test/native/lib/TestRunner.re
+++ b/test/native/lib/TestRunner.re
@@ -1,0 +1,1 @@
+Setup.cli();

--- a/test/native/lib/TestRunner.re
+++ b/test/native/lib/TestRunner.re
@@ -1,1 +1,1 @@
-Setup.cli();
+StyledPpxTestNativeLib.Setup.cli();

--- a/test/native/lib/dune
+++ b/test/native/lib/dune
@@ -1,7 +1,16 @@
 (library
  (name StyledPpxTestNativeLib)
+ (modules
+  (:standard \ TestRunner))
  (library_flags
   (-linkall -g))
  (libraries StyledPpxTestNativeBSCSS rely.lib styled-ppx.lib ppxlib)
+ (preprocess
+  (pps ppx_tools_versioned.metaquot_410 styled-ppx.lib)))
+
+(executable
+ (name TestRunner)
+ (modules TestRunner)
+ (libraries StyledPpxTestNativeLib)
  (preprocess
   (pps ppx_tools_versioned.metaquot_410 styled-ppx.lib)))

--- a/test/native/lib/dune
+++ b/test/native/lib/dune
@@ -2,6 +2,6 @@
  (name StyledPpxTestNativeLib)
  (library_flags
   (-linkall -g))
- (libraries rely.lib styled-ppx.lib ppxlib)
+ (libraries StyledPpxTestNativeBSCSS rely.lib styled-ppx.lib ppxlib)
  (preprocess
   (pps ppx_tools_versioned.metaquot_410 styled-ppx.lib)))

--- a/test/native/lib/dune
+++ b/test/native/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name StyledPpxTestNativeLib)
  (modules
-  (:standard \ TestRunner))
+  (:standard \ static_css_tests selectors_css_tests TestRunner))
  (library_flags
   (-linkall -g))
  (libraries StyledPpxTestNativeBSCSS rely.lib styled-ppx.lib ppxlib)
@@ -14,3 +14,27 @@
  (libraries StyledPpxTestNativeLib)
  (preprocess
   (pps ppx_tools_versioned.metaquot_410 styled-ppx.lib)))
+
+; type check
+
+(rule
+ (targets static_css_tests.ml selectors_css_tests.ml)
+ (deps ./TestRunner.exe)
+ (action
+  (run %{deps})))
+
+(library
+ (name StyledPpxTestNativeTypeCheck)
+ (libraries StyledPpxTestNativeBSCSS)
+ (modules static_css_tests selectors_css_tests)
+ (preprocess
+  (pps ppx_tools_versioned.metaquot_410 styled-ppx.lib)))
+
+(rule
+ (alias run_typecheck_test)
+ (deps
+   .StyledPpxTestNativeTypeCheck.objs/byte/styledPpxTestNativeTypeCheck__Static_css_tests.cmi
+   .StyledPpxTestNativeTypeCheck.objs/byte/styledPpxTestNativeTypeCheck__Selectors_css_tests.cmi)
+ (action
+  ; this is only because a action is required
+  (echo %{deps})))

--- a/test/native/snapshot/dune
+++ b/test/native/snapshot/dune
@@ -1,19 +1,20 @@
 (library
-  (name StyledPpxTestNativeSnapshot)
-  (library_flags (-linkall -g))
-  (libraries styled-ppx.lib)
-  (preprocess (pps styled-ppx.lib))
-)
+ (name StyledPpxTestNativeSnapshot)
+ (library_flags
+  (-linkall -g))
+ (libraries styled-ppx.lib)
+ (preprocess
+  (pps styled-ppx.lib)))
 
 (rule
  (targets pp.result)
  (deps simple.re.pp.ml)
  (action
   (with-stdout-to
-    %{targets}
-    (run refmt --parse=binary %{deps}))))
+   %{targets}
+   (run refmt --parse=binary %{deps}))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (diff pp.expected pp.result)))


### PR DESCRIPTION
**YEY +3536**

## What this PR does?

The intent is to mostly to replace(or automate) the bucklescript test suite in the future, but also to make it easier to be sure things are working, as there is no need to duplicate tests between the native and bucklescript.

And in the near future(tomorrow?) to integrate the current snapshot tests on the tests at `test/native/lib`

## Problems

I couldn't find a better way to run the typechecker on dune without pointing straight to the `.cmi` file.

## NOTE

I would really recommend you to review by commit