### PR TITLE
Shadowing makeProps by dynamic user props

### DIFF
--- a/packages/ppx/src/create.re
+++ b/packages/ppx/src/create.re
@@ -3,9 +3,7 @@ open Ppxlib;
 module Helper = Ast_helper;
 module Builder = Ppxlib.Ast_builder.Default;
 
-let withLoc = (~loc, txt) => {
-  { loc, txt }
-};
+let withLoc = (~loc, txt) => { loc, txt };
 
 /* fn(. ) */
 let uncurried = (~loc) => {
@@ -43,9 +41,9 @@ let dynamicStyles = (~loc, ~name, ~args, ~expr) => {
 };
 
 /*
-   [@bs.val] [@bs.module "react"] external createVariadicElement:
-   (string, Js.t({ .. })) => React.element =
-   "createElement";
+  [@bs.val] [@bs.module "react"] external createVariadicElement:
+  (string, Js.t({ .. })) => React.element =
+  "createElement";
  */
 let bindingCreateVariadicElement = (~loc) => {
   Helper.Str.primitive({
@@ -96,6 +94,7 @@ let bindingCreateVariadicElement = (~loc) => {
   });
 };
 
+/* ignore() */
 let applyIgnore = (~loc, expr) => {
   Helper.Exp.apply(
     ~loc,
@@ -341,7 +340,9 @@ let makeMakeProps = (~loc, ~customProps) => {
     | Some((params, props)) => (params, props)
     };
 
-  let makeProps = MakeProps.data
+  let dynamicPropNames = dynamicProps |> List.map(d => d.pld_name.txt);
+
+  let makeProps = MakeProps.get(dynamicPropNames)
     |> List.map(
       domProp =>
         switch (domProp) {

--- a/packages/ppx/src/makeProps.re
+++ b/packages/ppx/src/makeProps.re
@@ -487,6 +487,14 @@ let hasName = (prop, propName) => {
   }
 };
 
-let get = () => {
-  data |> List.filter((prop) => hasName(prop, "size"))
+let get = (propsToExclude) => {
+  let findInExclude = prop => List.find_opt(hasName(prop), propsToExclude);
+
+  data
+    |> List.filter(prop => {
+      prop
+        |> findInExclude
+        |> Option.is_none
+    }
+  );
 };

--- a/packages/ppx/src/makeProps.rei
+++ b/packages/ppx/src/makeProps.rei
@@ -1,0 +1,6 @@
+type alias = option(string);
+type event = { name: string, type_: string };
+type attr = { name: string, type_: string, alias };
+type domProp = | Event(event) | Attribute(attr);
+
+let get: (list(string)) => list(domProp);

--- a/packages/ppx/test/snapshot/test.expected.re
+++ b/packages/ppx/test/snapshot/test.expected.re
@@ -8675,7 +8675,7 @@ module ArrayDynamicComponent = {
 };
 module SequenceDynamicComponent = {
   [@bs.deriving abstract]
-  type makeProps('var) = {
+  type makeProps('size) = {
     [@bs.optional]
     ref: ReactDOM.domRef,
     [@bs.optional]
@@ -9277,8 +9277,6 @@ module SequenceDynamicComponent = {
     [@bs.optional]
     shapeRendering: string,
     [@bs.optional]
-    size: int,
-    [@bs.optional]
     sizes: string,
     [@bs.optional]
     slope: string,
@@ -9616,17 +9614,17 @@ module SequenceDynamicComponent = {
     onWaiting: ReactEvent.Media.t => unit,
     [@bs.optional]
     onWheel: ReactEvent.Wheel.t => unit,
-    var: 'var,
+    size: 'size,
   };
   [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
-  let styles = (~var) => {
+  let styles = (~size) => {
     Js.log("Logging when render");
-    CssJs.style(. [|CssJs.color(var), CssJs.display(`block)|]);
+    CssJs.style(. [|CssJs.width(width), CssJs.display(`block)|]);
   };
-  let make = (props: makeProps('var)) => {
-    let stylesObject = {"className": styles(~var=varGet(props))};
+  let make = (props: makeProps('size)) => {
+    let stylesObject = {"className": styles(~size=sizeGet(props))};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
     createVariadicElement("div", newProps);
   };

--- a/packages/ppx/test/snapshot/test.re
+++ b/packages/ppx/test/snapshot/test.re
@@ -86,11 +86,11 @@ module ArrayDynamicComponent = [%styled.div (~var) =>
 ];
 
 module SequenceDynamicComponent = [%styled.div
-  (~var) => {
+  (~size) => {
     Js.log("Logging when render");
 
   [|
-    [%css "color: $(var)"],
+    [%css "width: $(width)"],
     [%css "display: block;"]
   |]
   }


### PR DESCRIPTION
This PR fixes https://github.com/davesnx/styled-ppx/issues/143 by shadowing makeProps by dynamic user props. This allows users to define `size`, `x`, `y`, and many other common names for component APIs.

This would need to be documented in the next iteration of the docs.