### PR TITLE
implement's new API to dynamic components

### DIFF
--- a/src/css_to_emotion.re
+++ b/src/css_to_emotion.re
@@ -331,11 +331,15 @@ and render_style_rule = (ident, sr: Style_rule.t): expression => {
   };
 };
 
-let render_emotion_css = ((list, loc): Declaration_list.t): expression => {
-  let declarationListValues = render_declaration_list((list, loc));
+let render_emotion_style = (declaration_list: expression): expression => {
+  let loc = declaration_list.pexp_loc;
   let ident = Exp.ident(~loc, {txt: Emotion.lident("style"), loc});
 
-  Exp.apply(~loc, ident, [(Nolabel, declarationListValues)]);
+  Exp.apply(~loc, ident, [(Nolabel, declaration_list)]);
+};
+let render_emotion_css = ((list, loc): Declaration_list.t): expression => {
+  let declarationListValues = render_declaration_list((list, loc));
+  render_emotion_style(declarationListValues);
 };
 
 let render_rule = (ident, r: Rule.t): expression => {

--- a/src/css_to_emotion.rei
+++ b/src/css_to_emotion.rei
@@ -1,6 +1,7 @@
 open Css_types;
 let render_declaration_list:
   ((list(Declaration_list.kind), Warnings.loc)) => Parsetree.expression;
+let render_emotion_style: Parsetree.expression => Parsetree.expression;
 let render_emotion_css:
   ((list(Declaration_list.kind), Warnings.loc)) => Parsetree.expression;
 let render_global: Stylesheet.t => Parsetree.expression;

--- a/src/css_to_emotion.rei
+++ b/src/css_to_emotion.rei
@@ -1,4 +1,6 @@
 open Css_types;
+let render_declaration_list:
+  ((list(Declaration_list.kind), Warnings.loc)) => Parsetree.expression;
 let render_emotion_css:
   ((list(Declaration_list.kind), Warnings.loc)) => Parsetree.expression;
 let render_global: Stylesheet.t => Parsetree.expression;

--- a/src/styled_ppx.re
+++ b/src/styled_ppx.re
@@ -98,7 +98,7 @@ let rec getLabeledArgs = (mapper, expr, list) => {
       ~loc=pattern.ppat_loc,
       "Dynamic components are defined with labeled arguments. If you want to know more check the documentation: https://reasonml.org/docs/manual/latest/function#labeled-arguments",
     )
-  | innerExpression => (innerExpression, list, None)
+  | _ => (expr, list, None)
   };
 };
 
@@ -527,7 +527,8 @@ let match_mod_payload = mod_expr => {
             ||| map(
                   ~f=(f, payload, delim) => f(`String((payload, delim))),
                   pexp_constant(pconst_string(__', __)),
-                ),
+                )
+            ||| map(~f=(f, expr) => f(`Expr(expr)), __),
             nil,
           )
           ^:: nil
@@ -568,9 +569,36 @@ let renderStringPayload = (kind, payload, delim) => {
   | `Style =>
     let ast = parse(Css_parser.declaration_list);
     Css_to_emotion.render_emotion_css(ast);
+  | `Declarations =>
+    let ast = parse(Css_parser.declaration_list);
+    Css_to_emotion.render_declaration_list(ast);
   | `Global =>
     let ast = parse(Css_parser.stylesheet);
     Css_to_emotion.render_global(ast);
+  };
+};
+
+let renderPayload = (kind, default_mapper, expr) => {
+  // this mapper is used inside of [%styled.div expr]
+  let mapper = {
+    ...default_mapper,
+    expr: (mapper, expr) => {
+      let map = expr => mapper.Ast_mapper.expr(mapper, expr);
+      let loc = expr.pexp_loc;
+      switch (expr.pexp_desc) {
+      | Pexp_constant(Pconst_string(payload, delim)) =>
+        renderStringPayload(`Declarations, {txt: payload, loc}, delim)
+      | Pexp_sequence(left, right) =>
+        Ast_builder.eapply(~loc, [%expr (@)], [map(left), map(right)])
+      | _ => default_mapper.expr(mapper, expr)
+      };
+    },
+  };
+
+  switch (expr.pexp_desc) {
+  | Pexp_constant(Pconst_string(str, delim)) =>
+    renderStringPayload(kind, {txt: str, loc: expr.pexp_loc}, delim)
+  | _ => mapper.Ast_mapper.expr(mapper, expr)
   };
 };
 
