### PR TITLE
add type inference for styled components

### DIFF
--- a/src/styled_ppx.re
+++ b/src/styled_ppx.re
@@ -343,26 +343,27 @@ let createMakeBody = (~loc, ~tag, ~styledExpr) =>
   );
 
 /* props: makeProps */
-let createMakeArguments = (~loc) => {
+let createMakeArguments = (~loc, ~params) => {
   Pat.constraint_(
     ~loc,
     Pat.mk(~loc, Ppat_var({txt: "props", loc})),
-    Typ.constr(~loc, {txt: Lident("makeProps"), loc}, []),
+    Typ.constr(~loc, {txt: Lident("makeProps"), loc}, params),
   );
 };
 
 /* let make = (props: makeProps) => + createMakeBody */
-let createMakeFn = (~loc, ~tag, ~styledExpr) =>
+let createMakeFn = (~loc, ~tag, ~styledExpr, ~params) =>
   Exp.fun_(
     ~loc,
     Nolabel,
     None,
-    createMakeArguments(~loc),
+    createMakeArguments(~loc, ~params),
     createMakeBody(~loc, ~tag, ~styledExpr),
   );
 
 /* [@react.component] + createMakeFn */
-let createComponent = (~loc, ~tag, ~styledExpr) =>
+let createComponent = (~loc, ~tag, ~styledExpr, ~params) => {
+  let params = Option.value(~default=[], params);
   Str.mk(
     ~loc,
     Pstr_value(
@@ -371,15 +372,18 @@ let createComponent = (~loc, ~tag, ~styledExpr) =>
         Vb.mk(
           ~loc,
           Pat.mk(~loc, Ppat_var({txt: "make", loc})),
-          createMakeFn(~loc, ~tag, ~styledExpr),
+          createMakeFn(~loc, ~tag, ~styledExpr, ~params),
         ),
       ],
     ),
   );
+};
 
 /* [@bs.optional] color: string */
 let createCustomPropLabel = (~loc, name, type_) =>
   Type.field(~loc, {txt: name, loc}, type_);
+
+let createTypeVariable = (~loc, name) => Ast_builder.ptyp_var(~loc, name);
 
 /* [@bs.optional] ahref: string */
 let createRecordLabel = (~loc, name, kind) =>
@@ -440,10 +444,10 @@ let createMakeProps = (~loc, extraProps) => {
       ]),
     );
 
-  let dynamicProps =
+  let (params, dynamicProps) =
     switch (extraProps) {
-    | None => []
-    | Some(props) => props
+    | None => ([], [])
+    | Some((params, props)) => (params, props)
     };
   /*
      List of
@@ -472,6 +476,7 @@ let createMakeProps = (~loc, extraProps) => {
       dynamicProps,
     );
 
+  let params = params |> List.map(type_ => (type_, Invariant));
   Str.mk(
     ~loc,
     Pstr_type(
@@ -482,6 +487,7 @@ let createMakeProps = (~loc, extraProps) => {
           ~priv=Public,
           ~attrs=[bsDerivingAbstract],
           ~kind=Ptype_record(reactProps),
+          ~params,
           {txt: "makeProps", loc},
         ),
       ],
@@ -674,32 +680,32 @@ let styledPpxMapper = (_, _) => {
       let variableList =
         List.map(
           ((arg, _, _, _, loc, type_)) => {
-            open Ast_builder; /* Gets the type of the argument from the fn definition
-                      (~width: int, ~height: int) => {}
-                    */
-
-            let type_ =
+            let label = getLabel(arg);
+            let (kind, type_) =
               switch (type_) {
-              | Some(type_) => type_
-              | None =>
-                ptyp_constr(~loc, Located.mk(~loc, Lident("string")), [])
+              | Some(type_) => (`Typed, type_)
+              | None => (`Open, createTypeVariable(~loc, label))
               };
-            (getLabel(arg), type_);
+            (label, kind, type_);
           },
           argList,
         );
