### PR TITLE
implement css-fonts-4 as unsupported

### DIFF
--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "c14fdfd2d6ecf16d2bce296f925b7bf8",
+  "checksum": "be0e35f319a4f38c8c09802e18fda3d5",
   "root": "styled-ppx@link-dev:./package.json",
   "node": {
     "styled-ppx@link-dev:./package.json": {
@@ -14,27 +14,27 @@
       "overrides": [],
       "dependencies": [ "@opam/ppxlib@opam:0.14.0@c02ad40d" ],
       "devDependencies": [
-        "reason-css-parser@github:EduardoRFS/reason-css-parser:package.json#99da696f761823b959214f89b1687d0c4b261538@d41d8cd9",
+        "reason-css-parser@github:EduardoRFS/reason-css-parser:package.json#c8f1ecdb6dd3d7455611d0b891b901edd264e4b2@d41d8cd9",
         "ocaml@4.10.0@d41d8cd9", "@reason-native/rely@3.2.1@d41d8cd9",
         "@opam/sedlex@opam:2.2@ffde36c0",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
         "@opam/ocaml-lsp-server@github:ocaml/ocaml-lsp:ocaml-lsp-server.opam#fbc433e14035d520c7137916ae710b8ec3b415e9@d41d8cd9",
         "@opam/merlin@opam:3.3.6@7ca67060",
         "@opam/menhir@opam:20200211@26571604",
-        "@opam/dune@opam:2.5.1@f38f376e",
+        "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/reason@github:facebook/reason:reason.json#773dbcd@d41d8cd9"
       ]
     },
-    "reason-css-vds@github:EduardoRFS/reason-css-vds:package.json#7c04926465e9031b14b6193bd836cabc7aacb7a8@d41d8cd9": {
+    "reason-css-vds@github:EduardoRFS/reason-css-vds:package.json#84da87fcf7d441909c4ba07a6853ef4d6a10a415@d41d8cd9": {
       "id":
-        "reason-css-vds@github:EduardoRFS/reason-css-vds:package.json#7c04926465e9031b14b6193bd836cabc7aacb7a8@d41d8cd9",
+        "reason-css-vds@github:EduardoRFS/reason-css-vds:package.json#84da87fcf7d441909c4ba07a6853ef4d6a10a415@d41d8cd9",
       "name": "reason-css-vds",
       "version":
-        "github:EduardoRFS/reason-css-vds:package.json#7c04926465e9031b14b6193bd836cabc7aacb7a8",
+        "github:EduardoRFS/reason-css-vds:package.json#84da87fcf7d441909c4ba07a6853ef4d6a10a415",
       "source": {
         "type": "install",
         "source": [
-          "github:EduardoRFS/reason-css-vds:package.json#7c04926465e9031b14b6193bd836cabc7aacb7a8"
+          "github:EduardoRFS/reason-css-vds:package.json#84da87fcf7d441909c4ba07a6853ef4d6a10a415"
         ]
       },
       "overrides": [],
@@ -46,26 +46,26 @@
         "@opam/menhir@opam:20200211@26571604",
         "@opam/dune-private-libs@opam:2.5.1@60c1661f",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
-        "@opam/dune@opam:2.5.1@f38f376e",
+        "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/reason@github:facebook/reason:reason.json#773dbcd@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "reason-css-parser@github:EduardoRFS/reason-css-parser:package.json#99da696f761823b959214f89b1687d0c4b261538@d41d8cd9": {
+    "reason-css-parser@github:EduardoRFS/reason-css-parser:package.json#c8f1ecdb6dd3d7455611d0b891b901edd264e4b2@d41d8cd9": {
       "id":
-        "reason-css-parser@github:EduardoRFS/reason-css-parser:package.json#99da696f761823b959214f89b1687d0c4b261538@d41d8cd9",
+        "reason-css-parser@github:EduardoRFS/reason-css-parser:package.json#c8f1ecdb6dd3d7455611d0b891b901edd264e4b2@d41d8cd9",
       "name": "reason-css-parser",
       "version":
-        "github:EduardoRFS/reason-css-parser:package.json#99da696f761823b959214f89b1687d0c4b261538",
+        "github:EduardoRFS/reason-css-parser:package.json#c8f1ecdb6dd3d7455611d0b891b901edd264e4b2",
       "source": {
         "type": "install",
         "source": [
-          "github:EduardoRFS/reason-css-parser:package.json#99da696f761823b959214f89b1687d0c4b261538"
+          "github:EduardoRFS/reason-css-parser:package.json#c8f1ecdb6dd3d7455611d0b891b901edd264e4b2"
         ]
       },
       "overrides": [],
       "dependencies": [
-        "reason-css-vds@github:EduardoRFS/reason-css-vds:package.json#7c04926465e9031b14b6193bd836cabc7aacb7a8@d41d8cd9",
+        "reason-css-vds@github:EduardoRFS/reason-css-vds:package.json#84da87fcf7d441909c4ba07a6853ef4d6a10a415@d41d8cd9",
         "reason-css-lexer@github:EduardoRFS/reason-css-lexer:package.json#33d95c56005d6c169c46869da7e6aac75c36c441@d41d8cd9",
         "ocaml@4.10.0@d41d8cd9", "@reason-native/rely@3.2.1@d41d8cd9",
         "@opam/sedlex@github:ocaml-community/sedlex:sedlex.opam#25c0dbd82c7fc5d91102f5bd21db1411f2c46323@d41d8cd9",
@@ -73,7 +73,7 @@
         "@opam/ppx_deriving@opam:4.5@bb81afdc",
         "@opam/ocamlformat@opam:0.14.2@d742ffd5",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
-        "@opam/dune@opam:2.5.1@f38f376e",
+        "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/reason@github:facebook/reason:reason.json#773dbcd@d41d8cd9"
       ],
       "devDependencies": []
@@ -95,7 +95,7 @@
         "ocaml@4.10.0@d41d8cd9", "@reason-native/rely@3.2.1@d41d8cd9",
         "@opam/sedlex@github:ocaml-community/sedlex:sedlex.opam#25c0dbd82c7fc5d91102f5bd21db1411f2c46323@d41d8cd9",
         "@opam/ppx_deriving@opam:4.5@bb81afdc",
-        "@opam/dune@opam:2.5.1@f38f376e",
+        "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/reason@github:facebook/reason:reason.json#773dbcd@d41d8cd9"
       ],
       "devDependencies": []
@@ -130,7 +130,7 @@
         "@reason-native/file-context-printer@0.0.3@d41d8cd9",
         "@reason-native/cli@0.0.1-alpha@d41d8cd9",
         "@opam/re@opam:1.9.0@d4d5e13d", "@opam/junit@opam:2.0.2@0b7bd730",
-        "@opam/dune@opam:2.5.1@f38f376e",
+        "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/reason@github:facebook/reason:reason.json#773dbcd@d41d8cd9"
       ],
       "devDependencies": []
@@ -148,7 +148,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/re@opam:1.9.0@d4d5e13d",
-        "@opam/dune@opam:2.5.1@f38f376e",
+        "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/reason@github:facebook/reason:reason.json#773dbcd@d41d8cd9"
       ],
       "devDependencies": []
@@ -166,7 +166,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@reason-native/pastel@0.3.0@d41d8cd9",
-        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/dune@opam:2.5.1@f38f376e",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/reason@github:facebook/reason:reason.json#773dbcd@d41d8cd9"
       ],
       "devDependencies": []
