### PR TITLE
Add support to `:not` selector

### DIFF
--- a/packages/ppx/src/css_to_emotion.re
+++ b/packages/ppx/src/css_to_emotion.re
@@ -237,12 +237,21 @@ and render_style_rule = (~isUncurried, ident, rule: Style_rule.t): Parsetree.exp
       };
     let ident = Helper.Exp.ident(~loc, CssJs.lident(~loc, pseudoclass));
     Helper.Exp.apply(~loc=rule.Style_rule.loc, ident, [(Nolabel, dl_expr)]);
-  | /* nth-child & friends */
+  /* :not function & friends */
+  |
+    [
+      (Ident(_), _),
+      (Delim(":"), _),
+      (Function((_pc, loc), (_args, _args_loc)), _f_loc)
+    ]
+   /* nth-child & friends */
+  |
     [
       (Selector("&"), _),
       (Delim(":"), _),
       (Function((_pc, loc), (_args, _args_loc)), _f_loc),
-    ] =>
+    ]
+    =>
     // TODO: parses and use the correct functions instead of just strings selector
     let ident = Helper.Exp.ident(~loc, CssJs.lident(~loc, "selector"));
     let selector =

--- a/packages/ppx/test/snapshot/test.expected.re
+++ b/packages/ppx/test/snapshot/test.expected.re
@@ -4,6 +4,7 @@ ignore(
     [|CssJs.margin(`zero)|],
   ),
 );
+ignore(CssJs.selector({js|p:not(.active)|js}, [|CssJs.display(`flex)|]));
 module ShoudNotBreakOtherModulesPpxsWithStringAsPayload = [%ppx ""];
 module ShoudNotBreakOtherModulesPpxsWithMultiStringAsPayload = [%ppx
   {| stuff |}

--- a/packages/ppx/test/snapshot/test.re
+++ b/packages/ppx/test/snapshot/test.re
@@ -7,6 +7,12 @@ If you are looking to add some tests for CSS support, check packages/ppx/test/na
   }
 |}];
 
+[%styled.global {|
+  p:not(.active){
+    display: flex;
+  }
+|}]
+
 module ShoudNotBreakOtherModulesPpxsWithStringAsPayload = [%ppx ""];
 module ShoudNotBreakOtherModulesPpxsWithMultiStringAsPayload = [%ppx {| stuff |}];
 


### PR DESCRIPTION
Now `:not` and others css functions works as css rules in the `styled.global` extension

closes #130 