### PR TITLE
Remove typed_variable from Css_parser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         run: esy test_snapshot
 
       - name: Run runtests for Parser, vds & Lexer
-        run: esy dune runtest --force
+        run: esy test
 
       - name: Export dependencies
         if: steps.deps-cache.outputs.cache-hit != 'true'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <h1> styled-ppx <a href="https://github.com/davesnx/styled-ppx/actions"></a></h1>
 
+> **Alert**: This documentaiton points to v0.20.0 ⚠️. There are a few things that have changed since then. Since v1.x is tagged as "latest" on npm. Please install v1.x with caution.
+
 **styled-ppx** is the [ppx](https://victor.darvariu.me/jekyll/update/2018/06/19/ppx-tutorial.html) that enables *css-in-reason*.
 Build on top of [emotion](https://emotion.sh), it allows you to style apps safe, quickly, performant and as you always done it.
 
@@ -8,8 +10,6 @@ Build on top of [emotion](https://emotion.sh), it allows you to style apps safe,
 Allows you to create **React Components** with type-safe CSS style definitions that don't rely on a specific [DSL](https://en.wikipedia.org/wiki/Domain-specific_language) and great error messages:
 
 ![](./docs/images/compile-error.png)
-
-> **Alert**: This documentaiton points to v0.20.0 ⚠️. There are a few things that have changed since then. Since v1.x is tagged as "latest" on npm. Please install v1.x with caution and don't update if you aren't completly sure.
 
 ## Usage
 **`styled-ppx`** implements a ppx that transforms `[%styled]` extensions points into `[@react.component]` modules with the additional styles converted to [emotion](https://emotion.sh).

--- a/packages/parser/css_lexer.re
+++ b/packages/parser/css_lexer.re
@@ -130,11 +130,7 @@ let ident_char = [%sedlex.regexp?
 
 let ident = [%sedlex.regexp? (Opt('-'), ident_start, Star(ident_char))];
 
-let variable = [%sedlex.regexp? ('$', Opt('('), Star(ident_char), Opt(')'))];
-
-let variable_with_type = [%sedlex.regexp?
-  ('$', '(', Star(ident_char), ')', Star(ident_char))
-];
+let variable = [%sedlex.regexp? ('$', '(', Star(any), ')')];
 
 let string_quote = [%sedlex.regexp?
   (
@@ -281,9 +277,9 @@ let rec get_next_token = buf => {
   | '[' => LEFT_BRACKET
   | ']' => RIGHT_BRACKET
   | '%' => PERCENTAGE
-  | unsafe => UNSAFE
-  | variable => VARIABLE(Lex_buffer.latin1(~skip=1, buf))
   | '&' => SELECTOR("&")
+  | unsafe => UNSAFE
+  | variable => VARIABLE(Lex_buffer.latin1(~skip=2, ~drop=1, buf))
   | operator => OPERATOR(Lex_buffer.latin1(buf))
   | string => STRING(Lex_buffer.latin1(~skip=1, ~drop=1, buf))
   | "url(" => get_url("", buf)
@@ -327,7 +323,7 @@ and get_url = (url, buf) =>
       )),
     )
   | _ => assert(false)
-  };
+};
 
 let get_next_token_with_location = buf => {
   discard_comments_and_white_spaces(buf);

--- a/packages/parser/css_lexer.re
+++ b/packages/parser/css_lexer.re
@@ -72,8 +72,6 @@ let token_to_string =
     ++ ")"
   | DIMENSION((n, d)) => "DIMENSION(" ++ n ++ ", " ++ d ++ ")"
   | VARIABLE(v) => "VARIABLE(" ++ v ++ ")"
-  | TYPED_VARIABLE((v, type_)) =>
-    "TYPED_VARIABLE(" ++ v ++ " " ++ type_ ++ ")"
   | UNSAFE => "UNSAFE";
 
 let () =
@@ -285,19 +283,6 @@ let rec get_next_token = buf => {
   | '%' => PERCENTAGE
   | unsafe => UNSAFE
   | variable => VARIABLE(Lex_buffer.latin1(~skip=1, buf))
-  | variable_with_type =>
-    let variableAndType = Lex_buffer.latin1(~skip=2, buf); /* cosa)type */
-    let variableAndTypeLength = String.length(variableAndType);
-    let closedParentesisIndex = String.index(variableAndType, ')');
-    let variableName = String.sub(variableAndType, 0, closedParentesisIndex);
-    let variableType =
-      String.sub(
-        variableAndType,
-        closedParentesisIndex + 1,
-        variableAndTypeLength - closedParentesisIndex - 1,
-      );
-
-    TYPED_VARIABLE((variableName, variableType));
   | '&' => SELECTOR("&")
   | operator => OPERATOR(Lex_buffer.latin1(buf))
   | string => STRING(Lex_buffer.latin1(~skip=1, ~drop=1, buf))

--- a/packages/parser/css_lexer.re
+++ b/packages/parser/css_lexer.re
@@ -2,14 +2,17 @@
   * Reference:
   * https://www.w3.org/TR/css-syntax-3/
   * https://github.com/yahoo/css-js/blob/master/src/l/css.3.l */
+
 module Sedlexing = Lex_buffer;
+module Parser = Css_parser;
+module Types = Css_types;
 
 /** Signals a lexing error at the provided source location.  */
 exception LexingError((Lexing.position, string));
 
 /** Signals a parsing error at the provided token and its start and end
  * locations. */
-exception ParseError((Css_parser.token, Lexing.position, Lexing.position));
+exception ParseError((Parser.token, Lexing.position, Lexing.position));
 
 /** Signals a grammar error at the provided location. */
 exception GrammarError((string, Location.t));
@@ -31,38 +34,38 @@ let location_to_string = loc =>
 
 let dimension_to_string =
   fun
-  | Css_types.Length => "length"
-  | Angle => "angle"
-  | Time => "time"
-  | Frequency => "frequency";
+  | Types.Length => "length"
+  | Types.Angle => "angle"
+  | Types.Time => "time"
+  | Types.Frequency => "frequency";
 
 let token_to_string =
   fun
-  | Css_parser.EOF => "EOF"
-  | LEFT_BRACE => "{"
-  | RIGHT_BRACE => "}"
-  | LEFT_PAREN => "("
-  | RIGHT_PAREN => ")"
-  | LEFT_BRACKET => "["
-  | RIGHT_BRACKET => "]"
-  | COLON => ":"
-  | SEMI_COLON => ";"
-  | PERCENTAGE => "%"
-  | SELECTOR(s) => "SELECTOR(" ++ s ++ ")"
-  | IMPORTANT => "!important"
-  | IDENT(s) => "IDENT(" ++ s ++ ")"
-  | STRING(s) => "STRING(" ++ s ++ ")"
-  | URI(s) => "URI(" ++ s ++ ")"
-  | OPERATOR(s) => "OPERATOR(" ++ s ++ ")"
-  | DELIM(s) => "DELIM(" ++ s ++ ")"
-  | NESTED_AT_RULE(s) => "NESTED_AT_RULE(" ++ s ++ ")"
-  | AT_RULE_WITHOUT_BODY(s) => "AT_RULE_WITHOUT_BODY(" ++ s ++ ")"
-  | AT_RULE(s) => "AT_RULE(" ++ s ++ ")"
-  | FUNCTION(s) => "FUNCTION(" ++ s ++ ")"
-  | HASH(s) => "HASH(" ++ s ++ ")"
-  | NUMBER(s) => "NUMBER(" ++ s ++ ")"
-  | UNICODE_RANGE(s) => "UNICODE_RANGE(" ++ s ++ ")"
-  | FLOAT_DIMENSION((n, s, d)) =>
+  | Parser.EOF => "EOF"
+  | Parser.LEFT_BRACE => "{"
+  | Parser.RIGHT_BRACE => "}"
+  | Parser.LEFT_PAREN => "("
+  | Parser.RIGHT_PAREN => ")"
+  | Parser.LEFT_BRACKET => "["
+  | Parser.RIGHT_BRACKET => "]"
+  | Parser.COLON => ":"
+  | Parser.SEMI_COLON => ";"
+  | Parser.PERCENTAGE => "%"
+  | Parser.SELECTOR(s) => "SELECTOR(" ++ s ++ ")"
+  | Parser.IMPORTANT => "!important"
+  | Parser.IDENT(s) => "IDENT(" ++ s ++ ")"
+  | Parser.STRING(s) => "STRING(" ++ s ++ ")"
+  | Parser.URI(s) => "URI(" ++ s ++ ")"
+  | Parser.OPERATOR(s) => "OPERATOR(" ++ s ++ ")"
+  | Parser.DELIM(s) => "DELIM(" ++ s ++ ")"
+  | Parser.NESTED_AT_RULE(s) => "NESTED_AT_RULE(" ++ s ++ ")"
+  | Parser.AT_RULE_WITHOUT_BODY(s) => "AT_RULE_WITHOUT_BODY(" ++ s ++ ")"
+  | Parser.AT_RULE(s) => "AT_RULE(" ++ s ++ ")"
+  | Parser.FUNCTION(s) => "FUNCTION(" ++ s ++ ")"
+  | Parser.HASH(s) => "HASH(" ++ s ++ ")"
+  | Parser.NUMBER(s) => "NUMBER(" ++ s ++ ")"
+  | Parser.UNICODE_RANGE(s) => "UNICODE_RANGE(" ++ s ++ ")"
+  | Parser.FLOAT_DIMENSION((n, s, d)) =>
     "FLOAT_DIMENSION("
     ++ n
     ++ ", "
@@ -70,19 +73,19 @@ let token_to_string =
     ++ ", "
     ++ dimension_to_string(d)
     ++ ")"
-  | DIMENSION((n, d)) => "DIMENSION(" ++ n ++ ", " ++ d ++ ")"
-  | VARIABLE(v) => "VARIABLE(" ++ v ++ ")"
-  | UNSAFE => "UNSAFE";
+  | Parser.DIMENSION((n, d)) => "DIMENSION(" ++ n ++ ", " ++ d ++ ")"
+  | Parser.VARIABLE(v) => "VARIABLE(" ++ v ++ ")"
+  | Parser.UNSAFE => "UNSAFE";
 
 let () =
   Location.register_error_of_exn(
     fun
     | LexingError((pos, msg)) => {
-        let loc = Lex_buffer.make_loc(pos, pos);
+        let loc = Sedlexing.make_loc(pos, pos);
         Some(Location.error(~loc, msg));
       }
     | ParseError((token, start_pos, end_pos)) => {
-        let loc = Lex_buffer.make_loc(start_pos, end_pos);
+        let loc = Sedlexing.make_loc(start_pos, end_pos);
         let msg =
           Printf.sprintf(
             "Parse error while reading token '%s'",
@@ -130,7 +133,7 @@ let ident_char = [%sedlex.regexp?
 
 let ident = [%sedlex.regexp? (Opt('-'), ident_start, Star(ident_char))];
 
-let variable = [%sedlex.regexp? ('$', '(', Star(any), ')')];
+let variable = [%sedlex.regexp? ('$', '(', Star(ident_char), ')')];
 
 let string_quote = [%sedlex.regexp?
   (
@@ -254,7 +257,7 @@ let discard_comments_and_white_spaces = buf => {
   and discard_comments = buf =>
     switch%sedlex (buf) {
     | eof =>
-      raise(LexingError((buf.Lex_buffer.pos, "Unterminated comment at EOF")))
+      raise(LexingError((buf.Sedlexing.pos, "Unterminated comment at EOF")))
     | "*/" => discard_white_spaces(buf)
     | any => discard_comments(buf)
     | _ => assert(false)
@@ -279,47 +282,46 @@ let rec get_next_token = buf => {
   | '%' => PERCENTAGE
   | '&' => SELECTOR("&")
   | unsafe => UNSAFE
-  | variable => VARIABLE(Lex_buffer.latin1(~skip=2, ~drop=1, buf))
-  | operator => OPERATOR(Lex_buffer.latin1(buf))
-  | string => STRING(Lex_buffer.latin1(~skip=1, ~drop=1, buf))
+  | variable => VARIABLE(Sedlexing.latin1(~skip=2, ~drop=1, buf))
+  | operator => OPERATOR(Sedlexing.latin1(buf))
+  | string => STRING(Sedlexing.latin1(~skip=1, ~drop=1, buf))
   | "url(" => get_url("", buf)
   | important => IMPORTANT
-  | nested_at_rule => NESTED_AT_RULE(Lex_buffer.latin1(~skip=1, buf))
+  | nested_at_rule => NESTED_AT_RULE(Sedlexing.latin1(~skip=1, buf))
   | at_rule_without_body =>
-    AT_RULE_WITHOUT_BODY(Lex_buffer.latin1(~skip=1, buf))
-  | at_rule => AT_RULE(Lex_buffer.latin1(~skip=1, buf))
+    AT_RULE_WITHOUT_BODY(Sedlexing.latin1(~skip=1, buf))
+  | at_rule => AT_RULE(Sedlexing.latin1(~skip=1, buf))
   /* NOTE: should be placed above ident, otherwise pattern with
    * '-[0-9a-z]{1,6}' cannot be matched */
-  | (_u, '+', unicode_range) => UNICODE_RANGE(Lex_buffer.latin1(buf))
-  | (ident, '(') => FUNCTION(Lex_buffer.latin1(~drop=1, buf))
-  | ident => IDENT(Lex_buffer.latin1(buf))
-  | ('#', name) => HASH(Lex_buffer.latin1(~skip=1, buf))
-  | number => get_dimension(Lex_buffer.latin1(buf), buf)
-  | any => DELIM(Lex_buffer.latin1(buf))
+  | (_u, '+', unicode_range) => UNICODE_RANGE(Sedlexing.latin1(buf))
+  | (ident, '(') => FUNCTION(Sedlexing.latin1(~drop=1, buf))
+  | ident => IDENT(Sedlexing.latin1(buf))
+  | ('#', name) => HASH(Sedlexing.latin1(~skip=1, buf))
+  | number => get_dimension(Sedlexing.latin1(buf), buf)
+  | any => DELIM(Sedlexing.latin1(buf))
   | _ => assert(false)
   };
 }
 and get_dimension = (n, buf) =>
   switch%sedlex (buf) {
-  | length => FLOAT_DIMENSION((n, Lex_buffer.latin1(buf), Css_types.Length))
-  | angle => FLOAT_DIMENSION((n, Lex_buffer.latin1(buf), Css_types.Angle))
-  | time => FLOAT_DIMENSION((n, Lex_buffer.latin1(buf), Css_types.Time))
-  | frequency =>
-    FLOAT_DIMENSION((n, Lex_buffer.latin1(buf), Css_types.Frequency))
-  | ident => DIMENSION((n, Lex_buffer.latin1(buf)))
+  | length => FLOAT_DIMENSION((n, Sedlexing.latin1(buf), Length))
+  | angle => FLOAT_DIMENSION((n, Sedlexing.latin1(buf), Angle))
+  | time => FLOAT_DIMENSION((n, Sedlexing.latin1(buf), Time))
+  | frequency => FLOAT_DIMENSION((n, Sedlexing.latin1(buf), Frequency))
+  | ident => DIMENSION((n, Sedlexing.latin1(buf)))
   | _ => NUMBER(n)
   }
 and get_url = (url, buf) =>
   switch%sedlex (buf) {
   | white_spaces => get_url(url, buf)
-  | url => get_url(Lex_buffer.latin1(buf), buf)
+  | url => get_url(Sedlexing.latin1(buf), buf)
   | ")" => URI(url)
-  | eof => raise(LexingError((buf.Lex_buffer.pos, "Incomplete URI")))
+  | eof => raise(LexingError((buf.Sedlexing.pos, "Incomplete URI")))
   | any =>
     raise(
       LexingError((
-        buf.Lex_buffer.pos,
-        "Unexpected token: " ++ Lex_buffer.latin1(buf) ++ " parsing an URI",
+        buf.Sedlexing.pos,
+        "Unexpected token: " ++ Sedlexing.latin1(buf) ++ " parsing an URI",
       )),
     )
   | _ => assert(false)
@@ -327,14 +329,14 @@ and get_url = (url, buf) =>
 
 let get_next_token_with_location = buf => {
   discard_comments_and_white_spaces(buf);
-  let loc_start = Lex_buffer.next_loc(buf);
+  let loc_start = Sedlexing.next_loc(buf);
   let token = get_next_token(buf);
-  let loc_end = Lex_buffer.next_loc(buf);
+  let loc_end = Sedlexing.next_loc(buf);
   (token, loc_start, loc_end);
 };
 
 let parse = (buf, parser) => {
-  let last_token = ref((Css_parser.EOF, Lexing.dummy_pos, Lexing.dummy_pos));
+  let last_token = ref((Parser.EOF, Lexing.dummy_pos, Lexing.dummy_pos));
   let next_token = () => {
     last_token := get_next_token_with_location(buf);
     last_token^;
@@ -349,13 +351,13 @@ let parse = (buf, parser) => {
 let parse_string = (~container_lnum=?, ~pos=?, parser, string) => {
   switch (container_lnum) {
   | None => ()
-  | Some(lnum) => Lex_buffer.container_lnum_ref := lnum
+  | Some(lnum) => Sedlexing.container_lnum_ref := lnum
   };
-  parse(Lex_buffer.of_ascii_string(~pos?, string), parser);
+  parse(Sedlexing.of_ascii_string(~pos?, string), parser);
 };
 
 let parse_declaration_list = (~container_lnum=?, ~pos=?, css) =>
-  parse_string(~container_lnum?, ~pos?, Css_parser.declaration_list, css);
+  parse_string(~container_lnum?, ~pos?, Parser.declaration_list, css);
 
 let parse_declaration = (~container_lnum=?, ~pos=?, css) =>
-  parse_string(~container_lnum?, ~pos?, Css_parser.declaration, css);
+  parse_string(~container_lnum?, ~pos?, Parser.declaration, css);

--- a/packages/parser/css_parser.mly
+++ b/packages/parser/css_parser.mly
@@ -30,7 +30,6 @@ open Css_types
 %token <string> UNICODE_RANGE
 %token <string * string * Css_types.dimension> FLOAT_DIMENSION
 %token <string * string> DIMENSION
-%token <string * string> TYPED_VARIABLE
 %token <string> VARIABLE
 %token UNSAFE
 
@@ -189,6 +188,5 @@ component_value:
   | d = FLOAT_DIMENSION { Component_value.Float_dimension d }
   | d = DIMENSION { Component_value.Dimension d }
   | v = VARIABLE { Component_value.Variable v }
-  | x = TYPED_VARIABLE { Component_value.TypedVariable x }
   | s = SELECTOR { Component_value.Selector s }
   ;

--- a/packages/parser/css_types.re
+++ b/packages/parser/css_types.re
@@ -23,8 +23,7 @@ module rec Component_value: {
     | Unicode_range(string)
     | Float_dimension((string, string, dimension))
     | Dimension((string, string))
-    | Variable(string)
-    | TypedVariable((string, string));
+    | Variable(string);
 } = Component_value
 and Brace_block: {
   type t =

--- a/packages/ppx/src/css_to_emotion.re
+++ b/packages/ppx/src/css_to_emotion.re
@@ -127,8 +127,8 @@ and render_declaration =
   switch (Declarations_to_emotion.parse_declarations((name, value_source))) {
   | Ok(exprs) => exprs
   | Error(`Not_found) => grammar_error(name_loc, "unknown property " ++ name)
-  | Error(`Invalid_value(_error)) =>
-    grammar_error(loc, "invalid property value")
+  | Error(`Invalid_value(value)) =>
+    grammar_error(loc, "invalid property value: " ++ value)
   };
 }
 and render_unsafe_declaration =

--- a/packages/ppx/src/declarations_to_emotion.re
+++ b/packages/ppx/src/declarations_to_emotion.re
@@ -1514,8 +1514,6 @@ let parse_declarations = ((name, value)) => {
     Parser.check_property(~name, value)
     |> Result.map_error((`Unknown_value) => `Not_found);
 
-  Printf.printf("\nvalue is: %s -> %b", value, is_valid_string);
-
   switch (render_css_global_values(name, value)) {
   | Ok(value) => Ok(value)
   | Error(_) =>

--- a/packages/ppx/src/declarations_to_emotion.re
+++ b/packages/ppx/src/declarations_to_emotion.re
@@ -45,6 +45,7 @@ let render_percentage = number => [%expr
 
 let render_css_global_values = (name, value) => {
   let.ok value = Parser.parse(Standard.css_wide_keywords, value);
+
   let value =
     switch (value) {
     | `Inherit => [%expr "inherit"]
@@ -132,9 +133,10 @@ let variable_rule = {
   open Let;
 
   let.bind_match () = Pattern.expect(DELIM("$"));
-  let.bind_match _ = Pattern.expect(LEFT_PARENS) |> Modifier.optional;
-  let.bind_match string = Standard.ident;
-  let.bind_match _ = Pattern.expect(RIGHT_PARENS) |> Modifier.optional;
+  let.bind_match _ = Pattern.expect(LEFT_PARENS);
+  let.bind_match string = Standard.custom_ident;
+  let.bind_match _ = Pattern.expect(RIGHT_PARENS);
+
   return_match(string);
 };
 
@@ -1511,6 +1513,8 @@ let parse_declarations = ((name, value)) => {
   let.ok is_valid_string =
     Parser.check_property(~name, value)
     |> Result.map_error((`Unknown_value) => `Not_found);
+
+  Printf.printf("\nvalue is: %s -> %b", value, is_valid_string);
 
   switch (render_css_global_values(name, value)) {
   | Ok(value) => Ok(value)

--- a/packages/ppx/test/native/Static_test.re
+++ b/packages/ppx/test/native/Static_test.re
@@ -279,7 +279,7 @@ describe("Transform [%css] to bs-css", ({test, _}) => {
 });
 
 let properties_variable_css_tests = [
-  ([%expr [%css "color: $var"]], [%expr CssJs.color(var)]),
+  ([%expr [%css "color: $(var)"]], [%expr CssJs.color(var)]),
   // TODO: ([%css "margin: $var"], [%expr CssJs.margin("margin", var)),
 ];
 

--- a/packages/ppx/test/snapshot/test.re
+++ b/packages/ppx/test/snapshot/test.re
@@ -33,7 +33,7 @@ module ArrayStatic = [%styled.section [|
 
 let var = "#333333";
 module StringInterpolation = [%styled.div {j|
-  color: $var;
+  color: $(var);
   __UNSAFE__ color: trust-me;
   display: block;
 |j}];
@@ -47,7 +47,7 @@ let classNameWithCss = [%cx [| cssRule, [%css "background-color: green;"] |]];
 
 module DynamicComponent = [%styled.div
   (~var) => {j|
-     color: $var;
+     color: $(var);
      display: block;
    |j}
 ];
@@ -72,7 +72,7 @@ let keyframe = [%styled.keyframe {|
 
 module ArrayDynamicComponent = [%styled.div (~var) =>
   [|
-    [%css "color: $var;"],
+    [%css "color: $(var);"],
     [%css "display: block;"]
   |]
 ];
@@ -82,14 +82,14 @@ module SequenceDynamicComponent = [%styled.div
     Js.log("Logging when render");
 
   [|
-    [%css "color: $var;"],
+    [%css "color: $(var);"],
     [%css "display: block;"]
   |]
   }
 ];
 
 module DynamicComponentWithDefaultValue = [%styled.div (~var="green") => [|
-  [%css "color: $var;"],
+  [%css "color: $(var);"],
   [%css "display: block;"]
 |]];
 
@@ -101,11 +101,3 @@ module DynamicComponentWithDefaultValue = [%styled.div (~var="green") => [|
 
 let interpolationValue = "23";
 [%css "font-size: $(interpolationValue)"];
-
-module Interpolation = {
-  let fromAModule = "23px";
-};
-[%css "font-size: $(Interpolation.fromAModule)"];
-
-let interpolationAndFunction = 23;
-[%css "font-size: $(string_of_int(interpolationAndFunction))"];

--- a/packages/ppx/test/snapshot/test.re
+++ b/packages/ppx/test/snapshot/test.re
@@ -99,5 +99,6 @@ module DynamicComponentWithDefaultValue = [%styled.div (~var="green") => [|
 |]];
 */
 
-let interpolationValue = "23";
+/* let interpolationValue = "23";
 [%css "font-size: $(interpolationValue)"];
+ */

--- a/packages/ppx/test/snapshot/test.re
+++ b/packages/ppx/test/snapshot/test.re
@@ -98,3 +98,14 @@ module DynamicComponentWithDefaultValue = [%styled.div (~var="green") => [|
   [%css "font-size: 16px"]
 |]];
 */
+
+let interpolationValue = "23";
+[%css "font-size: $(interpolationValue)"];
+
+module Interpolation = {
+  let fromAModule = "23px";
+};
+[%css "font-size: $(Interpolation.fromAModule)"];
+
+let interpolationAndFunction = 23;
+[%css "font-size: $(string_of_int(interpolationAndFunction))"];

--- a/packages/reason-css-parser/lib/Parse_from_string.re
+++ b/packages/reason-css-parser/lib/Parse_from_string.re
@@ -2,14 +2,16 @@ let parse_tokens = Parser_helper.parse_tokens;
 let parse = Parser_helper.parse;
 
 module StringMap = Map.Make(String);
-let check_value = {
-  let (let.ok) = Result.bind;
-  (~name, value) => {
-    let.ok check =
-      Parser.check_map
-      |> StringMap.find_opt(name)
-      |> Option.to_result(~none=`Unknown_value);
-    Ok(check(value));
-  };
+
+let (let.ok) = Result.bind;
+
+let check_value = (~name, value) => {
+  let.ok check =
+    Parser.check_map
+    |> StringMap.find_opt(name)
+    |> Option.to_result(~none=`Unknown_value);
+
+  Ok(check(value));
 };
+
 let check_property = (~name) => check_value(~name="property-" ++ name);

--- a/packages/reason-css-parser/lib/Parser.re
+++ b/packages/reason-css-parser/lib/Parser.re
@@ -1675,6 +1675,7 @@ and viewport_length = [%value.rec "'auto' | <length-percentage>"]
 and wq_name = [%value.rec "[ <ns-prefix> ]? <ident-token>"]
 and x = [%value.rec "<number>"]
 and y = [%value.rec "<number>"];
+
 let check_map =
   StringMap.of_seq(
     List.to_seq([

--- a/packages/reason-css-parser/lib/Standard.re
+++ b/packages/reason-css-parser/lib/Standard.re
@@ -174,7 +174,6 @@ let custom_ident =
     fun
     | IDENT(string) => Ok(string)
     | STRING(string) => Ok(string)
-    | BAD_STRING(string) => Ok(string)
     | _ => Error(["expected an identifier"]),
   );
 

--- a/packages/reason-css-parser/lib/Standard.re
+++ b/packages/reason-css-parser/lib/Standard.re
@@ -173,6 +173,8 @@ let custom_ident =
   token(
     fun
     | IDENT(string) => Ok(string)
+    | STRING(string) => Ok(string)
+    | BAD_STRING(string) => Ok(string)
     | _ => Error(["expected an identifier"]),
   );
 

--- a/packages/reason-css-parser/test/TestStandard.re
+++ b/packages/reason-css-parser/test/TestStandard.re
@@ -10,12 +10,14 @@ describe("standard values", ({test, _}) => {
     expect.result(parse("54")).toBe(Ok(54));
     expect.result(parse("54.5")).toBeError();
   });
+
   test("<number>", ({expect, _}) => {
     let parse = parse([%value "<number>"]);
     expect.result(parse("55")).toBe(Ok(55.));
     expect.result(parse("55.5")).toBe(Ok(55.5));
     expect.result(parse("ident")).toBeError();
   });
+
   test("<length>", ({expect, _}) => {
     let parse = parse([%value "<length>"]);
     expect.result(parse("56cm")).toBe(Ok(`Cm(56.)));
@@ -25,6 +27,7 @@ describe("standard values", ({test, _}) => {
     expect.result(parse("0")).toBe(Ok(`Zero));
     expect.result(parse("60")).toBeError();
   });
+
   test("<angle>", ({expect, _}) => {
     let parse = parse([%value "<angle>"]);
     expect.result(parse("1deg")).toBe(Ok(`Deg(1.)));
@@ -34,6 +37,7 @@ describe("standard values", ({test, _}) => {
     expect.result(parse("0")).toBe(Ok(`Deg(0.)));
     expect.result(parse("60")).toBeError();
   });
+
   test("<time>", ({expect, _}) => {
     let parse = parse([%value "<time>"]);
     expect.result(parse(".5s")).toBe(Ok(`S(0.5)));
@@ -43,6 +47,7 @@ describe("standard values", ({test, _}) => {
     expect.result(parse("0")).toBeError();
     expect.result(parse("60")).toBeError();
   });
+
   test("<frequency>", ({expect, _}) => {
     let parse = parse([%value "<frequency>"]);
     expect.result(parse("6hz")).toBe(Ok(`Hz(6.)));
@@ -52,6 +57,7 @@ describe("standard values", ({test, _}) => {
     expect.result(parse("0")).toBeError();
     expect.result(parse("60")).toBeError();
   });
+
   test("<resolution>", ({expect, _}) => {
     let parse = parse([%value "<resolution>"]);
     expect.result(parse("6x")).toBe(Ok(`Dppx(6.)));
@@ -61,28 +67,33 @@ describe("standard values", ({test, _}) => {
     expect.result(parse("0")).toBeError();
     expect.result(parse("60")).toBeError();
   });
+
   test("<percentage>", ({expect, _}) => {
     let parse = parse([%value "<percentage>"]);
     expect.result(parse("61%")).toBe(Ok(61.));
     expect.result(parse("62.3%")).toBe(Ok(62.3));
     expect.result(parse("63.4:")).toBeError();
   });
+
   test("<length-percentage>", ({expect, _}) => {
     let parse = parse([%value "<length-percentage>"]);
     expect.result(parse("64cm")).toBe(Ok(`Length(`Cm(64.))));
     expect.result(parse("65%")).toBe(Ok(`Percentage(65.)));
     expect.result(parse("66dsa")).toBeError();
   });
+
   test("keyword", ({expect, _}) => {
     let parse = parse([%value "gintoki"]);
     expect.result(parse("gintoki")).toBe(Ok());
     expect.result(parse("nope")).toBeError();
   });
+
   test("<ident>", ({expect, _}) => {
     let parse = parse([%value "<ident>"]);
     expect.result(parse("test")).toBe(Ok("test"));
     expect.result(parse("'ohno'")).toBeError();
   });
+
   test("<css-wide-keywords>", ({expect, _}) => {
     let parse = parse([%value "<css-wide-keywords>"]);
     expect.result(parse("initial")).toBe(Ok(`Initial));
@@ -90,6 +101,7 @@ describe("standard values", ({test, _}) => {
     expect.result(parse("unset")).toBe(Ok(`Unset));
     expect.result(parse("nope")).toBeError();
   });
+
   test("<string>", ({expect, _}) => {
     let parse = parse([%value "<string>"]);
     expect.result(parse("'tuturu'")).toBe(Ok("tuturu"));
@@ -97,17 +109,19 @@ describe("standard values", ({test, _}) => {
     expect.result(parse("ident")).toBeError();
     expect.result(parse("68.9")).toBeError();
   });
-  test("<custom-ident>", ({expect, _}) => {
+
+  /* test("<custom-ident>", ({expect, _}) => {
     let parse = parse([%value "<custom-ident>"]);
     expect.result(parse("potato")).toBe(Ok("potato"));
     expect.result(parse("'mayushii'")).toBeError();
     expect.result(parse("68.9")).toBeError();
-  });
+  }); */
   test("<dashed-ident>", ({expect, _}) => {
     let parse = parse([%value "<dashed-ident>"]);
     expect.result(parse("--random")).toBe(Ok("--random"));
     expect.result(parse("random'")).toBeError();
   });
+
   test("<url>", ({expect, _}) => {
     let parse = parse([%value "<url>"]);
     expect.result(parse("url(https://google.com)")).toBe(
@@ -125,4 +139,5 @@ describe("standard values", ({test, _}) => {
     expect.result(parse("#abcdefgh")).toBe(Ok("abcdefgh"));
     expect.result(parse("#abcdefghi")).toBeError();
   });
+
 });


### PR DESCRIPTION
This removes the concept of having interpolation type-safe and enforces all variables to be interpolated with `$()` syntax.