@@ -184,7 +184,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@reason-native/pastel@0.3.0@d41d8cd9",
-        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/dune@opam:2.5.1@f38f376e",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/reason@github:facebook/reason:reason.json#773dbcd@d41d8cd9"
       ],
       "devDependencies": []
@@ -208,13 +208,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/easy-format@opam:1.3.2@0484b3c4",
-        "@opam/dune@opam:2.5.1@f38f376e", "@opam/cppo@opam:1.6.6@f4f83858",
+        "@opam/dune@opam:2.5.1@f25d5fdf", "@opam/cppo@opam:1.6.6@f4f83858",
         "@opam/biniou@opam:1.2.1@d7570399",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/easy-format@opam:1.3.2@0484b3c4",
-        "@opam/dune@opam:2.5.1@f38f376e", "@opam/biniou@opam:1.2.1@d7570399"
+        "@opam/dune@opam:2.5.1@f25d5fdf", "@opam/biniou@opam:1.2.1@d7570399"
       ]
     },
     "@opam/uutf@opam:1.0.2@4440868f": {
@@ -345,12 +345,12 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
         "@opam/seq@opam:base@d8d7de1d", "@opam/re@opam:1.9.0@d4d5e13d",
-        "@opam/dune@opam:2.5.1@f38f376e", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.5.1@f25d5fdf", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
         "@opam/seq@opam:base@d8d7de1d", "@opam/re@opam:1.9.0@d4d5e13d",
-        "@opam/dune@opam:2.5.1@f38f376e"
+        "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/topkg@opam:1.0.1@a42c631e": {
@@ -397,11 +397,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e",
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e"
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/stdio@opam:v0.13.0@eb59d879": {
@@ -422,12 +422,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e",
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@opam/base@opam:v0.13.2@c3150775",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e",
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@opam/base@opam:v0.13.2@c3150775"
       ]
     },
