### PR TITLE
initial keyframe support

### DIFF
--- a/src/css_to_emotion.rei
+++ b/src/css_to_emotion.rei
@@ -4,4 +4,5 @@ let render_declaration_list:
 let render_emotion_style: Parsetree.expression => Parsetree.expression;
 let render_emotion_css:
   ((list(Declaration_list.kind), Warnings.loc)) => Parsetree.expression;
+let render_emotion_keyframe: Stylesheet.t => Parsetree.expression;
 let render_global: Stylesheet.t => Parsetree.expression;

--- a/src/styled_ppx.re
+++ b/src/styled_ppx.re
@@ -575,6 +575,9 @@ let renderStringPayload = (kind, payload, delim) => {
   | `Global =>
     let ast = parse(Css_parser.stylesheet);
     Css_to_emotion.render_global(ast);
+  | `Keyframe =>
+    let ast = parse(Css_parser.stylesheet);
+    Css_to_emotion.render_emotion_keyframe(ast);
   };
 };
 
@@ -615,6 +618,8 @@ let styledPpxMapper = (_, _) => {
       renderStringPayload(`Style, payload, delim)
     | Some(("styled.global", payload, delim)) =>
       renderStringPayload(`Global, payload, delim)
+    | Some(("styled.keyframe", payload, delim)) =>
+      renderStringPayload(`Keyframe, payload, delim)
     | exception _
     | _ => default_mapper.expr(mapper, expr)
     },

--- a/test/bucklescript/src/__snapshots__/index_test.bs.js.snap
+++ b/test/bucklescript/src/__snapshots__/index_test.bs.js.snap
@@ -3,7 +3,7 @@
 exports[`Component renders 1`] = `
 <div>
   <div
-    class="css-s37awk"
+    class="css-1hbubrx"
   />
 </div>
 `;

--- a/test/bucklescript/src/index_test.re
+++ b/test/bucklescript/src/index_test.re
@@ -2,6 +2,11 @@ open Jest;
 open Expect;
 open ReactTestingLibrary;
 
+let fadeIn = [%styled.keyframe {|
+  0% { opacity: 0 }
+  100% { opacity: 1 }
+|}];
+
 module Component = [%styled.div {|
   display: flex;
   justify-content: center;
@@ -12,6 +17,9 @@ module Component = [%styled.div {|
   width: 100vw;
 
   font-size: 30px;
+
+  animation-name: $(fadeIn);
+  /* animation: $(fadeIn) ease-in 200ms; */
 
   width: unset;
   @media (min-width: 30em) and (min-height: 20em) {

--- a/test/native/lib/TestEmitter.re
+++ b/test/native/lib/TestEmitter.re
@@ -348,6 +348,42 @@ let media_query_static_css_tests = [%expr
     ),
   |]
 ];
+let keyframe_static_css_tests = [%expr
+  [|
+    (
+      [%styled.keyframe
+        {|
+        from { opacity: 0 }
+        50% {
+          background: red;
+          border: 1px solid blue
+        }
+        to { opacity: 1 }
+        |}
+      ],
+      [
+        (0, [Css.opacity(0.)]),
+        (
+          50,
+          [
+            Css.unsafe("background", "red"),
+            Css.unsafe("border", "1px solid blue"),
+          ],
+        ),
+        (100, [Css.opacity(1.)]),
+      ],
+    ),
+    (
+      [%styled.keyframe
+        {|
+        0% { opacity: 0 }
+        100% { opacity: 1 }
+        |}
+      ],
+      [(0, [Css.opacity(0.)]), (100, [Css.opacity(1.)])],
+    ),
+  |]
+];
 describe("emit bs-css from static [%css]", ({test, _}) => {
   let test = (prefix, index, (result, expected)) =>
     test(prefix ++ string_of_int(index), compare(result, expected));
@@ -356,6 +392,7 @@ describe("emit bs-css from static [%css]", ({test, _}) => {
   let selectors_static_css_tests = extract_tests(selectors_static_css_tests);
   let media_query_static_css_tests =
     extract_tests(media_query_static_css_tests);
+  let keyframe_static_css_tests = extract_tests(keyframe_static_css_tests);
 
   write_tests_to_file(properties_static_css_tests, "static_css_tests.ml");
   write_tests_to_file(selectors_static_css_tests, "selectors_css_tests.ml");
@@ -363,10 +400,12 @@ describe("emit bs-css from static [%css]", ({test, _}) => {
     media_query_static_css_tests,
     "media_query_css_tests.ml",
   );
+  write_tests_to_file(keyframe_static_css_tests, "keyframe_css_tests.ml");
 
   List.iteri(test("properties static: "), properties_static_css_tests);
   List.iteri(test("selectors static: "), selectors_static_css_tests);
   List.iteri(test("media query static: "), media_query_static_css_tests);
+  List.iteri(test("keyframes static: "), keyframe_static_css_tests);
 });
 
 let properties_variable_css_tests = [

--- a/test/native/lib/dune
+++ b/test/native/lib/dune
@@ -2,7 +2,7 @@
  (name StyledPpxTestNativeLib)
  (modules
   (:standard \ static_css_tests selectors_css_tests media_query_css_tests
-    TestRunner))
+    keyframe_css_tests TestRunner))
  (library_flags
   (-linkall -g))
  (libraries StyledPpxTestNativeBSCSS rely.lib styled-ppx.lib ppxlib)
@@ -19,7 +19,8 @@
 ; type check
 
 (rule
- (targets static_css_tests.ml selectors_css_tests.ml media_query_css_tests.ml)
+ (targets static_css_tests.ml selectors_css_tests.ml media_query_css_tests.ml
+   keyframe_css_tests.ml)
  (deps ./TestRunner.exe)
  (action
   (run %{deps})))
@@ -27,7 +28,8 @@
 (library
  (name StyledPpxTestNativeTypeCheck)
  (libraries StyledPpxTestNativeBSCSS)
- (modules static_css_tests selectors_css_tests media_query_css_tests)
+ (modules static_css_tests selectors_css_tests media_query_css_tests
+   keyframe_css_tests)
  (preprocess
   (pps ppx_tools_versioned.metaquot_410 styled-ppx.lib)))
 
@@ -36,7 +38,8 @@
  (deps
    .StyledPpxTestNativeTypeCheck.objs/byte/styledPpxTestNativeTypeCheck__Static_css_tests.cmi
    .StyledPpxTestNativeTypeCheck.objs/byte/styledPpxTestNativeTypeCheck__Selectors_css_tests.cmi
-   .StyledPpxTestNativeTypeCheck.objs/byte/styledPpxTestNativeTypeCheck__Media_query_css_tests.cmi)
+   .StyledPpxTestNativeTypeCheck.objs/byte/styledPpxTestNativeTypeCheck__Media_query_css_tests.cmi
+   .StyledPpxTestNativeTypeCheck.objs/byte/styledPpxTestNativeTypeCheck__Keyframe_css_tests.cmi)
  (action
   ; this is only because a action is required
   (echo %{deps})))


### PR DESCRIPTION
## Missing

Currently the animations properties doesn't support variables in the following form `animation: $(fadeIn) ease-in 200ms` so you're going to make the complete way.

```css
animation-name: $(fadeIn);
animation-timing-function: ease-in;
animation-duration: 200ms;
```

## Issues
- Closes #80