### PR TITLE
feat: Create a dummy renderer

### DIFF
--- a/packages/parser/css_lexer.re
+++ b/packages/parser/css_lexer.re
@@ -7,7 +7,7 @@ module Sedlexing = Lex_buffer;
 module Parser = Css_parser;
 module Types = Css_types;
 
-/** Signals a lexing error at the provided source location.  */
+/** Signals a lexing error at the provided source location. */
 exception LexingError((Lexing.position, string));
 
 /** Signals a parsing error at the provided token and its start and end

--- a/packages/parser/css_types.re
+++ b/packages/parser/css_types.re
@@ -7,6 +7,7 @@ type dimension =
   | Frequency;
 
 module rec Component_value: {
+  [@deriving show({with_path: false})]
   type t =
     | Paren_block(list(with_loc(t)))
     | Bracket_block(list(with_loc(t)))
@@ -26,12 +27,14 @@ module rec Component_value: {
     | Variable(list(string));
 } = Component_value
 and Brace_block: {
+  [@deriving show({with_path: false})]
   type t =
     | Empty
     | Declaration_list(Declaration_list.t)
     | Stylesheet(Stylesheet.t);
 } = Brace_block
 and At_rule: {
+  [@deriving show({with_path: false})]
   type t = {
     name: with_loc(string),
     prelude: with_loc(list(with_loc(Component_value.t))),
@@ -40,6 +43,7 @@ and At_rule: {
   };
 } = At_rule
 and Declaration: {
+  [@deriving show({with_path: false})]
   type t = {
     name: with_loc(string),
     value: with_loc(list(with_loc(Component_value.t))),
@@ -48,14 +52,17 @@ and Declaration: {
   };
 } = Declaration
 and Declaration_list: {
+  [@deriving show({with_path: false})]
   type kind =
     | Declaration(Declaration.t)
     | Unsafe(Declaration.t)
     | At_rule(At_rule.t)
     | Style_rule(Style_rule.t);
+  [@deriving show({with_path: false})]
   type t = with_loc(list(kind));
 } = Declaration_list
 and Style_rule: {
+  [@deriving show({with_path: false})]
   type t = {
     prelude: with_loc(list(with_loc(Component_value.t))),
     block: Declaration_list.t,
@@ -63,10 +70,12 @@ and Style_rule: {
   };
 } = Style_rule
 and Rule: {
+  [@deriving show({with_path: false})]
   type t =
     | Style_rule(Style_rule.t)
     | At_rule(At_rule.t);
 } = Rule
 and Stylesheet: {
+  [@deriving show({with_path: false})]
   type t = with_loc(list(Rule.t));
 } = Stylesheet;

--- a/packages/parser/css_types.re
+++ b/packages/parser/css_types.re
@@ -7,7 +7,6 @@ type dimension =
   | Frequency;
 
 module rec Component_value: {
-  [@deriving show({with_path: false})]
   type t =
     | Paren_block(list(with_loc(t)))
     | Bracket_block(list(with_loc(t)))
@@ -27,14 +26,12 @@ module rec Component_value: {
     | Variable(list(string));
 } = Component_value
 and Brace_block: {
-  [@deriving show({with_path: false})]
   type t =
     | Empty
     | Declaration_list(Declaration_list.t)
     | Stylesheet(Stylesheet.t);
 } = Brace_block
 and At_rule: {
-  [@deriving show({with_path: false})]
   type t = {
     name: with_loc(string),
     prelude: with_loc(list(with_loc(Component_value.t))),
@@ -43,7 +40,6 @@ and At_rule: {
   };
 } = At_rule
 and Declaration: {
-  [@deriving show({with_path: false})]
   type t = {
     name: with_loc(string),
     value: with_loc(list(with_loc(Component_value.t))),
@@ -52,17 +48,15 @@ and Declaration: {
   };
 } = Declaration
 and Declaration_list: {
-  [@deriving show({with_path: false})]
   type kind =
     | Declaration(Declaration.t)
     | Unsafe(Declaration.t)
     | At_rule(At_rule.t)
     | Style_rule(Style_rule.t);
-  [@deriving show({with_path: false})]
+
   type t = with_loc(list(kind));
 } = Declaration_list
 and Style_rule: {
-  [@deriving show({with_path: false})]
   type t = {
     prelude: with_loc(list(with_loc(Component_value.t))),
     block: Declaration_list.t,
@@ -70,12 +64,8 @@ and Style_rule: {
   };
 } = Style_rule
 and Rule: {
-  [@deriving show({with_path: false})]
   type t =
     | Style_rule(Style_rule.t)
     | At_rule(At_rule.t);
 } = Rule
-and Stylesheet: {
-  [@deriving show({with_path: false})]
-  type t = with_loc(list(Rule.t));
-} = Stylesheet;
+and Stylesheet: {type t = with_loc(list(Rule.t));} = Stylesheet;

--- a/packages/parser/dune
+++ b/packages/parser/dune
@@ -1,7 +1,6 @@
 (menhir
  (modules css_parser)
- (flags --explain)
-)
+ (flags --explain))
 
 (library
  (name styled_ppx_css_parser)
@@ -9,6 +8,4 @@
  (public_name styled-ppx-css-parser)
  (libraries sedlex menhirLib ocaml-migrate-parsetree)
  (preprocess
-  (pps sedlex.ppx)
- )
-)
+  (pps sedlex.ppx)))

--- a/packages/renderer/ast_renderer.re
+++ b/packages/renderer/ast_renderer.re
@@ -1,81 +1,99 @@
 open Css_types;
-let container_lnum = 0;
-let pos = Lexing.dummy_pos;
-let ast = Css_lexer.parse_stylesheet(~container_lnum, ~pos, "html, body {display: flex}");
 
 let render_record = zippedRecord => {
-  let inner = zippedRecord |> List.map(((key, value)) =>
-    Printf.sprintf("  %s: %s", key, value)
-  ) |> String.concat(",\n")
+  let inner =
+    zippedRecord
+    |> List.map(((key, value)) => Printf.sprintf("  %s: %s", key, value))
+    |> String.concat(",\n");
 
   Printf.sprintf("{\n%s\n}", inner);
-}
+};
 
 let rec render_stylesheet = (ast: Stylesheet.t) => {
   let inner = ast |> fst |> List.map(render_rule) |> String.concat(", ");
   "Stylesheet([" ++ inner ++ "])";
-} and render_rule = (ast: Rule.t) => {
-  switch (ast) {
-    | Style_rule(style_rule) => render_style_rule(style_rule)
-    | At_rule(at_rule) => render_at_rule(at_rule)
-  }
-} and render_style_rule = (ast:  Style_rule.t) => {
-  render_record([("prelude", ast.prelude |> render_declaration_value), ("block", render_declaration_list(ast.block))])
 }
- and render_at_rule = (ast: At_rule.t) => {
-   render_record([("prelude", ast.prelude |> render_declaration_value), ("block", render_brace_block(ast.block))])
- }
- and render_brace_block = (ast) => {
-   switch (ast: Brace_block.t) {
-     | Empty => "Empty"
-    | Declaration_list(declaration_list) => render_declaration_list(declaration_list)
-    | Stylesheet(stylesheet) => render_stylesheet(stylesheet)
-   }
- }
+and render_rule = (ast: Rule.t) => {
+  switch (ast) {
+  | Style_rule(style_rule) => render_style_rule(style_rule)
+  | At_rule(at_rule) => render_at_rule(at_rule)
+  };
+}
+and render_style_rule = (ast: Style_rule.t) => {
+  render_record([
+    ("prelude", ast.prelude |> render_declaration_value),
+    ("block", render_declaration_list(ast.block)),
+  ]);
+}
+and render_at_rule = (ast: At_rule.t) => {
+  render_record([
+    ("prelude", ast.prelude |> render_declaration_value),
+    ("block", render_brace_block(ast.block)),
+  ]);
+}
+and render_brace_block = ast => {
+  switch ((ast: Brace_block.t)) {
+  | Empty => "Empty"
+  | Declaration_list(declaration_list) =>
+    render_declaration_list(declaration_list)
+  | Stylesheet(stylesheet) => render_stylesheet(stylesheet)
+  };
+}
 and render_declaration_kind = (ast: Declaration_list.kind) => {
   switch (ast) {
-    | Declaration(declaration) => render_declaration(declaration)
-    | Unsafe(unsafe) => render_declaration(unsafe)
-    | Style_rule(style_rule) => render_style_rule(style_rule)
-    | At_rule(at_rule) => render_at_rule(at_rule)
-  }
-} and render_declaration_list = (ast: Declaration_list.t) => {
-  let inner = ast |> fst |> List.map(render_declaration_kind) |> String.concat(", ");
+  | Declaration(declaration) => render_declaration(declaration)
+  | Unsafe(unsafe) => render_declaration(unsafe)
+  | Style_rule(style_rule) => render_style_rule(style_rule)
+  | At_rule(at_rule) => render_at_rule(at_rule)
+  };
+}
+and render_declaration_list = (ast: Declaration_list.t) => {
+  let inner =
+    ast |> fst |> List.map(render_declaration_kind) |> String.concat(", ");
   "Declaration([" ++ inner ++ "])";
 }
 and render_declaration = (ast: Declaration.t) => {
-  render_record([("name", ast.name |> fst), ("value", ast.value |> render_declaration_value), ("important", ast.important |> fst |> string_of_bool)])
-} and render_declaration_value = (ast: with_loc(list(with_loc(Component_value.t)))) => {
-  let inner = ast |> fst |> List.map( render_component_value) |> String.concat(", ");
-  "[" ++ inner ++ "]"
+  render_record([
+    ("name", ast.name |> fst),
+    ("value", ast.value |> render_declaration_value),
+    ("important", ast.important |> fst |> string_of_bool),
+  ]);
+}
+and render_declaration_value =
+    (ast: with_loc(list(with_loc(Component_value.t)))) => {
+  let inner =
+    ast |> fst |> List.map(render_component_value) |> String.concat(", ");
+  "[" ++ inner ++ "]";
 }
 and render_component_value = (ast: with_loc(Component_value.t)) => {
   let value = ast |> fst;
   switch (value) {
-    | Paren_block(_) => "Paren_block(_)"
-    | Bracket_block(_) => "Bracket_block(_)"
-    | Percentage(string) => "Percentage(" ++ string ++ ")"
-    | Ident(string) => "Ident(" ++ string ++ ")"
-    | String(string) => "String(" ++ string ++ ")"
-    | Selector(string) => "Selector(" ++ string ++ ")"
-    | Uri(string) => "Uri(" ++ string ++ ")"
-    | Operator(string) => "Operator(" ++ string ++ ")"
-    | Delim(string) => "Delim(" ++ string ++ ")"
-    | Function(_) => "Function(_)"
-    | Hash(string) => "Hash(" ++ string ++ ")"
-    | Number(string) => "Number(" ++ string ++ ")"
-    | Unicode_range(string) => "Unicode_range(" ++ string ++ ")"
-    | Float_dimension(_) => failwith("TODO")
-    | Dimension(_) => "Dimension(_)"
-    | Variable(_) => "Variable(_)"
-  }
-}
+  | Paren_block(_) => "Paren_block(_)"
+  | Bracket_block(_) => "Bracket_block(_)"
+  | Percentage(string) => "Percentage(" ++ string ++ ")"
+  | Ident(string) => "Ident(" ++ string ++ ")"
+  | String(string) => "String(" ++ string ++ ")"
+  | Selector(string) => "Selector(" ++ string ++ ")"
+  | Uri(string) => "Uri(" ++ string ++ ")"
+  | Operator(string) => "Operator(" ++ string ++ ")"
+  | Delim(string) => "Delim(" ++ string ++ ")"
+  | Function(_) => "Function(_)"
+  | Hash(string) => "Hash(" ++ string ++ ")"
+  | Number(string) => "Number(" ++ string ++ ")"
+  | Unicode_range(string) => "Unicode_range(" ++ string ++ ")"
+  | Float_dimension(_) => failwith("TODO")
+  | Dimension(_) => "Dimension(_)"
+  | Variable(_) => "Variable(_)"
+  };
+};
 
-print_endline(render_stylesheet(ast))
+let container_lnum = 0;
+let pos = Lexing.dummy_pos;
+let ast =
+  Css_lexer.parse_stylesheet(
+    ~container_lnum,
+    ~pos,
+    "html, body {display: flex}",
+  );
 
-/* let parse_declaration = (~container_lnum=?, ~pos=?, css) =>
-  parse_string(~container_lnum?, ~pos?, Parser.declaration, css);
-
-let parse_stylesheet = (~container_lnum=?, ~pos=?, css) =>
-  parse_string(~container_lnum?, ~pos?, Parser.stylesheet, css);
- */
+print_endline(render_stylesheet(ast));

