### PR TITLE
Add Css.label into all the style calls

### DIFF
--- a/packages/css-spec-parser/lib/Ast.re
+++ b/packages/css-spec-parser/lib/Ast.re
@@ -26,7 +26,7 @@ type combinator =
   | Static /* a b */
   | And /* a && b */
   | Or /* a || b */
-  | Xor /* a | b */;
+  | Xor; /* a | b */
 
 // TODO: non-terminals https://drafts.csswg.org/css-values-3/#component-types item 4
 [@deriving show({with_path: false})]

--- a/packages/demo/bucklescript/src/index.re
+++ b/packages/demo/bucklescript/src/index.re
@@ -57,28 +57,31 @@ module Component = [%styled.div {j|
 |j}
 ];
 
-let stilos = [%cx "box-shadow: 1px 2px 0 0 #ff0000 inset, 1px 2px 0 0 #ff0000"];
+let stilos = [%cx "box-shadow: 10px 10px 0 0 #ff0000 inset, 10px 10px 0 0 #ff0000"];
+let styles = CssJs.style(. [|CssJs.label("ComponentName"), CssJs.display(`block)|]);
 
 switch (ReactDOM.querySelector("#app")) {
   | Some(el) =>
     ReactDOM.render(
       <div className=stilos>
-        <App onClick=Js.log>
-          <Dynamic a="23"/>
-          <Component>
-            {React.string("test..")}
-          </Component>
-          <App2>
+        <div className=styles>
+          <App onClick=Js.log>
+            <Dynamic a="23"/>
             <Component>
-              <p>
-                {React.string("Demo of...")}
-              </p>
+              {"test.." |> React.string}
             </Component>
-          </App2>
-          <Link href="https://github.com/davesnx/styled-ppx">
-            {React.string("styled-ppx")}
-          </Link>
-        </App>
+            <App2>
+              <Component>
+                <p>
+                  {"Demo of..." |> React.string}
+                </p>
+              </Component>
+            </App2>
+            <Link href="https://github.com/davesnx/styled-ppx">
+              {"styled-ppx" |> React.string}
+            </Link>
+          </App>
+        </div>
       </div>,
       el
     )

--- a/packages/parser/css_lexer.re
+++ b/packages/parser/css_lexer.re
@@ -361,3 +361,6 @@ let parse_declaration_list = (~container_lnum=?, ~pos=?, css) =>
 
 let parse_declaration = (~container_lnum=?, ~pos=?, css) =>
   parse_string(~container_lnum?, ~pos?, Parser.declaration, css);
+
+let parse_stylesheet = (~container_lnum=?, ~pos=?, css) =>
+  parse_string(~container_lnum?, ~pos?, Parser.stylesheet, css);

--- a/packages/parser/css_types.re
+++ b/packages/parser/css_types.re
@@ -67,4 +67,6 @@ and Rule: {
     | Style_rule(Style_rule.t)
     | At_rule(At_rule.t);
 } = Rule
-and Stylesheet: {type t = with_loc(list(Rule.t));} = Stylesheet;
+and Stylesheet: {
+  type t = with_loc(list(Rule.t));
+} = Stylesheet;

--- a/packages/ppx/src/css_to_emotion.re
+++ b/packages/ppx/src/css_to_emotion.re
@@ -271,20 +271,20 @@ and render_style_rule = (~isUncurried, ident, rule: Style_rule.t): Parsetree.exp
   };
 };
 
-let bsEmotionLabel = (~loc, name) => {
+let bsEmotionLabel = (~loc, label) => {
   Exp.apply(
     Exp.ident(Emotion.lident(~loc, "label")),
     [
       (
         Nolabel,
-        Exp.constant(Pconst_string(name, loc, None)),
+        Exp.constant(Pconst_string(label, loc, None)),
       ),
     ],
   )
 };
 
-let addLabel = (~loc, name, emotionExprs) => {
-  [bsEmotionLabel(~loc, name), ...emotionExprs]
+let addLabel = (~loc, label, emotionExprs) => {
+  [bsEmotionLabel(~loc, label), ...emotionExprs]
 };
 
 let render_style_call = (declaration_list): Parsetree.expression => {

--- a/packages/ppx/test/snapshot/test.expected.re
+++ b/packages/ppx/test/snapshot/test.expected.re
@@ -955,7 +955,8 @@ module OneSingleProperty = {
   [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
-  let styles = CssJs.style(. [|CssJs.display(`block)|]);
+  let styles =
+    CssJs.style(. [|CssJs.label("lola"), CssJs.display(`block)|]);
   let make = (props: makeProps) => {
     let stylesObject = {"className": styles};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
@@ -1911,6 +1912,7 @@ module SingleQuoteStrings = {
     "createElement";
   let styles =
     CssJs.style(. [|
+      CssJs.label("lola"),
       CssJs.display(`flex),
       CssJs.unsafe("justifyContent", "center"),
     |]);
