### PR TITLE
Fix complex type on components

### DIFF
--- a/src/css_to_emotion.rei
+++ b/src/css_to_emotion.rei
@@ -1,8 +1,4 @@
 open Css_types;
 let render_emotion_css:
-  (
-    (list(Declaration_list.kind), Warnings.loc),
-    option(list((string, string)))
-  ) =>
-  Parsetree.expression;
+  ((list(Declaration_list.kind), Warnings.loc)) => Parsetree.expression;
 let render_global: Stylesheet.t => Parsetree.expression;

--- a/test/bucklescript/src/__snapshots__/index_test.bs.js.snap
+++ b/test/bucklescript/src/__snapshots__/index_test.bs.js.snap
@@ -32,3 +32,12 @@ exports[`ComponentLink should render an <a /> tag 1`] = `
   />
 </div>
 `;
+
+exports[`ComponentWithParameter renders 1`] = `
+<div>
+  <div
+    class="css-1roeevf"
+    color="5194459,FF0000"
+  />
+</div>
+`;

--- a/test/bucklescript/src/index_test.re
+++ b/test/bucklescript/src/index_test.re
@@ -21,8 +21,21 @@ module Component = [%styled.div {|
 module ComponentInline = [%styled "color: #454545"];
 module ComponentLink = [%styled.a {| color: #454545 |}];
 
+module ComponentWithParameter = [%styled.div
+  (~color: Css.Types.Color.t) => 
+    "color: $(color)"
+];
+
 test("Component renders", () => {
   <Component />
+  |> render
+  |> container
+  |> expect
+  |> toMatchSnapshot
+});
+
+test("ComponentWithParameter renders", () => {
+  <ComponentWithParameter color=Css.red />
   |> render
   |> container
   |> expect


### PR DESCRIPTION
This is a bug, declaring anything other than a simple identifier wasn't working previously, with this behavior we can define any inline type on the component declaration

```reason
module ComponentWithParameter = [%styled.div
  (~color: Css.Types.Color.t) => 
    "color: $(color)"
];
```