-
+      let variableParams =
+        variableList
+        |> List.filter_map(
+             fun
+             | (_, `Open, type_) => Some(type_)
+             | _ => None,
+           );
       let variableProps =
-        Some(
-          List.map(
-            ((label, type_)) => createCustomPropLabel(~loc, label, type_),
-            variableList,
-          ),
+        List.map(
+          ((label, _, type_)) => createCustomPropLabel(~loc, label, type_),
+          variableList,
         );
       let css_expr = renderPayload(`Style, default_mapper, functionExpr);
       Mod.mk(
         Pmod_structure([
-          createMakeProps(~loc, variableProps),
+          createMakeProps(~loc, Some((variableParams, variableProps))),
           createReactBinding(~loc),
           createDynamicStyles(
             ~loc,
@@ -707,7 +713,12 @@ let styledPpxMapper = (_, _) => {
             ~args=argList,
             ~exp=css_expr,
           ),
-          createComponent(~loc, ~tag, ~styledExpr),
+          createComponent(
+            ~loc,
+            ~tag,
+            ~styledExpr,
+            ~params=Some(variableParams),
+          ),
         ]),
       );
     | Some(({txt: name, loc: nameLoc}, `String(str, delim)))
@@ -732,7 +743,7 @@ let styledPpxMapper = (_, _) => {
           createMakeProps(~loc, None),
           createReactBinding(~loc),
           createStyles(~loc, ~name=styleVariableName, ~exp=css_expr),
-          createComponent(~loc, ~tag, ~styledExpr),
+          createComponent(~loc, ~tag, ~styledExpr, ~params=None),
         ]),
       );
     | Some(({txt: name, loc: nameLoc}, `None)) when isStyledTag(name) =>
@@ -756,7 +767,7 @@ let styledPpxMapper = (_, _) => {
           createMakeProps(~loc, None),
           createReactBinding(~loc),
           createStyles(~loc, ~name=styleVariableName, ~exp=css_expr),
-          createComponent(~loc, ~tag, ~styledExpr),
+          createComponent(~loc, ~tag, ~styledExpr, ~params=None),
         ]),
       );
     // | Some(({txt: name, loc: nameLoc}, `Expr(expr))) => assert(false)