@@ -2869,6 +2871,7 @@ module MultiLineStrings = {
     "createElement";
   let styles =
     CssJs.style(. [|
+      CssJs.label("lola"),
       CssJs.display(`flex),
       CssJs.unsafe("justifyContent", "center"),
     |]);
@@ -3825,7 +3828,7 @@ module SelfClosingElement = {
   [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
-  let styles = CssJs.style(. [||]);
+  let styles = CssJs.style(. [|CssJs.label("lola")|]);
   let make = (props: makeProps) => {
     let stylesObject = {"className": styles};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
@@ -4781,6 +4784,7 @@ module ArrayStatic = {
     "createElement";
   let styles =
     CssJs.style(. [|
+      CssJs.label("lola"),
       CssJs.display(`flex),
       CssJs.unsafe("justifyContent", "center"),
     |]);
@@ -5740,6 +5744,7 @@ module StringInterpolation = {
     "createElement";
   let styles =
     CssJs.style(. [|
+      CssJs.label("lola"),
       CssJs.color(var),
       CssJs.unsafe("color", "trust-me"),
       CssJs.display(`block),
@@ -6705,7 +6710,11 @@ module DynamicComponent = {
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
   let styles = (~var) =>
-    CssJs.style(. [|CssJs.color(var), CssJs.display(`block)|]);
+    CssJs.style(. [|
+      CssJs.label("lola"),
+      CssJs.color(var),
+      CssJs.display(`block),
+    |]);
   let make = (props: makeProps('var)) => {
     let stylesObject = {"className": styles(~var=varGet(props))};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
@@ -7661,6 +7670,7 @@ module SelectorsMediaQueries = {
     "createElement";
   let styles =
     CssJs.style(. [|
+      CssJs.label("lola"),
       CssJs.media(
         "(min-width: 600px)",
         [|CssJs.unsafe("background", "blue")|],

--- a/packages/ppx/test/snapshot/test.expected.re
+++ b/packages/ppx/test/snapshot/test.expected.re
@@ -8631,7 +8631,11 @@ module ArrayDynamicComponent = {
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
   let styles = (~var) =>
-    CssJs.style(. [|CssJs.display(`block), CssJs.color(var)|]);
+    CssJs.style(. [|
+      CssJs.label("lola"),
+      CssJs.display(`block),
+      CssJs.color(var),
+    |]);
   let make = (props: makeProps('var)) => {
     let stylesObject = {"className": styles(~var=varGet(props))};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
@@ -10546,7 +10550,11 @@ module DynamicComponentWithDefaultValue = {
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
   let styles = (~var="green") =>
-    CssJs.style(. [|CssJs.display(`block), CssJs.color(var)|]);
+    CssJs.style(. [|
+      CssJs.label("lola"),
+      CssJs.display(`block),
+      CssJs.color(var),
+    |]);
   let make = (props: makeProps('var)) => {
     let stylesObject = {"className": styles(~var=?varGet(props))};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));

--- a/packages/ppx/test/snapshot/test.expected.re
+++ b/packages/ppx/test/snapshot/test.expected.re
@@ -956,7 +956,10 @@ module OneSingleProperty = {
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
   let styles =
-    CssJs.style(. [|CssJs.label("lola"), CssJs.display(`block)|]);
+    CssJs.style(. [|
+      CssJs.label("OneSingleProperty"),
+      CssJs.display(`block),
+    |]);
   let make = (props: makeProps) => {
     let stylesObject = {"className": styles};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
@@ -1912,7 +1915,7 @@ module SingleQuoteStrings = {
     "createElement";
   let styles =
     CssJs.style(. [|
-      CssJs.label("lola"),
+      CssJs.label("SingleQuoteStrings"),
       CssJs.display(`flex),
       CssJs.unsafe("justifyContent", "center"),
     |]);
@@ -2871,7 +2874,7 @@ module MultiLineStrings = {
     "createElement";
   let styles =
     CssJs.style(. [|
-      CssJs.label("lola"),
+      CssJs.label("MultiLineStrings"),
       CssJs.display(`flex),
       CssJs.unsafe("justifyContent", "center"),
     |]);
@@ -3828,7 +3831,7 @@ module SelfClosingElement = {
   [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
-  let styles = CssJs.style(. [|CssJs.label("lola")|]);
+  let styles = CssJs.style(. [|CssJs.label("SelfClosingElement")|]);
   let make = (props: makeProps) => {
     let stylesObject = {"className": styles};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
@@ -4784,7 +4787,7 @@ module ArrayStatic = {
     "createElement";
   let styles =
     CssJs.style(. [|
-      CssJs.label("lola"),
+      CssJs.label("ArrayStatic"),
       CssJs.display(`flex),
       CssJs.unsafe("justifyContent", "center"),
     |]);
@@ -5744,7 +5747,7 @@ module StringInterpolation = {
     "createElement";
   let styles =
     CssJs.style(. [|
-      CssJs.label("lola"),
+      CssJs.label("StringInterpolation"),
       CssJs.color(var),
       CssJs.unsafe("color", "trust-me"),
       CssJs.display(`block),
@@ -6711,7 +6714,7 @@ module DynamicComponent = {
     "createElement";
   let styles = (~var) =>
     CssJs.style(. [|
-      CssJs.label("lola"),
+      CssJs.label("DynamicComponent"),
       CssJs.color(var),
       CssJs.display(`block),
     |]);
@@ -7670,7 +7673,7 @@ module SelectorsMediaQueries = {
     "createElement";
   let styles =
     CssJs.style(. [|
-      CssJs.label("lola"),
+      CssJs.label("SelectorsMediaQueries"),
       CssJs.media(
         "(min-width: 600px)",
         [|CssJs.unsafe("background", "blue")|],
@@ -8642,7 +8645,7 @@ module ArrayDynamicComponent = {
     "createElement";
   let styles = (~var) =>
     CssJs.style(. [|
-      CssJs.label("lola"),
+      CssJs.label("ArrayDynamicComponent"),
       CssJs.display(`block),
       CssJs.color(var),
     |]);
@@ -10561,7 +10564,7 @@ module DynamicComponentWithDefaultValue = {
     "createElement";
   let styles = (~var="green") =>
     CssJs.style(. [|
-      CssJs.label("lola"),
+      CssJs.label("DynamicComponentWithDefaultValue"),
       CssJs.display(`block),
       CssJs.color(var),
     |]);


### PR DESCRIPTION
- Migrated from `Ppxlib` extensions to `preprocess_impl structure_item` since we needed to read all the structure items to get the module's name. 
- Refactored the renderStatic components into a more transparent approach, where the main entry point can read easily what's happening
- Added the CssJs.label with the component name

Note: This change allows us to move styled globals to a similar approach to render more than one structure_item for each declaration.