@@ -617,16 +645,6 @@ let styledPpxMapper = (_, _) => {
           "Unexpected HTML tag in [%styled." ++ tag ++ "]",
         );
       };
-
-      let (str, delim) =
-        switch (functionExpr) {
-        | Pexp_constant(Pconst_string(str, delim)) => (str, delim)
-        | _ =>
-          raiseWithLocation(
-            ~loc=pattern.ppat_loc,
-            "Unexpected error happened.",
-          )
-        };
 
       let loc = expression.pexp_loc;
 
@@ -677,7 +695,7 @@ let styledPpxMapper = (_, _) => {
             variableList,
           ),
         );
-      let css_expr = renderStringPayload(`Style, {txt: str, loc}, delim);
+      let css_expr = renderPayload(`Style, default_mapper, functionExpr);
       Mod.mk(
         Pmod_structure([
           createMakeProps(~loc, variableProps),
@@ -740,6 +758,7 @@ let styledPpxMapper = (_, _) => {
           createComponent(~loc, ~tag, ~styledExpr),
         ]),
       );
+    // | Some(({txt: name, loc: nameLoc}, `Expr(expr))) => assert(false)
     | _ => default_mapper.module_expr(mapper, expr)
     };
   },

--- a/src/styled_ppx.re
+++ b/src/styled_ppx.re
@@ -598,7 +598,8 @@ let renderPayload = (kind, default_mapper, expr) => {
   switch (expr.pexp_desc) {
   | Pexp_constant(Pconst_string(str, delim)) =>
     renderStringPayload(kind, {txt: str, loc: expr.pexp_loc}, delim)
-  | _ => mapper.Ast_mapper.expr(mapper, expr)
+  | _ =>
+    Css_to_emotion.render_emotion_style(mapper.Ast_mapper.expr(mapper, expr))
   };
 };
 

--- a/test/bucklescript/src/__snapshots__/index_test.bs.js.snap
+++ b/test/bucklescript/src/__snapshots__/index_test.bs.js.snap
@@ -36,7 +36,7 @@ exports[`ComponentLink should render an <a /> tag 1`] = `
 exports[`ComponentWithParameter renders 1`] = `
 <div>
   <div
-    class="background,blue,backgroundColor,#F0F0F0,color,#FF0000,0"
+    class="css-6hpeuv"
     color="5194459,FF0000"
     theme="136970422"
   />

--- a/test/bucklescript/src/__snapshots__/index_test.bs.js.snap
+++ b/test/bucklescript/src/__snapshots__/index_test.bs.js.snap
@@ -36,8 +36,9 @@ exports[`ComponentLink should render an <a /> tag 1`] = `
 exports[`ComponentWithParameter renders 1`] = `
 <div>
   <div
-    class="css-1roeevf"
+    class="background,blue,backgroundColor,#F0F0F0,color,#FF0000,0"
     color="5194459,FF0000"
+    theme="136970422"
   />
 </div>
 `;

--- a/test/bucklescript/src/index_test.re
+++ b/test/bucklescript/src/index_test.re
@@ -22,8 +22,14 @@ module ComponentInline = [%styled "color: #454545"];
 module ComponentLink = [%styled.a {| color: #454545 |}];
 
 module ComponentWithParameter = [%styled.div
-  (~color: Css.Types.Color.t) => 
-    "color: $(color)"
+  (~color: Css.Types.Color.t, ~theme: [`Light | `Dark]) => {
+    "background: blue";
+    switch (theme) {
+    | `Light => "background-color: #F0F0F0"
+    | `Dark => "background-color: #202020"
+    };
+    "color: $(color)";
+  }
 ];
 
 test("Component renders", () => {
@@ -35,7 +41,7 @@ test("Component renders", () => {
 });
 
 test("ComponentWithParameter renders", () => {
-  <ComponentWithParameter color=Css.red />
+  <ComponentWithParameter color=Css.red theme=`Light/>
   |> render
   |> container
   |> expect


### PR DESCRIPTION
## Goal

Any string inside of a component should be treated as `[%css]` and every statement should merged.

## How it works?

Any string inside of the component instead of generating a class they return a list with the declarations, so
```reason
"color: blue"; // input
[Css.color(Css.blue))]; // output
```

`;` in OCaml is a AST node called `Pexp_sequence`, so we map it to a `@`, because of that the following are identical

```reason
(~color) => {
  "color: $(color)";
  "opacity: 0.5"
};
(~color) => {
  "color: $(color)" @
  "opacity: 0.5"
};
```

## Issues

Closes #61

## Duplicated?

Same code as #126, but in a local branch to publish a nightly