@@ -449,11 +449,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e",
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e"
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/seq@opam:base@d8d7de1d": {
@@ -492,14 +492,14 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
         "@opam/ppx_tools_versioned@opam:5.4.0@48c10ee1",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
-        "@opam/gen@opam:0.5.3@4a903bee", "@opam/dune@opam:2.5.1@f38f376e",
+        "@opam/gen@opam:0.5.3@4a903bee", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
         "@opam/ppx_tools_versioned@opam:5.4.0@48c10ee1",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
-        "@opam/gen@opam:0.5.3@4a903bee", "@opam/dune@opam:2.5.1@f38f376e"
+        "@opam/gen@opam:0.5.3@4a903bee", "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/sedlex@opam:2.2@ffde36c0": {
@@ -523,14 +523,14 @@
         "ocaml@4.10.0@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
         "@opam/ppx_tools_versioned@opam:5.4.0@48c10ee1",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
-        "@opam/gen@opam:0.5.3@4a903bee", "@opam/dune@opam:2.5.1@f38f376e",
+        "@opam/gen@opam:0.5.3@4a903bee", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
         "@opam/ppx_tools_versioned@opam:5.4.0@48c10ee1",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
-        "@opam/gen@opam:0.5.3@4a903bee", "@opam/dune@opam:2.5.1@f38f376e"
+        "@opam/gen@opam:0.5.3@4a903bee", "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/result@opam:1.5@6b753c82": {
@@ -551,11 +551,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e",
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e"
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/re@opam:1.9.0@d4d5e13d": {
@@ -577,11 +577,11 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
-        "@opam/dune@opam:2.5.1@f38f376e", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.5.1@f25d5fdf", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
-        "@opam/dune@opam:2.5.1@f38f376e"
+        "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/ptime@opam:0.8.5@0051d642": {
@@ -634,7 +634,7 @@
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
         "@opam/ocaml-compiler-libs@opam:v0.12.1@5c34eb0d",
-        "@opam/dune@opam:2.5.1@f38f376e", "@opam/base@opam:v0.13.2@c3150775",
+        "@opam/dune@opam:2.5.1@f25d5fdf", "@opam/base@opam:v0.13.2@c3150775",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
@@ -642,7 +642,7 @@
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
         "@opam/ocaml-compiler-libs@opam:v0.12.1@5c34eb0d",
-        "@opam/dune@opam:2.5.1@f38f376e", "@opam/base@opam:v0.13.2@c3150775"
+        "@opam/dune@opam:2.5.1@f25d5fdf", "@opam/base@opam:v0.13.2@c3150775"
       ]
     },
     "@opam/ppxfind@opam:1.4@1e01d2a5": {
@@ -665,12 +665,12 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
-        "@opam/dune@opam:2.5.1@f38f376e", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.5.1@f25d5fdf", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
-        "@opam/dune@opam:2.5.1@f38f376e"
+        "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/ppx_yojson_conv_lib@opam:v0.14.0@116b53d6": {
@@ -692,11 +692,11 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
-        "@opam/dune@opam:2.5.1@f38f376e", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.5.1@f25d5fdf", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
-        "@opam/dune@opam:2.5.1@f38f376e"
+        "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/ppx_tools_versioned@opam:5.4.0@48c10ee1": {
@@ -719,12 +719,12 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
-        "@opam/dune@opam:2.5.1@f38f376e", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.5.1@f25d5fdf", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
-        "@opam/dune@opam:2.5.1@f38f376e"
+        "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/ppx_tools@opam:6.2@62a3aff2": {
@@ -745,11 +745,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e",
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e"
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/ppx_deriving@opam:4.5@bb81afdc": {
@@ -775,7 +775,7 @@
         "@opam/ppx_tools@opam:6.2@62a3aff2",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
-        "@opam/dune@opam:2.5.1@f38f376e", "@opam/cppo@opam:1.6.6@f4f83858",
+        "@opam/dune@opam:2.5.1@f25d5fdf", "@opam/cppo@opam:1.6.6@f4f83858",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
@@ -783,7 +783,7 @@
         "@opam/ppx_tools@opam:6.2@62a3aff2",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
-        "@opam/dune@opam:2.5.1@f38f376e"
+        "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/ppx_derivers@opam:1.2.1@ecf0aa45": {
@@ -804,11 +804,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e",
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e"
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/odoc@opam:1.5.1@dae60787": {
@@ -831,7 +831,7 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/tyxml@opam:4.4.0@1dca5713",
         "@opam/result@opam:1.5@6b753c82", "@opam/fpath@opam:0.7.2@45477b93",
-        "@opam/dune@opam:2.5.1@f38f376e", "@opam/cppo@opam:1.6.6@f4f83858",
+        "@opam/dune@opam:2.5.1@f25d5fdf", "@opam/cppo@opam:1.6.6@f4f83858",
         "@opam/cmdliner@opam:1.0.4@93208aac",
         "@opam/astring@opam:0.8.4@1215f84d",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -839,7 +839,7 @@
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/tyxml@opam:4.4.0@1dca5713",
         "@opam/result@opam:1.5@6b753c82", "@opam/fpath@opam:0.7.2@45477b93",
-        "@opam/dune@opam:2.5.1@f38f376e",
+        "@opam/dune@opam:2.5.1@f25d5fdf",
         "@opam/cmdliner@opam:1.0.4@93208aac",
         "@opam/astring@opam:0.8.4@1215f84d"
       ]
@@ -869,7 +869,7 @@
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
         "@opam/menhir@opam:20200211@26571604",
         "@opam/fpath@opam:0.7.2@45477b93",
-        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:2.5.1@f38f376e",
+        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@opam/cmdliner@opam:1.0.4@93208aac",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/base@opam:v0.13.2@c3150775",
@@ -883,7 +883,7 @@
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
         "@opam/menhir@opam:20200211@26571604",
         "@opam/fpath@opam:0.7.2@45477b93",
-        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:2.5.1@f38f376e",
+        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@opam/cmdliner@opam:1.0.4@93208aac",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/base@opam:v0.13.2@c3150775"
@@ -1025,12 +1025,12 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
-        "@opam/dune@opam:2.5.1@f38f376e", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.5.1@f25d5fdf", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/result@opam:1.5@6b753c82",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
-        "@opam/dune@opam:2.5.1@f38f376e"
+        "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/ocaml-lsp-server@github:ocaml/ocaml-lsp:ocaml-lsp-server.opam#fbc433e14035d520c7137916ae710b8ec3b415e9@d41d8cd9": {
@@ -1052,8 +1052,8 @@
         "@opam/ppx_yojson_conv_lib@opam:v0.14.0@116b53d6",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/menhir@opam:20200211@26571604",
-        "@opam/dune-build-info@opam:2.6.1@611bb155",
-        "@opam/dune@opam:2.5.1@f38f376e", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune-build-info@opam:2.6.2@03ffe168",
+        "@opam/dune@opam:2.5.1@f25d5fdf", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
@@ -1061,8 +1061,8 @@
         "@opam/ppx_yojson_conv_lib@opam:v0.14.0@116b53d6",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/menhir@opam:20200211@26571604",
-        "@opam/dune-build-info@opam:2.6.1@611bb155",
-        "@opam/dune@opam:2.5.1@f38f376e"
+        "@opam/dune-build-info@opam:2.6.2@03ffe168",
+        "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/ocaml-compiler-libs@opam:v0.12.1@5c34eb0d": {
@@ -1083,11 +1083,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e",
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e"
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/merlin-extend@opam:0.5@675b1611": {
@@ -1108,11 +1108,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e",
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@opam/cppo@opam:1.6.6@f4f83858", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e"
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/merlin@opam:3.3.6@7ca67060": {
@@ -1135,12 +1135,12 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/dune@opam:2.5.1@f38f376e", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.5.1@f25d5fdf", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/dune@opam:2.5.1@f38f376e"
+        "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/menhirSdk@opam:20200624@2a05b5a7": {
@@ -1161,11 +1161,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e",
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e"
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/menhirLib@opam:20200624@8bdd2b0e": {
@@ -1186,11 +1186,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e",
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e"
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/menhir@opam:20200211@26571604": {
@@ -1218,13 +1218,13 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/menhirSdk@opam:20200624@2a05b5a7",
         "@opam/menhirLib@opam:20200624@8bdd2b0e",
-        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:2.5.1@f38f376e",
+        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/menhirSdk@opam:20200624@2a05b5a7",
         "@opam/menhirLib@opam:20200624@8bdd2b0e",
-        "@opam/dune@opam:2.5.1@f38f376e"
+        "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/junit@opam:2.0.2@0b7bd730": {
@@ -1246,11 +1246,11 @@
       "overrides": [],
       "dependencies": [
         "@opam/tyxml@opam:4.4.0@1dca5713", "@opam/ptime@opam:0.8.5@0051d642",
-        "@opam/dune@opam:2.5.1@f38f376e", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.5.1@f25d5fdf", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "@opam/tyxml@opam:4.4.0@1dca5713", "@opam/ptime@opam:0.8.5@0051d642",
-        "@opam/dune@opam:2.5.1@f38f376e"
+        "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/gen@opam:0.5.3@4a903bee": {
@@ -1273,14 +1273,14 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
-        "@opam/dune@opam:2.5.1@f38f376e",
+        "@opam/dune@opam:2.5.1@f25d5fdf",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
-        "@opam/dune@opam:2.5.1@f38f376e",
+        "@opam/dune@opam:2.5.1@f25d5fdf",
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
@@ -1332,11 +1332,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e",
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e"
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/easy-format@opam:1.3.2@0484b3c4": {
@@ -1357,11 +1357,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e",
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e"
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/dune-private-libs@opam:2.5.1@60c1661f": {
@@ -1382,11 +1382,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e",
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e"
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/dune-configurator@opam:2.5.1@aeb9d8d5": {
@@ -1408,37 +1408,37 @@
       "overrides": [],
       "dependencies": [
         "@opam/dune-private-libs@opam:2.5.1@60c1661f",
-        "@opam/dune@opam:2.5.1@f38f376e", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.5.1@f25d5fdf", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "@opam/dune-private-libs@opam:2.5.1@60c1661f",
-        "@opam/dune@opam:2.5.1@f38f376e"
+        "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
-    "@opam/dune-build-info@opam:2.6.1@611bb155": {
-      "id": "@opam/dune-build-info@opam:2.6.1@611bb155",
+    "@opam/dune-build-info@opam:2.6.2@03ffe168": {
+      "id": "@opam/dune-build-info@opam:2.6.2@03ffe168",
       "name": "@opam/dune-build-info",
-      "version": "opam:2.6.1",
+      "version": "opam:2.6.2",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/5e/5ef959f286448ee172f1cffc86c439a6f7b662676e6015b282db071bb88899a0#sha256:5ef959f286448ee172f1cffc86c439a6f7b662676e6015b282db071bb88899a0",
-          "archive:https://github.com/ocaml/dune/releases/download/2.6.1/dune-2.6.1.tbz#sha256:5ef959f286448ee172f1cffc86c439a6f7b662676e6015b282db071bb88899a0"
+          "archive:https://opam.ocaml.org/cache/sha256/4f/4f6ec1f3f27ac48753d03b4a172127e4a56ae724201a3a18dc827c94425788e9#sha256:4f6ec1f3f27ac48753d03b4a172127e4a56ae724201a3a18dc827c94425788e9",
+          "archive:https://github.com/ocaml/dune/releases/download/2.6.2/dune-2.6.2.tbz#sha256:4f6ec1f3f27ac48753d03b4a172127e4a56ae724201a3a18dc827c94425788e9"
         ],
         "opam": {
           "name": "dune-build-info",
-          "version": "2.6.1",
-          "path": "esy.lock/opam/dune-build-info.2.6.1"
+          "version": "2.6.2",
+          "path": "esy.lock/opam/dune-build-info.2.6.2"
         }
       },
       "overrides": [],
       "dependencies": [
-        "@opam/dune@opam:2.5.1@f38f376e", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.5.1@f25d5fdf", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
-      "devDependencies": [ "@opam/dune@opam:2.5.1@f38f376e" ]
+      "devDependencies": [ "@opam/dune@opam:2.5.1@f25d5fdf" ]
     },
-    "@opam/dune@opam:2.5.1@f38f376e": {
-      "id": "@opam/dune@opam:2.5.1@f38f376e",
+    "@opam/dune@opam:2.5.1@f25d5fdf": {
+      "id": "@opam/dune@opam:2.5.1@f25d5fdf",
       "name": "@opam/dune",
       "version": "opam:2.5.1",
       "source": {
@@ -1491,12 +1491,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e",
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f38f376e",
+        "ocaml@4.10.0@d41d8cd9", "@opam/dune@opam:2.5.1@f25d5fdf",
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
@@ -1558,11 +1558,11 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/easy-format@opam:1.3.2@0484b3c4",
-        "@opam/dune@opam:2.5.1@f38f376e", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.5.1@f25d5fdf", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/easy-format@opam:1.3.2@0484b3c4",
-        "@opam/dune@opam:2.5.1@f38f376e"
+        "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/base-unix@opam:base@87d0b2eb": {
@@ -1641,12 +1641,12 @@
       "dependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/sexplib0@opam:v0.13.0@3f54c2be",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
-        "@opam/dune@opam:2.5.1@f38f376e", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.5.1@f25d5fdf", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.10.0@d41d8cd9", "@opam/sexplib0@opam:v0.13.0@3f54c2be",
         "@opam/dune-configurator@opam:2.5.1@aeb9d8d5",
-        "@opam/dune@opam:2.5.1@f38f376e"
+        "@opam/dune@opam:2.5.1@f25d5fdf"
       ]
     },
     "@opam/astring@opam:0.8.4@1215f84d": {
@@ -1704,7 +1704,7 @@
         "@opam/ocaml-migrate-parsetree@opam:1.7.3@dbcf3b47",
         "@opam/merlin-extend@opam:0.5@675b1611",
         "@opam/menhir@opam:20200211@26571604",
-        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:2.5.1@f38f376e"
+        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:2.5.1@f25d5fdf"
       ],
       "devDependencies": [ "ocaml@4.10.0@d41d8cd9" ]
     }

--- a/esy.lock/opam/dune-build-info.2.6.2/opam
+++ b/esy.lock/opam/dune-build-info.2.6.2/opam
@@ -32,9 +32,9 @@ build: [
   ]
 ]
 url {
-  src: "https://github.com/ocaml/dune/releases/download/2.6.1/dune-2.6.1.tbz"
+  src: "https://github.com/ocaml/dune/releases/download/2.6.2/dune-2.6.2.tbz"
   checksum: [
-    "sha256=5ef959f286448ee172f1cffc86c439a6f7b662676e6015b282db071bb88899a0"
-    "sha512=67b750716563fde1135f3d0f3892f97e912d6f95a40bcd7cd854f3ae09ba0b037e7b8829bdaee141cb6c998396f2a51a380451db117571d77895781798d625e7"
+    "sha256=4f6ec1f3f27ac48753d03b4a172127e4a56ae724201a3a18dc827c94425788e9"
+    "sha512=d195479c99a59edb0cb7674375f45e518389b2f251b02e5f603c196b9592acbcf2a12193b3de70831a543fa477f57abb101fdd210660e25805b147c66877cafa"
   ]
 }

--- a/esy.lock/opam/dune.2.5.1/opam
+++ b/esy.lock/opam/dune.2.5.1/opam
@@ -41,7 +41,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .travis.yml, dune-project
   # and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.07"} | ("ocaml" {< "4.07~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {< "4.07~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@opam/sedlex": "*",
     "@reason-native/rely": "^3.2.1",
     "@opam/ocaml-lsp-server": "ocaml/ocaml-lsp:ocaml-lsp-server.opam#fbc433e14035d520c7137916ae710b8ec3b415e9",
-    "reason-css-parser": "EduardoRFS/reason-css-parser:package.json#99da696f761823b959214f89b1687d0c4b261538"
+    "reason-css-parser": "EduardoRFS/reason-css-parser:package.json#c8f1ecdb6dd3d7455611d0b891b901edd264e4b2"
   },
   "resolutions": {
     "@esy-ocaml/reason": "facebook/reason:reason.json#773dbcd"

--- a/src/declarations_to_emotion.re
+++ b/src/declarations_to_emotion.re
@@ -931,6 +931,37 @@ let text_indent =
   );
 let hanging_punctuation = unsupported(property_hanging_punctuation);
 
+// css-fonts-4
+let font_family =
+  unsupported(property_font_family, ~call=[%expr Css.fontFamily]);
+let font_weight =
+  unsupported(property_font_weight, ~call=[%expr Css.fontWeight]);
+let font_stretch = unsupported(property_font_stretch);
+let font_style =
+  unsupported(property_font_style, ~call=[%expr Css.fontStyle]);
+let font_size = unsupported(property_font_size, ~call=[%expr Css.fontSize]);
+let font_size_adjust = unsupported(property_font_size_adjust);
+let font = unsupported(property_font);
+let font_synthesis_weight = unsupported(property_font_synthesis_weight);
+let font_synthesis_style = unsupported(property_font_synthesis_style);
+let font_synthesis_small_caps =
+  unsupported(property_font_synthesis_small_caps);
+let font_synthesis = unsupported(property_font_synthesis);
+let font_kerning = unsupported(property_font_kerning);
+let font_variant_ligatures = unsupported(property_font_variant_ligatures);
+let font_variant_position = unsupported(property_font_variant_position);
+let font_variant_caps = unsupported(property_font_variant_caps);
+let font_variant_numeric = unsupported(property_font_variant_numeric);
+let font_variant_alternates = unsupported(property_font_variant_alternates);
+let font_variant_east_asian = unsupported(property_font_variant_east_asian);
+let font_variant =
+  unsupported(property_font_variant, ~call=[%expr Css.fontVariant]);
+let font_feature_settings = unsupported(property_font_feature_settings);
+let font_optical_sizing = unsupported(property_font_optical_sizing);
+let font_variation_settings = unsupported(property_font_variation_settings);
+let font_palette = unsupported(property_font_palette);
+let font_variant_emoji = unsupported(property_font_variant_emoji);
+
 // css-flexbox-1
 // using id() because refmt
 let flex_direction =
@@ -1112,6 +1143,31 @@ let properties = [
   ("letter-spacing", found(letter_spacing)),
   ("text-indent", found(text_indent)),
   ("hanging-punctuation", found(hanging_punctuation)),
+  // css-fonts-4
+  ("font-family", found(font_family)),
+  ("font-weight", found(font_weight)),
+  ("font-stretch", found(font_stretch)),
+  ("font-style", found(font_style)),
+  ("font-size", found(font_size)),
+  ("font-size-adjust", found(font_size_adjust)),
+  ("font", found(font)),
+  ("font-synthesis-weight", found(font_synthesis_weight)),
+  ("font-synthesis-style", found(font_synthesis_style)),
+  ("font-synthesis-small-caps", found(font_synthesis_small_caps)),
+  ("font-synthesis", found(font_synthesis)),
+  ("font-kerning", found(font_kerning)),
+  ("font-variant-ligatures", found(font_variant_ligatures)),
+  ("font-variant-position", found(font_variant_position)),
+  ("font-variant-caps", found(font_variant_caps)),
+  ("font-variant-numeric", found(font_variant_numeric)),
+  ("font-variant-alternates", found(font_variant_alternates)),
+  ("font-variant-east-asian", found(font_variant_east_asian)),
+  ("font-variant", found(font_variant)),
+  ("font-feature-settings", found(font_feature_settings)),
+  ("font-optical-sizing", found(font_optical_sizing)),
+  ("font-variation-settings", found(font_variation_settings)),
+  ("font-palette", found(font_palette)),
+  ("font-variant-emoji", found(font_variant_emoji)),
   // css-flexbox-1
   ("flex-direction", found(flex_direction)),
   ("flex-wrap", found(flex_wrap)),

--- a/test/native/lib/TestEmitter.re
+++ b/test/native/lib/TestEmitter.re
@@ -56,7 +56,7 @@ let properties_static_css_tests = [%expr
     ([%css "color: red"], [Css.color(Css.red)]),
     ([%css "display: flex"], [Css.display(`flex)]),
     ([%css "flex-direction: column"], [Css.flexDirection(`column)]),
-    ([%css "font-size: 30px"], [Css.fontSize(Css.px(30))]),
+    ([%css "font-size: 30px"], [Css.unsafe("fontSize", "30px")]),
     ([%css "height: 100vh"], [Css.height(`vh(100.))]),
     ([%css "justify-content: center"], [Css.justifyContent(`center)]),
     ([%css "margin: 0"], [Css.margin(`zero)]),


### PR DESCRIPTION
As we discussed previously there is no good reason to properly emit bs-css for most cases, so just having unsupported + variables is a good start for every property.

This PR does that for every property in css-fonts-4