### PR TITLE
add support to basic media queries

### DIFF
--- a/parser/css_parser.mly
+++ b/parser/css_parser.mly
@@ -78,6 +78,13 @@ at_rule:
         loc = Lex_buffer.make_loc $startpos $endpos;
       }
     }
+  | name = NESTED_AT_RULE; xs = prelude_with_loc; LEFT_BRACE; ds = declarations_with_loc; RIGHT_BRACE {
+      { At_rule.name = (name, Lex_buffer.make_loc $startpos(name) $endpos(name));
+        prelude = xs;
+        block = Brace_block.Declaration_list ds;
+        loc = Lex_buffer.make_loc $startpos $endpos;
+      }
+    }
   ;
 
 style_rule:

--- a/test/bucklescript/src/__snapshots__/css_support_test.bs.js.snap
+++ b/test/bucklescript/src/__snapshots__/css_support_test.bs.js.snap
@@ -269,3 +269,5 @@ exports[`Component 132 renders 1`] = `"css-1x2q6ya"`;
 exports[`Component 133 renders 1`] = `"css-ddf2bd"`;
 
 exports[`Component 134 renders 1`] = `"css-1a9l89f"`;
+
+exports[`Component 135 renders 1`] = `"css-1fqgwix"`;

--- a/test/bucklescript/src/__snapshots__/index_test.bs.js.snap
+++ b/test/bucklescript/src/__snapshots__/index_test.bs.js.snap
@@ -3,7 +3,7 @@
 exports[`Component renders 1`] = `
 <div>
   <div
-    class="css-sffn4v"
+    class="css-s37awk"
   />
 </div>
 `;

--- a/test/bucklescript/src/css_support_test.re
+++ b/test/bucklescript/src/css_support_test.re
@@ -155,6 +155,8 @@ let supportList = [
   // not supported
   [%css "-moz-text-blink: blink"],
   [%css "display: -webkit-inline-box"],
+  // media-query
+  [%css "@media (min-width: 30em) and (min-height: 20em) { color: brown; }"],
 ];
 
 Belt.List.forEachWithIndex(supportList, (index, css) => {

--- a/test/bucklescript/src/index_test.re
+++ b/test/bucklescript/src/index_test.re
@@ -14,6 +14,9 @@ module Component = [%styled.div {|
   font-size: 30px;
 
   width: unset;
+  @media (min-width: 30em) and (min-height: 20em) {
+    color: brown;
+  }
 |}];
 module ComponentInline = [%styled "color: #454545"];
 module ComponentLink = [%styled.a {| color: #454545 |}];

--- a/test/native/lib/TestEmitter.re
+++ b/test/native/lib/TestEmitter.re
@@ -326,18 +326,47 @@ let selectors_static_css_tests = [%expr
     ),
   |]
 ];
+let media_query_static_css_tests = [%expr
+  [|
+    (
+      [%css {|color: blue; @media (min-width: 30em) { color: red; }|}],
+      [
+        Css.color(Css.blue),
+        Css.media("(min-width: 30em)", [Css.color(Css.red)]),
+      ],
+    ),
+    (
+      [%css
+        {|@media (min-width: 30em) and (min-height: 20em) { color: brown; }|}
+      ],
+      [
+        Css.media(
+          "(min-width: 30em) and (min-height: 20em)",
+          [Css.color(Css.brown)],
+        ),
+      ],
+    ),
+  |]
+];
 describe("emit bs-css from static [%css]", ({test, _}) => {
   let test = (prefix, index, (result, expected)) =>
     test(prefix ++ string_of_int(index), compare(result, expected));
   let properties_static_css_tests =
     extract_tests(properties_static_css_tests);
   let selectors_static_css_tests = extract_tests(selectors_static_css_tests);
+  let media_query_static_css_tests =
+    extract_tests(media_query_static_css_tests);
 
   write_tests_to_file(properties_static_css_tests, "static_css_tests.ml");
   write_tests_to_file(selectors_static_css_tests, "selectors_css_tests.ml");
+  write_tests_to_file(
+    media_query_static_css_tests,
+    "media_query_css_tests.ml",
+  );
 
   List.iteri(test("properties static: "), properties_static_css_tests);
   List.iteri(test("selectors static: "), selectors_static_css_tests);
+  List.iteri(test("media query static: "), media_query_static_css_tests);
 });
 
 let properties_variable_css_tests = [

--- a/test/native/lib/dune
+++ b/test/native/lib/dune
@@ -1,7 +1,8 @@
 (library
  (name StyledPpxTestNativeLib)
  (modules
-  (:standard \ static_css_tests selectors_css_tests TestRunner))
+  (:standard \ static_css_tests selectors_css_tests media_query_css_tests
+    TestRunner))
  (library_flags
   (-linkall -g))
  (libraries StyledPpxTestNativeBSCSS rely.lib styled-ppx.lib ppxlib)
@@ -11,14 +12,14 @@
 (executable
  (name TestRunner)
  (modules TestRunner)
- (libraries StyledPpxTestNativeLib)
+ (libraries StyledPpxTestNativeLib styled-ppx.parser)
  (preprocess
   (pps ppx_tools_versioned.metaquot_410 styled-ppx.lib)))
 
 ; type check
 
 (rule
- (targets static_css_tests.ml selectors_css_tests.ml)
+ (targets static_css_tests.ml selectors_css_tests.ml media_query_css_tests.ml)
  (deps ./TestRunner.exe)
  (action
   (run %{deps})))
@@ -26,7 +27,7 @@
 (library
  (name StyledPpxTestNativeTypeCheck)
  (libraries StyledPpxTestNativeBSCSS)
- (modules static_css_tests selectors_css_tests)
+ (modules static_css_tests selectors_css_tests media_query_css_tests)
  (preprocess
   (pps ppx_tools_versioned.metaquot_410 styled-ppx.lib)))
 
@@ -34,7 +35,8 @@
  (alias run_typecheck_test)
  (deps
    .StyledPpxTestNativeTypeCheck.objs/byte/styledPpxTestNativeTypeCheck__Static_css_tests.cmi
-   .StyledPpxTestNativeTypeCheck.objs/byte/styledPpxTestNativeTypeCheck__Selectors_css_tests.cmi)
+   .StyledPpxTestNativeTypeCheck.objs/byte/styledPpxTestNativeTypeCheck__Selectors_css_tests.cmi
+   .StyledPpxTestNativeTypeCheck.objs/byte/styledPpxTestNativeTypeCheck__Media_query_css_tests.cmi)
  (action
   ; this is only because a action is required
   (echo %{deps})))


### PR DESCRIPTION
## Problems

The parser now has a bunch of ambiguities, so there is possible to have some weird edge cases.

`[%styled.global]` still doesn't support media queries