--- a/test/bucklescript/src/index_test.re
+++ b/test/bucklescript/src/index_test.re
@@ -22,7 +22,7 @@ module ComponentInline = [%styled "color: #454545"];
 module ComponentLink = [%styled.a {| color: #454545 |}];
 
 module ComponentWithParameter = [%styled.div
-  (~color: Css.Types.Color.t, ~theme: [`Light | `Dark]) => {
+  (~color, ~theme: [`Light | `Dark]) => {
     "background: blue";
     switch (theme) {
     | `Light => "background-color: #F0F0F0"

--- a/test/native/snapshot/pp.expected
+++ b/test/native/snapshot/pp.expected
@@ -2703,6 +2703,898 @@ Css.style([Css.unsafe("display", "block")]);
 
 module Component = {
   [@bs.deriving abstract]
+  type makeProps('var) = {
+    [@bs.optional]
+    ref: ReactDOMRe.domRef,
+    [@bs.optional]
+    children: React.element,
+    [@bs.optional]
+    key: string,
+    [@bs.optional]
+    defaultChecked: bool,
+    [@bs.optional]
+    defaultValue: string,
+    [@bs.optional]
+    accessKey: string,
+    [@bs.optional]
+    className: string,
+    [@bs.optional]
+    contentEditable: bool,
+    [@bs.optional]
+    contextMenu: string,
+    [@bs.optional]
+    dir: string,
+    [@bs.optional]
+    draggable: bool,
+    [@bs.optional]
+    hidden: bool,
+    [@bs.optional]
+    id: string,
+    [@bs.optional]
+    lang: string,
+    [@bs.optional]
+    role: string,
+    [@bs.optional]
+    spellCheck: bool,
+    [@bs.optional]
+    tabIndex: int,
+    [@bs.optional]
+    title: string,
+    [@bs.optional]
+    itemID: string,
+    [@bs.optional]
+    itemProp: string,
+    [@bs.optional]
+    itemRef: string,
+    [@bs.optional]
+    itemScope: bool,
+    [@bs.optional]
+    itemType: string,
+    [@bs.optional]
+    accept: string,
+    [@bs.optional]
+    acceptCharset: string,
+    [@bs.optional]
+    action: string,
+    [@bs.optional]
+    allowFullScreen: bool,
+    [@bs.optional]
+    alt: string,
+    [@bs.optional]
+    async: bool,
+    [@bs.optional]
+    autoComplete: string,
+    [@bs.optional]
+    autoFocus: bool,
+    [@bs.optional]
+    autoPlay: bool,
+    [@bs.optional]
+    challenge: string,
+    [@bs.optional]
+    charSet: string,
+    [@bs.optional]
+    checked: bool,
+    [@bs.optional]
+    cite: string,
+    [@bs.optional]
+    crossorigin: bool,
+    [@bs.optional]
+    cols: int,
+    [@bs.optional]
+    colSpan: int,
+    [@bs.optional]
+    content: string,
+    [@bs.optional]
+    controls: bool,
+    [@bs.optional]
+    coords: string,
+    [@bs.optional]
+    data: string,
+    [@bs.optional]
+    dateTime: string,
+    [@bs.optional]
+    default: bool,
+    [@bs.optional]
+    defer: bool,
+    [@bs.optional]
+    disabled: bool,
+    [@bs.optional]
+    download: string,
+    [@bs.optional]
+    encType: string,
+    [@bs.optional]
+    form: string,
+    [@bs.optional]
+    formAction: string,
+    [@bs.optional]
+    formTarget: string,
+    [@bs.optional]
+    formMethod: string,
+    [@bs.optional]
+    headers: string,
+    [@bs.optional]
+    height: string,
+    [@bs.optional]
+    high: int,
+    [@bs.optional]
+    href: string,
+    [@bs.optional]
+    hrefLang: string,
+    [@bs.optional]
+    htmlFor: string,
+    [@bs.optional]
+    httpEquiv: string,
+    [@bs.optional]
+    icon: string,
+    [@bs.optional]
+    inputMode: string,
+    [@bs.optional]
+    integrity: string,
+    [@bs.optional]
+    keyType: string,
+    [@bs.optional]
+    kind: string,
+    [@bs.optional]
+    label: string,
+    [@bs.optional]
+    list: string,
+    [@bs.optional]
+    loop: bool,
+    [@bs.optional]
+    low: int,
+    [@bs.optional]
+    manifest: string,
+    [@bs.optional]
+    max: string,
+    [@bs.optional]
+    maxLength: int,
+    [@bs.optional]
+    media: string,
+    [@bs.optional]
+    mediaGroup: string,
+    [@bs.optional]
+    min: int,
+    [@bs.optional]
+    minLength: int,
+    [@bs.optional]
+    multiple: bool,
+    [@bs.optional]
+    muted: bool,
+    [@bs.optional]
+    name: string,
+    [@bs.optional]
+    nonce: string,
+    [@bs.optional]
+    noValidate: bool,
+    [@bs.optional]
+    open_: bool,
+    [@bs.optional]
+    optimum: int,
+    [@bs.optional]
+    pattern: string,
+    [@bs.optional]
+    placeholder: string,
+    [@bs.optional]
+    poster: string,
+    [@bs.optional]
+    preload: string,
+    [@bs.optional]
+    radioGroup: string,
+    [@bs.optional]
+    readOnly: bool,
+    [@bs.optional]
+    rel: string,
+    [@bs.optional]
+    required: bool,
+    [@bs.optional]
+    reversed: bool,
+    [@bs.optional]
+    rows: int,
+    [@bs.optional]
+    rowSpan: int,
+    [@bs.optional]
+    sandbox: string,
+    [@bs.optional]
+    scope: string,
+    [@bs.optional]
+    scoped: bool,
+    [@bs.optional]
+    scrolling: string,
+    [@bs.optional]
+    selected: bool,
+    [@bs.optional]
+    shape: string,
+    [@bs.optional]
+    size: int,
+    [@bs.optional]
+    sizes: string,
+    [@bs.optional]
+    span: int,
+    [@bs.optional]
+    src: string,
+    [@bs.optional]
+    srcDoc: string,
+    [@bs.optional]
+    srcLang: string,
+    [@bs.optional]
+    srcSet: string,
+    [@bs.optional]
+    start: int,
+    [@bs.optional]
+    step: float,
+    [@bs.optional]
+    summary: string,
+    [@bs.optional]
+    target: string,
+    [@bs.optional]
+    type_: string,
+    [@bs.optional]
+    useMap: string,
+    [@bs.optional]
+    value: string,
+    [@bs.optional]
+    width: string,
+    [@bs.optional]
+    wrap: string,
+    [@bs.optional]
+    onCopy: ReactEvent.Clipboard.t => unit,
+    [@bs.optional]
+    onCut: ReactEvent.Clipboard.t => unit,
+    [@bs.optional]
+    onPaste: ReactEvent.Clipboard.t => unit,
+    [@bs.optional]
+    onCompositionEnd: ReactEvent.Composition.t => unit,
+    [@bs.optional]
+    onCompositionStart: ReactEvent.Composition.t => unit,
+    [@bs.optional]
+    onCompositionUpdate: ReactEvent.Composition.t => unit,
+    [@bs.optional]
+    onKeyDown: ReactEvent.Keyboard.t => unit,
+    [@bs.optional]
+    onKeyPress: ReactEvent.Keyboard.t => unit,
+    [@bs.optional]
+    onKeyUp: ReactEvent.Keyboard.t => unit,
+    [@bs.optional]
+    onFocus: ReactEvent.Focus.t => unit,
+    [@bs.optional]
+    onBlur: ReactEvent.Focus.t => unit,
+    [@bs.optional]
+    onChange: ReactEvent.Form.t => unit,
+    [@bs.optional]
+    onInput: ReactEvent.Form.t => unit,
+    [@bs.optional]
+    onSubmit: ReactEvent.Form.t => unit,
+    [@bs.optional]
+    onClick: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onContextMenu: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDoubleClick: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDrag: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDragEnd: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDragEnter: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDragExit: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDragLeave: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDragOver: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDragStart: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onDrop: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onMouseDown: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onMouseEnter: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onMouseLeave: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onMouseMove: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onMouseOut: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onMouseOver: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onMouseUp: ReactEvent.Mouse.t => unit,
+    [@bs.optional]
+    onSelect: ReactEvent.Selection.t => unit,
+    [@bs.optional]
+    onTouchCancel: ReactEvent.Touch.t => unit,
+    [@bs.optional]
+    onTouchEnd: ReactEvent.Touch.t => unit,
+    [@bs.optional]
+    onTouchMove: ReactEvent.Touch.t => unit,
+    [@bs.optional]
+    onTouchStart: ReactEvent.Touch.t => unit,
+    [@bs.optional]
+    onScroll: ReactEvent.UI.t => unit,
+    [@bs.optional]
+    onWheel: ReactEvent.Wheel.t => unit,
+    [@bs.optional]
+    onAbort: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onCanPlay: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onCanPlayThrough: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onDurationChange: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onEmptied: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onEncrypetd: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onEnded: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onError: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onLoadedData: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onLoadedMetadata: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onLoadStart: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onPause: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onPlay: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onPlaying: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onProgress: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onRateChange: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onSeeked: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onSeeking: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onStalled: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onSuspend: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onTimeUpdate: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onVolumeChange: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onWaiting: ReactEvent.Media.t => unit,
+    [@bs.optional]
+    onAnimationStart: ReactEvent.Animation.t => unit,
+    [@bs.optional]
+    onAnimationEnd: ReactEvent.Animation.t => unit,
+    [@bs.optional]
+    onAnimationIteration: ReactEvent.Animation.t => unit,
+    [@bs.optional]
+    onTransitionEnd: ReactEvent.Transition.t => unit,
+    [@bs.optional]
+    accentHeight: string,
+    [@bs.optional]
+    accumulate: string,
+    [@bs.optional]
+    additive: string,
+    [@bs.optional]
+    alignmentBaseline: string,
+    [@bs.optional]
+    allowReorder: string,
+    [@bs.optional]
+    alphabetic: string,
+    [@bs.optional]
+    amplitude: string,
+    [@bs.optional]
+    arabicForm: string,
+    [@bs.optional]
+    ascent: string,
+    [@bs.optional]
+    attributeName: string,
+    [@bs.optional]
+    attributeType: string,
+    [@bs.optional]
+    autoReverse: string,
+    [@bs.optional]
+    azimuth: string,
+    [@bs.optional]
+    baseFrequency: string,
+    [@bs.optional]
+    baseProfile: string,
+    [@bs.optional]
+    baselineShift: string,
+    [@bs.optional]
+    bbox: string,
+    [@bs.optional]
+    begin_: string,
+    [@bs.optional]
+    bias: string,
+    [@bs.optional]
+    by: string,
+    [@bs.optional]
+    calcMode: string,
+    [@bs.optional]
+    capHeight: string,
+    [@bs.optional]
+    clip: string,
+    [@bs.optional]
+    clipPath: string,
+    [@bs.optional]
+    clipPathUnits: string,
+    [@bs.optional]
+    clipRule: string,
+    [@bs.optional]
+    colorInterpolation: string,
+    [@bs.optional]
+    colorInterpolationFilters: string,
+    [@bs.optional]
+    colorProfile: string,
+    [@bs.optional]
+    colorRendering: string,
+    [@bs.optional]
+    contentScriptType: string,
+    [@bs.optional]
+    contentStyleType: string,
+    [@bs.optional]
+    cursor: string,
+    [@bs.optional]
+    cx: string,
+    [@bs.optional]
+    cy: string,
+    [@bs.optional]
+    d: string,
+    [@bs.optional]
+    decelerate: string,
+    [@bs.optional]
+    descent: string,
+    [@bs.optional]
+    diffuseConstant: string,
+    [@bs.optional]
+    direction: string,
+    [@bs.optional]
+    display: string,
+    [@bs.optional]
+    divisor: string,
+    [@bs.optional]
+    dominantBaseline: string,
+    [@bs.optional]
+    dur: string,
+    [@bs.optional]
+    dx: string,
+    [@bs.optional]
+    dy: string,
+    [@bs.optional]
+    edgeMode: string,
+    [@bs.optional]
+    elevation: string,
+    [@bs.optional]
+    enableBackground: string,
+    [@bs.optional]
+    end_: string,
+    [@bs.optional]
+    exponent: string,
+    [@bs.optional]
+    externalResourcesRequired: string,
+    [@bs.optional]
+    fill: string,
+    [@bs.optional]
+    fillOpacity: string,
+    [@bs.optional]
+    fillRule: string,
+    [@bs.optional]
+    filter: string,
+    [@bs.optional]
+    filterRes: string,
+    [@bs.optional]
+    filterUnits: string,
+    [@bs.optional]
+    floodColor: string,
+    [@bs.optional]
+    floodOpacity: string,
+    [@bs.optional]
+    focusable: string,
+    [@bs.optional]
+    fontFamily: string,
+    [@bs.optional]
+    fontSize: string,
+    [@bs.optional]
+    fontSizeAdjust: string,
+    [@bs.optional]
+    fontStretch: string,
+    [@bs.optional]
+    fontStyle: string,
+    [@bs.optional]
+    fontVariant: string,
+    [@bs.optional]
+    fontWeight: string,
+    [@bs.optional]
+    fomat: string,
+    [@bs.optional]
+    from: string,
+    [@bs.optional]
+    fx: string,
+    [@bs.optional]
+    fy: string,
+    [@bs.optional]
+    g1: string,
+    [@bs.optional]
+    g2: string,
+    [@bs.optional]
+    glyphName: string,
+    [@bs.optional]
+    glyphOrientationHorizontal: string,
+    [@bs.optional]
+    glyphOrientationVertical: string,
+    [@bs.optional]
+    glyphRef: string,
+    [@bs.optional]
+    gradientTransform: string,
+    [@bs.optional]
+    gradientUnits: string,
+    [@bs.optional]
+    hanging: string,
+    [@bs.optional]
+    horizAdvX: string,
+    [@bs.optional]
+    horizOriginX: string,
+    [@bs.optional]
+    ideographic: string,
+    [@bs.optional]
+    imageRendering: string,
+    [@bs.optional]
+    in_: string,
+    [@bs.optional]
+    in2: string,
+    [@bs.optional]
+    intercept: string,
+    [@bs.optional]
+    k: string,
+    [@bs.optional]
+    k1: string,
+    [@bs.optional]
+    k2: string,
+    [@bs.optional]
+    k3: string,
+    [@bs.optional]
+    k4: string,
+    [@bs.optional]
+    kernelMatrix: string,
+    [@bs.optional]
+    kernelUnitLength: string,
+    [@bs.optional]
+    kerning: string,
+    [@bs.optional]
+    keyPoints: string,
+    [@bs.optional]
+    keySplines: string,
+    [@bs.optional]
+    keyTimes: string,
+    [@bs.optional]
+    lengthAdjust: string,
+    [@bs.optional]
+    letterSpacing: string,
+    [@bs.optional]
+    lightingColor: string,
+    [@bs.optional]
+    limitingConeAngle: string,
+    [@bs.optional]
+    local: string,
+    [@bs.optional]
+    markerEnd: string,
+    [@bs.optional]
+    markerHeight: string,
+    [@bs.optional]
+    markerMid: string,
+    [@bs.optional]
+    markerStart: string,
+    [@bs.optional]
+    markerUnits: string,
+    [@bs.optional]
+    markerWidth: string,
+    [@bs.optional]
+    mask: string,
+    [@bs.optional]
+    maskContentUnits: string,
+    [@bs.optional]
+    maskUnits: string,
+    [@bs.optional]
+    mathematical: string,
+    [@bs.optional]
+    mode: string,
+    [@bs.optional]
+    numOctaves: string,
+    [@bs.optional]
+    offset: string,
+    [@bs.optional]
+    opacity: string,
+    [@bs.optional]
+    operator: string,
+    [@bs.optional]
+    order: string,
+    [@bs.optional]
+    orient: string,
+    [@bs.optional]
+    orientation: string,
+    [@bs.optional]
+    origin: string,
+    [@bs.optional]
+    overflow: string,
+    [@bs.optional]
+    overflowX: string,
+    [@bs.optional]
+    overflowY: string,
+    [@bs.optional]
+    overlinePosition: string,
+    [@bs.optional]
+    overlineThickness: string,
+    [@bs.optional]
+    paintOrder: string,
+    [@bs.optional]
+    panose1: string,
+    [@bs.optional]
+    pathLength: string,
+    [@bs.optional]
+    patternContentUnits: string,
+    [@bs.optional]
+    patternTransform: string,
+    [@bs.optional]
+    patternUnits: string,
+    [@bs.optional]
+    pointerEvents: string,
+    [@bs.optional]
+    points: string,
+    [@bs.optional]
+    pointsAtX: string,
+    [@bs.optional]
+    pointsAtY: string,
+    [@bs.optional]
+    pointsAtZ: string,
+    [@bs.optional]
+    preserveAlpha: string,
+    [@bs.optional]
+    preserveAspectRatio: string,
+    [@bs.optional]
+    primitiveUnits: string,
+    [@bs.optional]
+    r: string,
+    [@bs.optional]
+    radius: string,
+    [@bs.optional]
+    refX: string,
+    [@bs.optional]
+    refY: string,
+    [@bs.optional]
+    renderingIntent: string,
+    [@bs.optional]
+    repeatCount: string,
+    [@bs.optional]
+    repeatDur: string,
+    [@bs.optional]
+    requiredExtensions: string,
+    [@bs.optional]
+    requiredFeatures: string,
+    [@bs.optional]
+    restart: string,
+    [@bs.optional]
+    result: string,
+    [@bs.optional]
+    rotate: string,
+    [@bs.optional]
+    rx: string,
+    [@bs.optional]
+    ry: string,
+    [@bs.optional]
+    scale: string,
+    [@bs.optional]
+    seed: string,
+    [@bs.optional]
+    shapeRendering: string,
+    [@bs.optional]
+    slope: string,
+    [@bs.optional]
+    spacing: string,
+    [@bs.optional]
+    specularConstant: string,
+    [@bs.optional]
+    specularExponent: string,
+    [@bs.optional]
+    speed: string,
+    [@bs.optional]
+    spreadMethod: string,
+    [@bs.optional]
+    startOffset: string,
+    [@bs.optional]
+    stdDeviation: string,
+    [@bs.optional]
+    stemh: string,
+    [@bs.optional]
+    stemv: string,
+    [@bs.optional]
+    stitchTiles: string,
+    [@bs.optional]
+    stopColor: string,
+    [@bs.optional]
+    stopOpacity: string,
+    [@bs.optional]
+    strikethroughPosition: string,
+    [@bs.optional]
+    strikethroughThickness: string,
+    [@bs.optional]
+    stroke: string,
+    [@bs.optional]
+    strokeDasharray: string,
+    [@bs.optional]
+    strokeDashoffset: string,
+    [@bs.optional]
+    strokeLinecap: string,
+    [@bs.optional]
+    strokeLinejoin: string,
+    [@bs.optional]
+    strokeMiterlimit: string,
+    [@bs.optional]
+    strokeOpacity: string,
+    [@bs.optional]
+    strokeWidth: string,
+    [@bs.optional]
+    surfaceScale: string,
+    [@bs.optional]
+    systemLanguage: string,
+    [@bs.optional]
+    tableValues: string,
+    [@bs.optional]
+    targetX: string,
+    [@bs.optional]
+    targetY: string,
+    [@bs.optional]
+    textAnchor: string,
+    [@bs.optional]
+    textDecoration: string,
+    [@bs.optional]
+    textLength: string,
+    [@bs.optional]
+    textRendering: string,
+    [@bs.optional]
+    to_: string,
+    [@bs.optional]
+    transform: string,
+    [@bs.optional]
+    u1: string,
+    [@bs.optional]
+    u2: string,
+    [@bs.optional]
+    underlinePosition: string,
+    [@bs.optional]
+    underlineThickness: string,
+    [@bs.optional]
+    unicode: string,
+    [@bs.optional]
+    unicodeBidi: string,
+    [@bs.optional]
+    unicodeRange: string,
+    [@bs.optional]
+    unitsPerEm: string,
+    [@bs.optional]
+    vAlphabetic: string,
+    [@bs.optional]
+    vHanging: string,
+    [@bs.optional]
+    vIdeographic: string,
+    [@bs.optional]
+    vMathematical: string,
+    [@bs.optional]
+    values: string,
+    [@bs.optional]
+    vectorEffect: string,
+    [@bs.optional]
+    version: string,
+    [@bs.optional]
+    vertAdvX: string,
+    [@bs.optional]
+    vertAdvY: string,
+    [@bs.optional]
+    vertOriginX: string,
+    [@bs.optional]
+    vertOriginY: string,
+    [@bs.optional]
+    viewBox: string,
+    [@bs.optional]
+    viewTarget: string,
+    [@bs.optional]
+    visibility: string,
+    [@bs.optional]
+    widths: string,
+    [@bs.optional]
+    wordSpacing: string,
+    [@bs.optional]
+    writingMode: string,
+    [@bs.optional]
+    x: string,
+    [@bs.optional]
+    x1: string,
+    [@bs.optional]
+    x2: string,
+    [@bs.optional]
+    xChannelSelector: string,
+    [@bs.optional]
+    xHeight: string,
+    [@bs.optional]
+    xlinkActuate: string,
+    [@bs.optional]
+    xlinkArcrole: string,
+    [@bs.optional]
+    xlinkHref: string,
+    [@bs.optional]
+    xlinkRole: string,
+    [@bs.optional]
+    xlinkShow: string,
+    [@bs.optional]
+    xlinkTitle: string,
+    [@bs.optional]
+    xlinkType: string,
+    [@bs.optional]
+    xmlns: string,
+    [@bs.optional]
+    xmlnsXlink: string,
+    [@bs.optional]
+    xmlBase: string,
+    [@bs.optional]
+    xmlLang: string,
+    [@bs.optional]
+    xmlSpace: string,
+    [@bs.optional]
+    y: string,
+    [@bs.optional]
+    y1: string,
+    [@bs.optional]
+    y2: string,
+    [@bs.optional]
+    yChannelSelector: string,
+    [@bs.optional]
+    z: string,
+    [@bs.optional]
+    zoomAndPan: string,
+    [@bs.optional]
+    about: string,
+    [@bs.optional]
+    datatype: string,
+    [@bs.optional]
+    inlist: string,
+    [@bs.optional]
+    prefix: string,
+    [@bs.optional]
+    property: string,
+    [@bs.optional]
+    resource: string,
+    [@bs.optional]
+    typeof: string,
+    [@bs.optional]
+    vocab: string,
+    [@bs.optional]
+    suppressContentEditableWarning: bool,
+    var: 'var,
+  };
+  [@bs.val] [@bs.module "react"]
+  external createElement:
+    (string, Js.t({..}), array(React.element)) => React.element =
+    "createElement";
+
+  let styles = (~var) =>
+    Css.style([Css.color(var), Css.unsafe("display", "block")]);
+  let make = (props: makeProps('var)) => {
+    let stylesObject = {"className": styles(~var=varGet(props))};
+    let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
+    createElement(
+      "div",
+      newProps,
+      [|
+        switch (childrenGet(props)) {
+        | Some(chil) => chil
+        | None => React.null
+        },
+      |],
+    );
+  };
+};
+
+module Component = {
+  [@bs.deriving abstract]
   type makeProps = {
     [@bs.optional]
     ref: ReactDOMRe.domRef,

--- a/test/native/snapshot/simple.re
+++ b/test/native/snapshot/simple.re
@@ -35,11 +35,12 @@ module Component = [%styled {j|
 
 [%css "display: block"];
 
-/* module Component = [%styled fun ~var -> {j|
+module Component = [%styled
+  (~var) => {j|
      color: $var;
      display: block;
-   |j}]
-    */
+   |j}
+];
 
 module Component = [%styled];
 module Component = [%styled ""];


### PR DESCRIPTION
## Why?

Currently by omitting the type parameter it fallbacks to `string` which forces us to actually type the structure, that wasn't a problem before but now that most type variables are typed that isn't simple

## Example

```reason
// from
module ComponentWithParameter = [%styled.div
  (~color: Css.Types.Color.t, ~theme: [`Light | `Dark]) => {
    "background: blue";
    switch (theme) {
    | `Light => "background-color: #F0F0F0"
    | `Dark => "background-color: #202020"
    };
    "color: $(color)";
  }
];
// to
module ComponentWithParameter = [%styled.div
  (~color, ~theme) => {
    "background: blue";
    switch (theme) {
    | `Light => "background-color: #F0F0F0"
    | `Dark => "background-color: #202020"
    };
    "color: $(color)";
  }
];
```