### PR TITLE
[I-122] Remove warning about key on nested components (uppercase components with children)

### DIFF
--- a/demo/bsconfig.json
+++ b/demo/bsconfig.json
@@ -3,7 +3,9 @@
   "reason": {
     "react-jsx": 3
   },
-  "bsc-flags": ["-bs-super-errors"],
+  "bsc-flags": [
+    "-bs-super-errors"
+  ],
   "sources": {
     "dir": "src",
     "subdirs": true,
@@ -15,9 +17,15 @@
       "in-source": true
     }
   ],
-  "ppx-flags": ["../_esy/default/build/default/bin/Bin.exe"],
+  "ppx-flags": [
+    "../_build/default/bin/Bin.exe"
+  ],
   "suffix": ".bs.js",
   "namespace": true,
-  "bs-dependencies": ["bs-css", "bs-css-emotion", "reason-react"],
+  "bs-dependencies": [
+    "bs-css",
+    "bs-css-emotion",
+    "reason-react"
+  ],
   "refmt": 3
 }

--- a/demo/src/index.re
+++ b/demo/src/index.re
@@ -5,8 +5,7 @@
   }
 |}];
 
-module App = [%styled.div
-  (~background) => {j|
+module App = [%styled.div {j|
   position: absolute;
   top: 0;
   left: 0;
@@ -18,57 +17,50 @@ module App = [%styled.div
   align-items: center;
   flex-direction: column;
 
-  background-color: $background;
-
   cursor: pointer;
 
   & > div {
     padding: 20px;
   }
-
-  & > a:nth-child(3n+2) {
-    background-color: green;
-  }
-  & > a:nth-child(even) {
-    background-color: red;
-  }
-
-  &::active {
-    background-color: blue;
-  }
 |j}
 ];
 
+module App2 = {
+  [@react.component]
+  let make = (~children) => {
+    <div>
+      children
+    </div>
+  }
+}
+
 module Link = [%styled.a
   {|
-  color: #FFFFFF;
   font-size: 36px;
   margin-top: 16px;
-  &:hover {
-    background-color: pink;
-  }
 |}
 ];
 
 module Line = [%styled.span];
 module Wrapper = [%styled ""];
 
-let space = "10px";
-
-module Component = [%styled
-  (~background: string, ~space: string) => {j|
-    background-color: $background;
-    padding: $space;
-    border-radius: 20px;
-    box-sizing: border-box;
+module Component = [%styled {j|
+  background-color: red;
+  border-radius: 20px;
+  box-sizing: border-box;
 |j}
 ];
 
 ReactDOMRe.renderToElementWithId(
-  <App onClick=Js.log background="#443434">
-    <Component background="#FFFFFF" space="30">
-      {React.string("Demo of...")}
+  <App onClick=Js.log>
+    <Component>
+      {React.string("test..")}
     </Component>
+    <App2>
+      <Component>
+        {React.string("Demo of...")}
+      </Component>
+    </App2>
     <Link href="https://github.com/davesnx/styled-ppx">
       {React.string("styled-ppx")}
     </Link>

--- a/test/bucklescript/src/Emotion.re
+++ b/test/bucklescript/src/Emotion.re
@@ -1,5 +1,5 @@
 let loadSerializer = [%bs.raw "
-function loadEmotionSerializer () {
+function () {
   var serializer = require('jest-emotion');
   expect.addSnapshotSerializer(serializer);
 }

--- a/test/bucklescript/src/__snapshots__/dynamic_test.bs.js.snap
+++ b/test/bucklescript/src/__snapshots__/dynamic_test.bs.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ComponentWithParameter renders 1`] = `
+.emotion-0 {
+  background: blue;
+  background-color: #F0F0F0;
+  color: #FF0000;
+}
+
+<div>
+  <div
+    class="emotion-0"
+    color="5194459,FF0000"
+    theme="136970422"
+  />
+</div>
+`;

--- a/test/bucklescript/src/__snapshots__/index_test.bs.js.snap
+++ b/test/bucklescript/src/__snapshots__/index_test.bs.js.snap
@@ -34,12 +34,6 @@ exports[`Component renders 1`] = `
   animation-name: animation-0;
 }
 
-@media (min-width:30em) and (min-height:20em) {
-  .emotion-0 {
-    color: #A52A2A;
-  }
-}
-
 <div>
   <div
     class="emotion-0"
@@ -80,22 +74,6 @@ exports[`ComponentLink should render an <a /> tag 1`] = `
 <div>
   <a
     class="emotion-0"
-  />
-</div>
-`;
-
-exports[`ComponentWithParameter renders 1`] = `
-.emotion-0 {
-  background: blue;
-  background-color: #F0F0F0;
-  color: #FF0000;
-}
-
-<div>
-  <div
-    class="emotion-0"
-    color="5194459,FF0000"
-    theme="136970422"
   />
 </div>
 `;

--- a/test/bucklescript/src/__snapshots__/keyframe_test.bs.js.snap
+++ b/test/bucklescript/src/__snapshots__/keyframe_test.bs.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Animate should render keyframes 1`] = `
+@keyframes animation-0 {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.emotion-0 {
+  background-color: #000000;
+  height: 100vh;
+  width: 100vw;
+  -webkit-animation-name: animation-0;
+  animation-name: animation-0;
+}
+
+<div>
+  <div
+    class="emotion-0"
+  />
+</div>
+`;

--- a/test/bucklescript/src/__snapshots__/media_query_test.bs.js.snap
+++ b/test/bucklescript/src/__snapshots__/media_query_test.bs.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MediaQueryComponent renders 1`] = `
+.emotion-0 {
+  color: #FF0000;
+}
+
+@media (min-width:30em) and (min-height:20em) {
+  .emotion-0 {
+    color: #A52A2A;
+  }
+}
+
+<div>
+  <div
+    class="emotion-0"
+  />
+</div>
+`;

--- a/test/bucklescript/src/__snapshots__/nested_test.bs.js.snap
+++ b/test/bucklescript/src/__snapshots__/nested_test.bs.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Nested component renders 1`] = `
+.emotion-0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  color: #FF0000;
+  height: 100vh;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100vw;
+}
+
+.emotion-0 > p {
+  color: #800080;
+}
+
+<div>
+  <div
+    class="emotion-0"
+  />
+</div>
+`;

--- a/test/bucklescript/src/dynamic_test.re
+++ b/test/bucklescript/src/dynamic_test.re
@@ -1,0 +1,23 @@
+open Jest;
+open Expect;
+open ReactTestingLibrary;
+Emotion.loadSerializer();
+
+module ComponentWithParameter = [%styled.div
+  (~color, ~theme: [`Light | `Dark]) => {
+    "background: blue";
+    switch (theme) {
+    | `Light => "background-color: #F0F0F0"
+    | `Dark => "background-color: #202020"
+    };
+    "color: $(color)";
+  }
+];
+
+test("ComponentWithParameter renders", () => {
+  <ComponentWithParameter color=Css.red theme=`Light/>
+  |> render
+  |> container
+  |> expect
+  |> toMatchSnapshot
+});

--- a/test/bucklescript/src/index_test.re
+++ b/test/bucklescript/src/index_test.re
@@ -23,35 +23,14 @@ module Component = [%styled.div {|
   /* animation: $(fadeIn) ease-in 200ms; */
 
   width: unset;
-  @media (min-width: 30em) and (min-height: 20em) {
-    color: brown;
-  }
 |}];
-module ComponentInline = [%styled "color: #454545"];
-module ComponentLink = [%styled.a {| color: #454545 |}];
-module StyledInput = [%styled.input "color: #454545"];
 
-module ComponentWithParameter = [%styled.div
-  (~color, ~theme: [`Light | `Dark]) => {
-    "background: blue";
-    switch (theme) {
-    | `Light => "background-color: #F0F0F0"
-    | `Dark => "background-color: #202020"
-    };
-    "color: $(color)";
-  }
-];
+module ComponentInline = [%styled "color: #454545"];
+module StyledInput = [%styled.input "color: #454545"];
+module ComponentLink = [%styled.a {| color: #454545 |}];
 
 test("Component renders", () => {
   <Component />
-  |> render
-  |> container
-  |> expect
-  |> toMatchSnapshot
-});
-
-test("ComponentWithParameter renders", () => {
-  <ComponentWithParameter color=Css.red theme=`Light/>
   |> render
   |> container
   |> expect

--- a/test/bucklescript/src/keyframe_test.re
+++ b/test/bucklescript/src/keyframe_test.re
@@ -1,0 +1,25 @@
+open Jest;
+open Expect;
+open ReactTestingLibrary;
+Emotion.loadSerializer();
+
+let fadeIn = [%styled.keyframe {|
+  0% { opacity: 0 }
+  100% { opacity: 1 }
+|}];
+
+module Animate = [%styled.div {|
+  background-color: black;
+  height: 100vh;
+  width: 100vw;
+  animation-name: $(fadeIn);
+  /* animation: $(fadeIn) ease-in 200ms; */
+|}];
+
+test("Animate should render keyframes", () => {
+  <Animate />
+  |> render
+  |> container
+  |> expect
+  |> toMatchSnapshot
+});

--- a/test/bucklescript/src/media_query_test.re
+++ b/test/bucklescript/src/media_query_test.re
@@ -1,0 +1,20 @@
+open Jest;
+open Expect;
+open ReactTestingLibrary;
+Emotion.loadSerializer();
+
+module MediaQueryComponent = [%styled.div {|
+  color: red;
+
+  @media (min-width: 30em) and (min-height: 20em) {
+    color: brown;
+  }
+|}];
+
+test("MediaQueryComponent renders", () => {
+  <MediaQueryComponent />
+  |> render
+  |> container
+  |> expect
+  |> toMatchSnapshot
+});

--- a/test/bucklescript/src/nested_test.re
+++ b/test/bucklescript/src/nested_test.re
@@ -1,0 +1,28 @@
+open Jest;
+open Expect;
+open ReactTestingLibrary;
+Emotion.loadSerializer();
+
+module Nested = [%styled.div
+  {|
+    align-items: center;
+    display: flex;
+    color: red;
+
+    height: 100vh;
+    justify-content: center;
+    width: 100vw;
+
+    > p {
+      color: purple;
+    }
+  |}
+];
+
+test("Nested component renders", () => {
+  <Nested />
+  |> render
+  |> container
+  |> expect
+  |> toMatchSnapshot
+});

--- a/test/native/snapshot/pp.expected
+++ b/test/native/snapshot/pp.expected
@@ -894,10 +894,6 @@ module Component = {
     suppressContentEditableWarning: bool,
   };
   [@bs.val] [@bs.module "react"]
-  external createElement:
-    (string, Js.t({..}), array(React.element)) => React.element =
-    "createElement";
-  [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
 
@@ -905,16 +901,7 @@ module Component = {
   let make = (props: makeProps) => {
     let stylesObject = {"className": styles};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
-    createElement(
-      "div",
-      newProps,
-      [|
-        switch (childrenGet(props)) {
-        | Some(chil) => chil
-        | None => React.null
-        },
-      |],
-    );
+    createVariadicElement("div", newProps);
   };
 };
 module Component = {
@@ -1786,10 +1773,6 @@ module Component = {
     suppressContentEditableWarning: bool,
   };
   [@bs.val] [@bs.module "react"]
-  external createElement:
-    (string, Js.t({..}), array(React.element)) => React.element =
-    "createElement";
-  [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
 
@@ -1801,16 +1784,7 @@ module Component = {
   let make = (props: makeProps) => {
     let stylesObject = {"className": styles};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
-    createElement(
-      "section",
-      newProps,
-      [|
-        switch (childrenGet(props)) {
-        | Some(chil) => chil
-        | None => React.null
-        },
-      |],
-    );
+    createVariadicElement("section", newProps);
   };
 };
 
@@ -2684,10 +2658,6 @@ module Component = {
     suppressContentEditableWarning: bool,
   };
   [@bs.val] [@bs.module "react"]
-  external createElement:
-    (string, Js.t({..}), array(React.element)) => React.element =
-    "createElement";
-  [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
 
@@ -2695,16 +2665,7 @@ module Component = {
   let make = (props: makeProps) => {
     let stylesObject = {"className": styles};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
-    createElement(
-      "div",
-      newProps,
-      [|
-        switch (childrenGet(props)) {
-        | Some(chil) => chil
-        | None => React.null
-        },
-      |],
-    );
+    createVariadicElement("div", newProps);
   };
 };
 
@@ -3580,10 +3541,6 @@ module Component = {
     var: 'var,
   };
   [@bs.val] [@bs.module "react"]
-  external createElement:
-    (string, Js.t({..}), array(React.element)) => React.element =
-    "createElement";
-  [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
 
@@ -3592,16 +3549,7 @@ module Component = {
   let make = (props: makeProps('var)) => {
     let stylesObject = {"className": styles(~var=varGet(props))};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
-    createElement(
-      "div",
-      newProps,
-      [|
-        switch (childrenGet(props)) {
-        | Some(chil) => chil
-        | None => React.null
-        },
-      |],
-    );
+    createVariadicElement("div", newProps);
   };
 };
 
@@ -4474,10 +4422,6 @@ module Component = {
     suppressContentEditableWarning: bool,
   };
   [@bs.val] [@bs.module "react"]
-  external createElement:
-    (string, Js.t({..}), array(React.element)) => React.element =
-    "createElement";
-  [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
 
@@ -4485,16 +4429,7 @@ module Component = {
   let make = (props: makeProps) => {
     let stylesObject = {"className": styles};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
-    createElement(
-      "div",
-      newProps,
-      [|
-        switch (childrenGet(props)) {
-        | Some(chil) => chil
-        | None => React.null
-        },
-      |],
-    );
+    createVariadicElement("div", newProps);
   };
 };
 module Component = {
@@ -5366,10 +5301,6 @@ module Component = {
     suppressContentEditableWarning: bool,
   };
   [@bs.val] [@bs.module "react"]
-  external createElement:
-    (string, Js.t({..}), array(React.element)) => React.element =
-    "createElement";
-  [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
 
@@ -5377,16 +5308,7 @@ module Component = {
   let make = (props: makeProps) => {
     let stylesObject = {"className": styles};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
-    createElement(
-      "div",
-      newProps,
-      [|
-        switch (childrenGet(props)) {
-        | Some(chil) => chil
-        | None => React.null
-        },
-      |],
-    );
+    createVariadicElement("div", newProps);
   };
 };
 
@@ -6259,10 +6181,6 @@ module NestedSelectors = {
     suppressContentEditableWarning: bool,
   };
   [@bs.val] [@bs.module "react"]
-  external createElement:
-    (string, Js.t({..}), array(React.element)) => React.element =
-    "createElement";
-  [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
 
@@ -6294,16 +6212,7 @@ module NestedSelectors = {
   let make = (props: makeProps) => {
     let stylesObject = {"className": styles};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
-    createElement(
-      "body",
-      newProps,
-      [|
-        switch (childrenGet(props)) {
-        | Some(chil) => chil
-        | None => React.null
-        },
-      |],
-    );
+    createVariadicElement("body", newProps);
   };
 };
 
@@ -7175,10 +7084,6 @@ module Input = {
     [@bs.optional]
     suppressContentEditableWarning: bool,
   };
-  [@bs.val] [@bs.module "react"]
-  external createElement:
-    (string, Js.t({..}), array(React.element)) => React.element =
-    "createElement";
   [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";


### PR DESCRIPTION
This PR solves https://github.com/davesnx/styled-ppx/issues/122

- Updated demo code
- Split use-cases of bucklescript testing
- Removed the createElement with an array from our ppx, this removed a lot of code and makes the children handled by the reasonreact jsx ppx, not us.