### PR TITLE
fix @deriving clash in rescript 9

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -2,6 +2,4 @@
   (name ppx)
   (public_name styled-ppx)
   (libraries styled-ppx.lib)
-  (ocamlopt_flags ( -linkall ))
-  (package styled-ppx)
-)
+  (package styled-ppx))


### PR DESCRIPTION
See 
https://github.com/rescript-lang/rescript-compiler/issues/5036
https://forum.rescript-lang.org/t/were-bs-deriving-jsconverter-and-bs-deriving-abstract-removed/1333/12
and https://github.com/reasonml-community/graphql-ppx/commit/b7aff4e26a878be0850e3e964b519f057b4f350a