--- a/packages/renderer/ast_renderer.re
+++ b/packages/renderer/ast_renderer.re
@@ -9,6 +9,13 @@ let render_record = zippedRecord => {
   Printf.sprintf("{\n%s\n}", inner);
 };
 
+let dimension_of_string =
+  fun
+  | Length => "Length"
+  | Angle => "Angle"
+  | Time => "Time"
+  | Frequency => "Frequency";
+
 let rec render_stylesheet = (ast: Stylesheet.t) => {
   let inner = ast |> fst |> List.map(render_rule) |> String.concat(", ");
   "Stylesheet([" ++ inner ++ "])";
@@ -68,8 +75,14 @@ and render_declaration_value =
 and render_component_value = (ast: with_loc(Component_value.t)) => {
   let value = ast |> fst;
   switch (value) {
-  | Paren_block(_) => "Paren_block(_)"
-  | Bracket_block(_) => "Bracket_block(_)"
+  | Paren_block(block) =>
+    let block =
+      block |> List.map(render_component_value) |> String.concat(", ");
+    "Paren_block(" ++ block ++ ")";
+  | Bracket_block(block) =>
+    let block =
+      block |> List.map(render_component_value) |> String.concat(", ");
+    "Bracket_block(" ++ block ++ ")";
   | Percentage(string) => "Percentage(" ++ string ++ ")"
   | Ident(string) => "Ident(" ++ string ++ ")"
   | String(string) => "String(" ++ string ++ ")"
@@ -77,13 +90,24 @@ and render_component_value = (ast: with_loc(Component_value.t)) => {
   | Uri(string) => "Uri(" ++ string ++ ")"
   | Operator(string) => "Operator(" ++ string ++ ")"
   | Delim(string) => "Delim(" ++ string ++ ")"
-  | Function(_) => "Function(_)"
+  | Function(name, body) =>
+    let body =
+      body |> fst |> List.map(render_component_value) |> String.concat(", ");
+    "Function(" ++ fst(name) ++ ", " ++ body ++ ")";
   | Hash(string) => "Hash(" ++ string ++ ")"
   | Number(string) => "Number(" ++ string ++ ")"
   | Unicode_range(string) => "Unicode_range(" ++ string ++ ")"
-  | Float_dimension(_) => failwith("TODO")
-  | Dimension(_) => "Dimension(_)"
-  | Variable(_) => "Variable(_)"
+  | Float_dimension((a, b, dimension)) =>
+    "Float_dimension("
+    ++ a
+    ++ ", "
+    ++ b
+    ++ ", "
+    ++ dimension_of_string(dimension)
+    ++ ")"
+  | Dimension((a, b)) => "Dimension(" ++ a ++ ", " ++ b ++ ")"
+  | Variable(variables) =>
+    "Variable(" ++ String.concat(", ", variables) ++ ")"
   };
 };
 

--- a/packages/renderer/ast_renderer.re
+++ b/packages/renderer/ast_renderer.re
@@ -1,0 +1,61 @@
+open Css_types;
+
+let container_lnum = 0;
+let pos = Lexing.dummy_pos;
+let ast = Css_lexer.parse_declaration_list(~container_lnum, ~pos, "display: flex");
+
+let render_record = zippedRecord => {
+  let inner = zippedRecord |> List.map(((key, value)) =>
+    Printf.sprintf("  %s: %s", key, value)
+  ) |> String.concat(",\n")
+
+  Printf.sprintf("{\n%s\n}", inner);
+}
+
+let rec render_declaration_kind = (ast: Declaration_list.kind): string => {
+  switch (ast) {
+    | Declaration(declaration) => render_declaration(declaration)
+    | Unsafe(unsafe) => render_declaration(unsafe)
+    | At_rule(_at_rule) => failwith("TODO")
+    | Style_rule(_style_rule) => failwith("TODO")
+  }
+} and render_declaration_list = (ast: Declaration_list.t): string => {
+  let inner = ast |> fst |> List.map(render_declaration_kind) |> String.concat(", ");
+  "Declaration(" ++ inner ++ ")";
+}
+and render_declaration = (ast: Declaration.t): string => {
+  render_record([("name", ast.name |> fst), ("value", ast.value |> fst |> render_declaration_value), ("important", ast.important |> fst |> string_of_bool)])
+} and render_declaration_value = (ast): string => {
+  let inner = ast |> List.map(render_value) |> String.concat(", ");
+  "[" ++ inner ++ "]"
+}
+and render_value = (ast): string => {
+  let value = ast |> fst;
+  switch (value) {
+    | Paren_block(_) => "Paren_block(_)"
+    | Bracket_block(_) => "Bracket_block(_)"
+    | Percentage(string) => "Percentage(" ++ string ++ ")"
+    | Ident(string) => "Ident(" ++ string ++ ")"
+    | String(string) => "String(" ++ string ++ ")"
+    | Selector(string) => "Selector(" ++ string ++ ")"
+    | Uri(string) => "Uri(" ++ string ++ ")"
+    | Operator(string) => "Operator(" ++ string ++ ")"
+    | Delim(string) => "Delim(" ++ string ++ ")"
+    | Function(_) => "Function(_)"
+    | Hash(string) => "Hash(" ++ string ++ ")"
+    | Number(string) => "Number(" ++ string ++ ")"
+    | Unicode_range(string) => "Unicode_range(" ++ string ++ ")"
+    | Float_dimension(_) => failwith("TODO")
+    | Dimension(_) => "Dimension(_)"
+    | Variable(_) => "Variable(_)"
+  }
+}
+
+print_endline(render_declaration_list(ast))
+
+/* let parse_declaration = (~container_lnum=?, ~pos=?, css) =>
+  parse_string(~container_lnum?, ~pos?, Parser.declaration, css);
+
+let parse_stylesheet = (~container_lnum=?, ~pos=?, css) =>
+  parse_string(~container_lnum?, ~pos?, Parser.stylesheet, css);
+ */

--- a/packages/renderer/dune
+++ b/packages/renderer/dune
@@ -1,0 +1,5 @@
+(executable
+ (name ast_renderer)
+ (public_name renderer)
+ (libraries styled-ppx-css-parser)
+ (link_flags -linkall))


### PR DESCRIPTION
This would allow us to visualise better the AST and discuss the changes over it.

It's just an executable as a package. I would organize better most of the packages such as css_to_emotion and declarations_to_emotion with this ast_renderer. I consider the 3 of them "renderers" and we might have another one that prints CSS.

So, renderers are anything that takes a CSS AST, some produce bs-css bindings and some strings.