### PR TITLE
Implement removing props from the object passed down

### DIFF
--- a/packages/ppx/src/main.re
+++ b/packages/ppx/src/main.re
@@ -5,17 +5,19 @@ module Helper = Ast_helper;
 module Config = Ppx_config;
 
 let raiseError = (~loc, ~description, ~example, ~link) => {
-  let error = switch (example) {
+  let error =
+    switch (example) {
     | Some(e) =>
       Location.raise_errorf(
         ~loc,
-        "%s\n\n%s\n\nMore info: %s", description, e, link
+        "%s\n\n%s\n\nMore info: %s",
+        description,
+        e,
+        link,
       )
-    | None => Location.raise_errorf(
-        ~loc,
-        "%s\n\nMore info: %s", description, link
-      )
-  };
+    | None =>
+      Location.raise_errorf(~loc, "%s\n\nMore info: %s", description, link)
+    };
 
   raise(error);
 };
@@ -53,7 +55,8 @@ let getType = pattern =>
 
 let getAlias = (pattern, label) =>
   switch (pattern.ppat_desc) {
-  | Ppat_alias(_, {txt, _}) | Ppat_var({txt, _}) => txt
+  | Ppat_alias(_, {txt, _})
+  | Ppat_var({txt, _}) => txt
   | Ppat_any => "_"
   | _ => getLabel(label)
   };
@@ -74,23 +77,24 @@ let rec getArgs = (expr, list) => {
       ~loc=pattern.ppat_loc,
       ~description="Dynamic components are defined with labeled arguments.",
       ~example=Some("[%styled.div (~a, ~b) => {}]"),
-      ~link="https://reasonml.org/docs/manual/latest/function#labeled-arguments",
-    );
+      ~link=
+        "https://reasonml.org/docs/manual/latest/function#labeled-arguments",
+    )
   | _ => (expr, list)
   };
 };
 
-let getIsEmpty = (param) => {
+let getIsEmpty = param => {
   switch (param.ppat_desc) {
-    /* Not complely sure if this checks emptyness */
-    | Ppat_construct(_, _) => true
-    | _ => false
-  }
+  /* Not completly sure if this checks emptyness */
+  | Ppat_construct(_, _) => true
+  | _ => false
+  };
 };
 
 let getLabeledArgs = (label, defaultValue, param, expr) => {
   /* Get the first argument of the Pexp_fun, since it's a recursive type.
-  getArgs gets all the function parameters from the next parsetree */
+     getArgs gets all the function parameters from the next parsetree */
   let alias = getAlias(param, label);
   let type_ = getType(param);
   let firstArg = (label, defaultValue, param, alias, param.ppat_loc, type_);
@@ -98,99 +102,65 @@ let getLabeledArgs = (label, defaultValue, param, expr) => {
   if (getIsEmpty(param)) {
     raiseError(
       ~loc=param.ppat_loc,
-      ~description="A dynamic component without props doesn't make much sense. Try to translate into static.",
+      ~description=
+        "A dynamic component without props doesn't make much sense. Try to translate into static.",
       ~example=None,
       ~link="https://styled-ppx.vercel.app/usage/dynamic-components",
     );
-  }
+  };
 
   if (getNotLabelled(label)) {
     raiseError(
       ~loc=param.ppat_loc,
       ~description="Dynamic components are defined with labeled arguments.",
       ~example=Some("[%styled.div (~a, ~b) => {}]"),
-      ~link="https://reasonml.org/docs/manual/latest/function#labeled-arguments",
+      ~link=
+        "https://reasonml.org/docs/manual/latest/function#labeled-arguments",
     );
-  }
+  };
 
   getArgs(expr, [firstArg]);
 };
 
 let styleVariableName = "styles";
 
-let parsePayloadStyle = (
-  payload,
-  loc,
-) => {
+let parsePayloadStyle = (payload, loc) => {
   let loc_start = loc.Location.loc_start;
   /* TODO: Bring back "delimiter location conditional logic" */
   /* let loc_start =
-  switch (delim) {
-  | None => payload.loc.Location.loc_start
-  | Some(s) => {
-      ...payload.loc.Location.loc_start,
-      Lexing.pos_cnum:
-        payload.loc.Location.loc_start.Lexing.pos_cnum + String.length(s) + 1,
-    }
-  }; */
+     switch (delim) {
+     | None => payload.loc.Location.loc_start
+     | Some(s) => {
+         ...payload.loc.Location.loc_start,
+         Lexing.pos_cnum:
+           payload.loc.Location.loc_start.Lexing.pos_cnum + String.length(s) + 1,
+       }
+     }; */
 
   Css_lexer.parse_declaration_list(
     ~container_lnum=loc_start.Lexing.pos_lnum,
     ~pos=loc_start,
-    payload
+    payload,
   );
 };
 
-let getLastSequence = (expr) => {
-  let rec inner = (expr) =>
+let getLastSequence = expr => {
+  let rec inner = expr =>
     switch (expr.pexp_desc) {
-      | Pexp_sequence(_, sequence) => inner(sequence)
-      | _ => expr
-  };
+    | Pexp_sequence(_, sequence) => inner(sequence)
+    | _ => expr
+    };
 
   inner(expr);
 };
 
-let renderStyledDynamic = (
-  ~loc,
-  ~htmlTag,
-  ~label,
-  ~moduleName,
-  ~defaultValue,
-  ~param,
-  ~body
-) => {
+let renderStyledDynamic =
+    (~loc, ~htmlTag, ~label, ~moduleName, ~defaultValue, ~param, ~body) => {
   let (functionExpr, labeledArguments) =
     getLabeledArgs(label, defaultValue, param, body);
 
-  let propExpr = Builder.pexp_ident(~loc, {txt: Lident("props"), loc});
-  let propToGetter = str => str ++ "Get";
-
-  /* (~arg1=arg1Get(props), ~arg2=arg2Get(props), ...) */
-  let styledArguments =
-    List.map(
-      ((arg, _, _, _, _, _)) => {
-        let label = arg |> getLabel |> propToGetter;
-        let value =
-          Builder.pexp_ident(~loc, {txt: Lident(label), loc});
-        (arg, Builder.pexp_apply(~loc, value, [(Nolabel, propExpr)]));
-      },
-      labeledArguments,
-    );
-
-  let unit = (Nolabel, Builder.pexp_construct(~loc, {txt: Lident("()"), loc}, None));
-
-  /* let styles = styled(...) */
-  let styledFunctionExpr =
-    Builder.pexp_apply(
-      ~loc,
-      Builder.pexp_ident(~loc, {txt: Lident(styleVariableName), loc}),
-      /* Last argument is a unit to avoid the warning of optinal labeled args */
-      styledArguments @ [unit],
-    );
-
   let variableList =
-    List.map(
+    labeledArguments |> List.map(
       ((arg, optionalArg, _, _, loc, type_)) => {
         let label = getLabel(arg);
         let (kind, type_) =
@@ -200,122 +170,149 @@ let renderStyledDynamic = (
           };
 
         (arg, Option.is_some(optionalArg), kind, type_);
-      },
-      labeledArguments,
+      }
     );
 
   /* ('a, 'b) */
   let makePropsParameters: list(core_type) =
     variableList
     |> List.filter_map(
-      fun
-      | (_, _, `Open, type_) => Some(type_)
-      | _ => None,
-    );
+         fun
+         | (_, _, `Open, type_) => Some(type_)
+         | _ => None,
+       );
 
   /* type makeProps('a) = { a: 'a } */
   let variableMakeProps =
     variableList
     |> List.map(((arg, optional, _, type_)) =>
-        Create.customPropLabel(~loc, getLabel(arg), type_, optional)
+         Create.customPropLabel(~loc, getLabel(arg), type_, optional)
+       );
+
+  let propsExpr = Builder.pexp_ident(~loc, {txt: Lident("props"), loc});
+  let propToGetter = str => str ++ "Get";
+
+  /* (~arg1=arg1Get(props), ~arg2=arg2Get(props), ...) */
+  let styledArguments =
+    List.map(
+      ((arg, _, _, _, _, _)) => {
+        let label = arg |> getLabel |> propToGetter;
+        let value = Builder.pexp_ident(~loc, {txt: Lident(label), loc});
+        (arg, Builder.pexp_apply(~loc, value, [(Nolabel, propsExpr)]));
+      },
+      labeledArguments,
     );
 
-  let styles = switch (functionExpr.pexp_desc) {
-    | Pexp_constant(Pconst_string(str, loc, _label)) =>
-      parsePayloadStyle(
-        str,
-        loc
-      )
-        |> Css_to_emotion.render_declarations
-        |> Css_to_emotion.addLabel(~loc, moduleName)
-        |> Builder.pexp_array(~loc)
-        |> Css_to_emotion.render_style_call;
-    | Pexp_array(arr) =>
-        arr
-          |> List.rev
-          |> Css_to_emotion.addLabel(~loc, moduleName)
-          |> Builder.pexp_array(~loc)
-          |> Css_to_emotion.render_style_call;
-    | Pexp_sequence(expr, sequence) => {
-      /* Generate a new sequence where the last expression is
-        wrapped in render_style_call and render the other expressions. */
-      let styles = sequence |> getLastSequence |> Css_to_emotion.render_style_call;
-      Builder.pexp_sequence(~loc, expr, styles);
-    }
-    /* TODO: With this default case we support all expressions here.
-    Users might find this confusing, we could give some warnings before the type-checker does. */
-    | _ => functionExpr
-  };
+  let unit = (
+    Nolabel,
+    Builder.pexp_construct(~loc, {txt: Lident("()"), loc}, None),
+  );
 
-  Builder.pmod_structure(~loc, [
-    Create.makeMakeProps(
+    /* let styles = styles(...) */
+  let stylesFunctionCall =
+    Builder.pexp_apply(
       ~loc,
-      ~customProps=Some((makePropsParameters, variableMakeProps))
-    ),
-    Create.bindingCreateVariadicElement(~loc),
-    Create.defineDeletePropFn(~loc),
-    Create.dynamicStyles(
-      ~loc,
-      ~name=styleVariableName,
-      ~args=labeledArguments,
-      ~expr=styles,
-    ),
-    Create.component(
-      ~loc,
-      ~htmlTag,
-      ~styledExpr=styledFunctionExpr,
-      ~params=makePropsParameters,
-      ~variables=variableList
-    ),
-  ]);
+      Builder.pexp_ident(~loc, {txt: Lident(styleVariableName), loc}),
+      /* Last argument is a unit to avoid the warning of optinal labeled args */
+      styledArguments @ [unit],
+    );
+
+  let styles =
+    switch (functionExpr.pexp_desc) {
+    | Pexp_constant(Pconst_string(str, loc, _label)) =>
+      parsePayloadStyle(str, loc)
+      |> Css_to_emotion.render_declarations
+      |> Css_to_emotion.addLabel(~loc, moduleName)
+      |> Builder.pexp_array(~loc)
+      |> Css_to_emotion.render_style_call
+    | Pexp_array(arr) =>
+      arr
+      |> List.rev
+      |> Css_to_emotion.addLabel(~loc, moduleName)
+      |> Builder.pexp_array(~loc)
+      |> Css_to_emotion.render_style_call
+    | Pexp_sequence(expr, sequence) =>
+      /* Generate a new sequence where the last expression is
+         wrapped in render_style_call and render the other expressions. */
+      let styles =
+        sequence |> getLastSequence |> Css_to_emotion.render_style_call;
+      Builder.pexp_sequence(~loc, expr, styles);
+    /* TODO: With this default case we support all expressions here.
+       Users might find this confusing, we could give some warnings before the type-checker does. */
+    | _ => functionExpr
+    };
+
+  Builder.pmod_structure(
+    ~loc,
+    [
+      Create.makeMakeProps(
+        ~loc,
+        ~customProps=Some((makePropsParameters, variableMakeProps)),
+      ),
+      Create.bindingCreateVariadicElement(~loc),
+      Create.defineDeletePropFn(~loc),
+      Create.dynamicStyles(
+        ~loc,
+        ~name=styleVariableName,
+        ~args=labeledArguments,
+        ~expr=styles,
+      ),
+      Create.component(
+        ~loc,
+        ~htmlTag,
+        ~styledExpr=stylesFunctionCall,
+        ~makePropTypes=makePropsParameters,
+        ~labeledArguments
+      ),
+    ],
+  );
 };
 
 let renderStyledComponent = (~loc, ~htmlTag, styles) => {
-  let styledExpr =
+  let styleReference =
     Builder.pexp_ident(~loc, {txt: Lident(styleVariableName), loc});
 
-  Builder.pmod_structure(~loc, [
-    Create.makeMakeProps(~loc, ~customProps=None),
-    Create.bindingCreateVariadicElement(~loc),
-    Create.defineDeletePropFn(~loc),
-    Create.styles(
-      ~loc,
-      ~name=styleVariableName,
-      ~expr=styles
-    ),
-    Create.component(~loc, ~htmlTag, ~styledExpr, ~params=[], ~variables=[])
-  ]);
+  Builder.pmod_structure(
+    ~loc,
+    [
+      Create.makeMakeProps(~loc, ~customProps=None),
+      Create.bindingCreateVariadicElement(~loc),
+      Create.defineDeletePropFn(~loc),
+      Create.styles(~loc, ~name=styleVariableName, ~expr=styles),
+      Create.component(
+        ~loc,
+        ~htmlTag,
+        ~styledExpr=styleReference,
+        ~makePropTypes=[],
+        ~labeledArguments=[]
+      ),
+    ],
+  );
 };
 
 let string_payload =
   Ast_pattern.(
-    pstr(
-      pstr_eval(
-        pexp_constant(pconst_string(__', __, __)),
-        nil
-      ) ^:: nil,
-    ),
-);
+    pstr(pstr_eval(pexp_constant(pconst_string(__', __, __)), nil) ^:: nil)
+  );
 
-let any_payload =
-  Ast_pattern.(single_expr_payload(__));
+let any_payload = Ast_pattern.(single_expr_payload(__));
 
 /* TODO: Throw better errors when this pattern doesn't match */
 let static_pattern =
   Ast_pattern.(
     pstr(
       pstr_eval(
-        map(~f=(catch, payload, _, delim) =>
-          catch(`String((payload, delim))),
-          pexp_constant(pconst_string(__', __, __))
+        map(
+          ~f=(catch, payload, _, delim) => catch(`String((payload, delim))),
+          pexp_constant(pconst_string(__', __, __)),
         )
-        ||| map(~f=(catch, payload) =>
-          catch(`Array((payload))),
-          pexp_array(__)
-        ),
-        nil
+        ||| map(
+              ~f=(catch, payload) => catch(`Array(payload)),
+              pexp_array(__),
+            ),
+        nil,
       )
-    ^:: nil
+      ^:: nil,
     )
   );
 
@@ -327,32 +324,34 @@ let extensions = [
     Ppxlib.Extension.Context.Expression,
     static_pattern,
     (~loc, ~path as _, payload) => {
-      switch (payload) {
-        | `String(({ loc, txt }, _delim)) =>
-          parsePayloadStyle(txt, loc)
-            |> Css_to_emotion.render_declarations
-            |> Builder.pexp_array(~loc)
-            |> Css_to_emotion.render_style_call;
-        | `Array(arr) => arr |> Builder.pexp_array(~loc) |> Css_to_emotion.render_style_call;
-      }
+    switch (payload) {
+    | `String({loc, txt}, _delim) =>
+      parsePayloadStyle(txt, loc)
+      |> Css_to_emotion.render_declarations
+      |> Builder.pexp_array(~loc)
+      |> Css_to_emotion.render_style_call
+    | `Array(arr) =>
+      arr |> Builder.pexp_array(~loc) |> Css_to_emotion.render_style_call
     }
-  ),
+  }),
   Ppxlib.Extension.declare(
     compatibleModeWithBsEmotionPpx ? "css_" : "css",
     Ppxlib.Extension.Context.Expression,
     string_payload,
     (~loc as _, ~path as _, payload, _label, _) => {
       let loc_start = payload.loc.Location.loc_start;
-      let declarationListValues = Css_lexer.parse_declaration(
-        ~container_lnum=loc_start.Lexing.pos_lnum,
-        ~pos=loc_start,
-        payload.txt
-      ) |> Css_to_emotion.render_declaration;
+      let declarationListValues =
+        Css_lexer.parse_declaration(
+          ~container_lnum=loc_start.Lexing.pos_lnum,
+          ~pos=loc_start,
+          payload.txt,
+        )
+        |> Css_to_emotion.render_declaration;
       /* TODO: Instead of getting the first element,
-       fail when there's more than one declaration or
-      make a mechanism to flatten all the properties */
+          fail when there's more than one declaration or
+         make a mechanism to flatten all the properties */
       List.nth(declarationListValues, 0);
-    }
+    },
   ),
   Ppxlib.Extension.declare(
     "styled.global",
@@ -360,13 +359,14 @@ let extensions = [
     string_payload,
     (~loc as _, ~path as _, payload, _label, _) => {
       let loc_start = payload.loc.Location.loc_start;
-      let stylesheet = Css_lexer.parse_stylesheet(
-        ~container_lnum=loc_start.Lexing.pos_lnum,
-        ~pos=loc_start,
-        payload.txt
-      );
-     Css_to_emotion.render_global(stylesheet);
-    }
+      let stylesheet =
+        Css_lexer.parse_stylesheet(
+          ~container_lnum=loc_start.Lexing.pos_lnum,
+          ~pos=loc_start,
+          payload.txt,
+        );
+      Css_to_emotion.render_global(stylesheet);
+    },
   ),
   Ppxlib.Extension.declare(
     "keyframe",
@@ -374,13 +374,14 @@ let extensions = [
     string_payload,
     (~loc as _, ~path as _, payload, _label, _) => {
       let loc_start = payload.loc.Location.loc_start;
-      let stylesheet = Css_lexer.parse_stylesheet(
-        ~container_lnum=loc_start.Lexing.pos_lnum,
-        ~pos=loc_start,
-        payload.txt
-      );
-     Css_to_emotion.render_keyframes(stylesheet);
-    }
+      let stylesheet =
+        Css_lexer.parse_stylesheet(
+          ~container_lnum=loc_start.Lexing.pos_lnum,
+          ~pos=loc_start,
+          payload.txt,
+        );
+      Css_to_emotion.render_keyframes(stylesheet);
+    },
   ),
   /* This extension just raises an error to educate users, since before 0.20 this was valid */
   Ppxlib.Extension.declare(
@@ -388,13 +389,18 @@ let extensions = [
     Ppxlib.Extension.Context.Module_expr,
     any_payload,
     (~loc, ~path as _, payload) => {
-      raiseError(~loc,
-        ~description="An styled component without a tag is not valid. You must define an HTML tag, like, `styled.div`",
-        ~example=Some("[%styled.div " ++ Pprintast.string_of_expression(payload) ++ "]"),
-        ~link="https://developer.mozilla.org/en-US/docs/Learn/Accessibility/HTML"
-      )
-    }
-  ),
+    raiseError(
+      ~loc,
+      ~description=
+        "An styled component without a tag is not valid. You must define an HTML tag, like, `styled.div`",
+      ~example=
+        Some(
+          "[%styled.div " ++ Pprintast.string_of_expression(payload) ++ "]",
+        ),
+      ~link=
+        "https://developer.mozilla.org/en-US/docs/Learn/Accessibility/HTML",
+    )
+  }),
 ];
 
 module Mapper = {
@@ -407,21 +413,25 @@ module Mapper = {
           __',
           pstr(
             pstr_eval(
-              map(~f=(catch, payload, _, delim) =>
-                catch(`String(payload, delim)),
-                pexp_constant(pconst_string(__', __, __))
+              map(
+                ~f=
+                  (catch, payload, _, delim) =>
+                    catch(`String((payload, delim))),
+                pexp_constant(pconst_string(__', __, __)),
               )
-              ||| map(~f=(catch, payload) =>
-                catch(`Array(payload)),
-                pexp_array(__)
-              )
-              ||| map(~f=(catch, lbl, def, param, body) =>
-                catch(`Function(lbl, def, param, body)),
-                pexp_fun(__, __, __, __)
-              ),
+              ||| map(
+                    ~f=(catch, payload) => catch(`Array(payload)),
+                    pexp_array(__),
+                  )
+              ||| map(
+                    ~f=
+                      (catch, lbl, def, param, body) =>
+                        catch(`Function((lbl, def, param, body))),
+                    pexp_fun(__, __, __, __),
+                  ),
               nil,
             )
-            ^:: nil
+            ^:: nil,
           ),
         ),
       );
@@ -449,220 +459,246 @@ module Mapper = {
     | _ =>
       raiseError(
         ~loc,
-        ~description="This styled component is not valid. Doesn't have the right format.",
+        ~description=
+          "This styled component is not valid. Doesn't have the right format.",
         ~example=Some("[%styled.div ..."),
-        ~link="https://reasonml.org/docs/manual/latest/function#labeled-arguments",
-      );
+        ~link=
+          "https://reasonml.org/docs/manual/latest/function#labeled-arguments",
+      )
     };
   };
 
-  let isStyled = (name) => {
-    name |> getHtmlTag |> Option.is_some
+  let isStyled = name => {
+    name |> getHtmlTag |> Option.is_some;
   };
 
-  let transform = (expr) => {
+  let transform = expr => {
     switch (expr.pstr_desc) {
-      /* [%styled.div {||}] */
-      | Pstr_module({
-          pmb_name: { loc: _, txt: Some(moduleName) } as name,
-          pmb_attributes: _pmb_attributes,
-          pmb_loc: moduleLoc,
-          pmb_expr: {
-            pmod_desc:
-              Pmod_extension((
-                {txt: extensionName, loc: extensionLoc},
-                PStr([
-                  {
-                    pstr_desc:
-                      Pstr_eval(
-                        {
-                          pexp_loc: stringLoc,
-                          pexp_desc:
-                            Pexp_constant(
-                              Pconst_string(str, _loc, _label)
-                            ),
-                          _,
-                        },
-                        _attributes,
-                      ),
-                    pstr_loc: _,
-                  },
-                ]),
-              )),
-            _
-          }
-        }) when isStyled(extensionName) =>
-        let htmlTag = getHtmlTagUnsafe(~loc=extensionLoc, extensionName);
-        let styles = parsePayloadStyle(str, stringLoc)
-          |> Css_to_emotion.render_declarations
-          |> Css_to_emotion.addLabel(~loc=stringLoc, moduleName)
-          |> Builder.pexp_array(~loc=stringLoc)
-          |> Css_to_emotion.render_style_call;
-
-        Builder.pstr_module(~loc=moduleLoc,
-          Builder.module_binding(~loc=moduleLoc,
-            ~name,
-            ~expr=renderStyledComponent(~loc=stringLoc, ~htmlTag, styles)
-          )
-        );
-      /* [%styled.div [||]] */
-      | Pstr_module({
-          pmb_name: { loc: _, txt: Some(moduleName) } as name,
-          pmb_attributes: _pmb_attributes,
-          pmb_loc: moduleLoc,
-          pmb_expr: {
-            pmod_desc:
-              Pmod_extension((
-                {txt: extensionName, loc: extensionLoc},
-                PStr([
-                  {
-                    pstr_desc:
-                      Pstr_eval(
-                        {
-                          pexp_loc: arrayLoc,
-                          pexp_desc:
-                            Pexp_array(arr),
-                          _,
-                        },
+    /* [%styled.div {||}] */
+    | Pstr_module({
+        pmb_name: {loc: _, txt: Some(moduleName)} as name,
+        pmb_attributes: _pmb_attributes,
+        pmb_loc: moduleLoc,
+        pmb_expr: {
+          pmod_desc:
+            Pmod_extension((
+              {txt: extensionName, loc: extensionLoc},
+              PStr([
+                {
+                  pstr_desc:
+                    Pstr_eval(
+                      {
+                        pexp_loc: stringLoc,
+                        pexp_desc:
+                          Pexp_constant(Pconst_string(str, _loc, _label)),
                         _,
-                      ),
-                    pstr_loc: _,
-                  },
-                ]),
-              )),
-            _
-          }
-        }) when isStyled(extensionName) =>
-        let htmlTag = getHtmlTagUnsafe(~loc=extensionLoc, extensionName);
-        let styles = arr
-          |> Css_to_emotion.addLabel(~loc=arrayLoc, moduleName)
-          |> Builder.pexp_array(~loc=arrayLoc)
-          |> Css_to_emotion.render_style_call;
+                      },
+                      _attributes,
+                    ),
+                  pstr_loc: _,
+                },
+              ]),
+            )),
+          _,
+        },
+      })
+        when isStyled(extensionName) =>
+      let htmlTag = getHtmlTagUnsafe(~loc=extensionLoc, extensionName);
+      let styles =
+        parsePayloadStyle(str, stringLoc)
+        |> Css_to_emotion.render_declarations
+        |> Css_to_emotion.addLabel(~loc=stringLoc, moduleName)
+        |> Builder.pexp_array(~loc=stringLoc)
+        |> Css_to_emotion.render_style_call;
 
-        Builder.pstr_module(~loc=moduleLoc,
-          Builder.module_binding(~loc=moduleLoc,
-            ~name,
-            ~expr=renderStyledComponent(~loc=arrayLoc, ~htmlTag, styles)
-          )
-        );
-      /* [%styled.div () => {}] */
-      | Pstr_module({
-          pmb_name: { loc: _, txt: Some(moduleName) } as name,
-          pmb_attributes: _pmb_attributes,
-          pmb_loc: moduleLoc,
-          pmb_expr: {
-            pmod_desc:
-              Pmod_extension((
-                {txt: extensionName, loc: extensionLoc},
-                PStr([
-                  {
-                    pstr_desc:
-                      Pstr_eval(
-                        {
-                          pexp_loc: functionLoc,
-                          pexp_desc:
-                            Pexp_fun(fnLabel, defaultValue, param, expression),
-                          _,
-                        },
+      Builder.pstr_module(
+        ~loc=moduleLoc,
+        Builder.module_binding(
+          ~loc=moduleLoc,
+          ~name,
+          ~expr=renderStyledComponent(~loc=stringLoc, ~htmlTag, styles),
+        ),
+      );
+    /* [%styled.div [||]] */
+    | Pstr_module({
+        pmb_name: {loc: _, txt: Some(moduleName)} as name,
+        pmb_attributes: _pmb_attributes,
+        pmb_loc: moduleLoc,
+        pmb_expr: {
+          pmod_desc:
+            Pmod_extension((
+              {txt: extensionName, loc: extensionLoc},
+              PStr([
+                {
+                  pstr_desc:
+                    Pstr_eval(
+                      {pexp_loc: arrayLoc, pexp_desc: Pexp_array(arr), _},
+                      _,
+                    ),
+                  pstr_loc: _,
+                },
+              ]),
+            )),
+          _,
+        },
+      })
+        when isStyled(extensionName) =>
+      let htmlTag = getHtmlTagUnsafe(~loc=extensionLoc, extensionName);
+      let styles =
+        arr
+        |> Css_to_emotion.addLabel(~loc=arrayLoc, moduleName)
+        |> Builder.pexp_array(~loc=arrayLoc)
+        |> Css_to_emotion.render_style_call;
+
+      Builder.pstr_module(
+        ~loc=moduleLoc,
+        Builder.module_binding(
+          ~loc=moduleLoc,
+          ~name,
+          ~expr=renderStyledComponent(~loc=arrayLoc, ~htmlTag, styles),
+        ),
+      );
+    /* [%styled.div () => {}] */
+    | Pstr_module({
+        pmb_name: {loc: _, txt: Some(moduleName)} as name,
+        pmb_attributes: _pmb_attributes,
+        pmb_loc: moduleLoc,
+        pmb_expr: {
+          pmod_desc:
+            Pmod_extension((
+              {txt: extensionName, loc: extensionLoc},
+              PStr([
+                {
+                  pstr_desc:
+                    Pstr_eval(
+                      {
+                        pexp_loc: functionLoc,
+                        pexp_desc:
+                          Pexp_fun(fnLabel, defaultValue, param, expression),
                         _,
-                      ),
-                    pstr_loc: _,
-                  },
-                ]),
-              )),
-            _
-          }
-        }) when isStyled(extensionName) =>
-        let htmlTag = getHtmlTagUnsafe(~loc=extensionLoc, extensionName);
+                      },
+                      _,
+                    ),
+                  pstr_loc: _,
+                },
+              ]),
+            )),
+          _,
+        },
+      })
+        when isStyled(extensionName) =>
+      let htmlTag = getHtmlTagUnsafe(~loc=extensionLoc, extensionName);
 
-        Builder.pstr_module(~loc=moduleLoc,
-          Builder.module_binding(~loc=moduleLoc,
-            ~name,
-            ~expr=renderStyledDynamic(
+      Builder.pstr_module(
+        ~loc=moduleLoc,
+        Builder.module_binding(
+          ~loc=moduleLoc,
+          ~name,
+          ~expr=
+            renderStyledDynamic(
               ~loc=functionLoc,
               ~htmlTag,
               ~label=fnLabel,
-              ~moduleName=moduleName,
+              ~moduleName,
               ~defaultValue,
               ~param,
               ~body=expression,
-            )
-          )
-        );
-      /* [%cx ""] */
-      | Pstr_value(
-          Nonrecursive,
-          [{
-            pvb_pat: {
-              ppat_desc: Ppat_var({ loc: patternLoc, txt: valueName }),
-              _
-            } as pat,
+            ),
+        ),
+      );
+    /* [%cx ""] */
+    | Pstr_value(
+        Nonrecursive,
+        [
+          {
+            pvb_pat:
+              {ppat_desc: Ppat_var({loc: patternLoc, txt: valueName}), _} as pat,
             pvb_expr: {
-              pexp_desc: Pexp_extension(({txt: "cx", _}, PStr([{
-                  pstr_desc:
-                    Pstr_eval(
-                      {
-                        pexp_loc: payloadLoc,
-                        pexp_desc: Pexp_constant(Pconst_string(styles, _, _)),
-                        _,
-                      },
+              pexp_desc:
+                Pexp_extension((
+                  {txt: "cx", _},
+                  PStr([
+                    {
+                      pstr_desc:
+                        Pstr_eval(
+                          {
+                            pexp_loc: payloadLoc,
+                            pexp_desc:
+                              Pexp_constant(Pconst_string(styles, _, _)),
+                            _,
+                          },
+                          _,
+                        ),
                       _,
-                    ),
-                  _,
-                }]))), _
+                    },
+                  ]),
+                )),
+              _,
             },
             pvb_loc: loc,
-            _
-          }]
-        ) => {
-          let expr = parsePayloadStyle(styles, loc)
-            |> Css_to_emotion.render_declarations
-            |> Css_to_emotion.addLabel(~loc, valueName)
-            |> Builder.pexp_array(~loc=payloadLoc)
-            |> Css_to_emotion.render_style_call;
+            _,
+          },
+        ],
+      ) =>
+      let expr =
+        parsePayloadStyle(styles, loc)
+        |> Css_to_emotion.render_declarations
+        |> Css_to_emotion.addLabel(~loc, valueName)
+        |> Builder.pexp_array(~loc=payloadLoc)
+        |> Css_to_emotion.render_style_call;
 
-          Builder.pstr_value(~loc, Nonrecursive, [
-            Builder.value_binding(~loc=patternLoc, ~pat, ~expr)
-          ]);
-        }
-      /* [%cx [||]] */
-      | Pstr_value(
-          Nonrecursive,
-          [{
-            pvb_pat: {
-              ppat_desc: Ppat_var({ loc: patternLoc, txt: valueName }),
-              _
-            } as pat,
+      Builder.pstr_value(
+        ~loc,
+        Nonrecursive,
+        [Builder.value_binding(~loc=patternLoc, ~pat, ~expr)],
+      );
+    /* [%cx [||]] */
+    | Pstr_value(
+        Nonrecursive,
+        [
+          {
+            pvb_pat:
+              {ppat_desc: Ppat_var({loc: patternLoc, txt: valueName}), _} as pat,
             pvb_expr: {
-              pexp_desc: Pexp_extension(({txt: "cx", _}, PStr([{
-                  pstr_desc:
-                    Pstr_eval(
-                      {
-                        pexp_loc: payloadLoc,
-                        pexp_desc: Pexp_array(arr),
-                        _,
-                      },
+              pexp_desc:
+                Pexp_extension((
+                  {txt: "cx", _},
+                  PStr([
+                    {
+                      pstr_desc:
+                        Pstr_eval(
+                          {
+                            pexp_loc: payloadLoc,
+                            pexp_desc: Pexp_array(arr),
+                            _,
+                          },
+                          _,
+                        ),
                       _,
-                    ),
-                  _,
-                }]))), _
+                    },
+                  ]),
+                )),
+              _,
             },
             pvb_loc: loc,
-            _
-          }]
-        ) => {
-          let expr = arr
-            |> Css_to_emotion.addLabel(~loc=payloadLoc, valueName)
-            |> Builder.pexp_array(~loc=payloadLoc)
-            |> Css_to_emotion.render_style_call;
+            _,
+          },
+        ],
+      ) =>
+      let expr =
+        arr
+        |> Css_to_emotion.addLabel(~loc=payloadLoc, valueName)
+        |> Builder.pexp_array(~loc=payloadLoc)
+        |> Css_to_emotion.render_style_call;
 
-          Builder.pstr_value(~loc, Nonrecursive, [
-            Builder.value_binding(~loc=patternLoc, ~pat, ~expr)
-          ]);
-        }
-      | _ => expr
-    }
-  }
+      Builder.pstr_value(
+        ~loc,
+        Nonrecursive,
+        [Builder.value_binding(~loc=patternLoc, ~pat, ~expr)],
+      );
+    | _ => expr
+    };
+  };
 };
 
 let traverser = {
@@ -679,14 +715,15 @@ Config.setDefault();
 Driver.add_arg(
   "--compat-with-bs-emotion-ppx",
   Arg.Bool(Config.updateCompatibleModeWithBsEmotionPpx),
-  ~doc="Changes the extension name from css to css_, avoids breakage with bs-emotion-ppx"
+  ~doc=
+    "Changes the extension name from css to css_, avoids breakage with bs-emotion-ppx",
 );
 
 Driver.register_transformation(
   ~preprocess_impl=traverser#structure,
   ~extensions,
   /* Instrument is needed to run styled-ppx after metaquote,
-   we rely on this order in native tests */
+     we rely on this order in native tests */
   ~instrument=Driver.Instrument.make(Fun.id, ~position=Before),
-  "styled-ppx"
+  "styled-ppx",
 );

--- a/packages/ppx/src/main.re
+++ b/packages/ppx/src/main.re
@@ -253,7 +253,7 @@ let renderStyledDynamic = (
       ~customProps=Some((makePropsParameters, variableMakeProps))
     ),
     Create.bindingCreateVariadicElement(~loc),
-    Create.defineDeleteInnerRefFn(~loc),
+    Create.defineDeletePropFn(~loc),
     Create.dynamicStyles(
       ~loc,
       ~name=styleVariableName,
@@ -265,6 +265,7 @@ let renderStyledDynamic = (
       ~htmlTag,
       ~styledExpr=styledFunctionExpr,
       ~params=makePropsParameters,
+      ~variables=variableList
     ),
   ]);
 };
@@ -276,13 +277,13 @@ let renderStyledComponent = (~loc, ~htmlTag, styles) => {
   Builder.pmod_structure(~loc, [
     Create.makeMakeProps(~loc, ~customProps=None),
     Create.bindingCreateVariadicElement(~loc),
-    Create.defineDeleteInnerRefFn(~loc),
+    Create.defineDeletePropFn(~loc),
     Create.styles(
       ~loc,
       ~name=styleVariableName,
       ~expr=styles
     ),
-    Create.component(~loc, ~htmlTag, ~styledExpr, ~params=[])
+    Create.component(~loc, ~htmlTag, ~styledExpr, ~params=[], ~variables=[])
   ]);
 };
 

--- a/packages/ppx/test/bucklescript/src/__snapshots__/array_test.bs.js.snap
+++ b/packages/ppx/test/bucklescript/src/__snapshots__/array_test.bs.js.snap
@@ -9,7 +9,6 @@ exports[`ArrayDynamicComponent renders 1`] = `
 <div>
   <div
     class="emotion-0"
-    var="Black"
   />
 </div>
 `;
@@ -42,7 +41,6 @@ exports[`SequenceDynamicComponent renders 1`] = `
 <div>
   <div
     class="emotion-0"
-    var="White"
   />
 </div>
 `;

--- a/packages/ppx/test/snapshot/test.expected.re
+++ b/packages/ppx/test/snapshot/test.expected.re
@@ -957,7 +957,7 @@ module OneSingleProperty = {
   [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
-  let deleteInnerRef = [%raw "(newProps) => delete newProps.innerRef"];
+  let deleteProp = [%raw "(newProps, key) => delete newProps[key]"];
   let styles =
     CssJs.style(. [|
       CssJs.label("OneSingleProperty"),
@@ -966,7 +966,7 @@ module OneSingleProperty = {
   let make = (props: makeProps) => {
     let stylesObject = {"className": styles, "ref": innerRefGet(props)};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
-    ignore(deleteInnerRef(newProps));
+    ignore(deleteProp(newProps, "innerRef"));
     createVariadicElement("div", newProps);
   };
 };
@@ -1919,7 +1919,7 @@ module SingleQuoteStrings = {
   [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
-  let deleteInnerRef = [%raw "(newProps) => delete newProps.innerRef"];
+  let deleteProp = [%raw "(newProps, key) => delete newProps[key]"];
   let styles =
     CssJs.style(. [|
       CssJs.label("SingleQuoteStrings"),
@@ -1929,7 +1929,7 @@ module SingleQuoteStrings = {
   let make = (props: makeProps) => {
     let stylesObject = {"className": styles, "ref": innerRefGet(props)};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
-    ignore(deleteInnerRef(newProps));
+    ignore(deleteProp(newProps, "innerRef"));
     createVariadicElement("section", newProps);
   };
 };
@@ -2882,7 +2882,7 @@ module MultiLineStrings = {
   [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
-  let deleteInnerRef = [%raw "(newProps) => delete newProps.innerRef"];
+  let deleteProp = [%raw "(newProps, key) => delete newProps[key]"];
   let styles =
     CssJs.style(. [|
       CssJs.label("MultiLineStrings"),
@@ -2892,7 +2892,7 @@ module MultiLineStrings = {
   let make = (props: makeProps) => {
     let stylesObject = {"className": styles, "ref": innerRefGet(props)};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
-    ignore(deleteInnerRef(newProps));
+    ignore(deleteProp(newProps, "innerRef"));
     createVariadicElement("section", newProps);
   };
 };
@@ -3845,12 +3845,12 @@ module SelfClosingElement = {
   [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
-  let deleteInnerRef = [%raw "(newProps) => delete newProps.innerRef"];
+  let deleteProp = [%raw "(newProps, key) => delete newProps[key]"];
   let styles = CssJs.style(. [|CssJs.label("SelfClosingElement")|]);
   let make = (props: makeProps) => {
     let stylesObject = {"className": styles, "ref": innerRefGet(props)};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
-    ignore(deleteInnerRef(newProps));
+    ignore(deleteProp(newProps, "innerRef"));
     createVariadicElement("input", newProps);
   };
 };
@@ -4803,7 +4803,7 @@ module ArrayStatic = {
   [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
-  let deleteInnerRef = [%raw "(newProps) => delete newProps.innerRef"];
+  let deleteProp = [%raw "(newProps, key) => delete newProps[key]"];
   let styles =
     CssJs.style(. [|
       CssJs.label("ArrayStatic"),
@@ -4813,7 +4813,7 @@ module ArrayStatic = {
   let make = (props: makeProps) => {
     let stylesObject = {"className": styles, "ref": innerRefGet(props)};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
-    ignore(deleteInnerRef(newProps));
+    ignore(deleteProp(newProps, "innerRef"));
     createVariadicElement("section", newProps);
   };
 };
@@ -5773,7 +5773,7 @@ module StringInterpolation = {
   [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
-  let deleteInnerRef = [%raw "(newProps) => delete newProps.innerRef"];
+  let deleteProp = [%raw "(newProps, key) => delete newProps[key]"];
   let styles =
     CssJs.style(. [|
       CssJs.label("StringInterpolation"),
@@ -5786,7 +5786,7 @@ module StringInterpolation = {
   let make = (props: makeProps) => {
     let stylesObject = {"className": styles, "ref": innerRefGet(props)};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
-    ignore(deleteInnerRef(newProps));
+    ignore(deleteProp(newProps, "innerRef"));
     createVariadicElement("div", newProps);
   };
 };
@@ -6756,7 +6756,7 @@ module DynamicComponent = {
   [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
-  let deleteInnerRef = [%raw "(newProps) => delete newProps.innerRef"];
+  let deleteProp = [%raw "(newProps, key) => delete newProps[key]"];
   let styles = (~var, _) =>
     CssJs.style(. [|
       CssJs.label("DynamicComponent"),
@@ -6769,7 +6769,8 @@ module DynamicComponent = {
       "ref": innerRefGet(props),
     };
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
-    ignore(deleteInnerRef(newProps));
+    ignore(deleteProp(newProps, "var"));
+    ignore(deleteProp(newProps, "innerRef"));
     createVariadicElement("div", newProps);
   };
 };
@@ -7722,7 +7723,7 @@ module SelectorsMediaQueries = {
   [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
-  let deleteInnerRef = [%raw "(newProps) => delete newProps.innerRef"];
+  let deleteProp = [%raw "(newProps, key) => delete newProps[key]"];
   let styles =
     CssJs.style(. [|
       CssJs.label("SelectorsMediaQueries"),
@@ -7739,7 +7740,7 @@ module SelectorsMediaQueries = {
   let make = (props: makeProps) => {
     let stylesObject = {"className": styles, "ref": innerRefGet(props)};
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
-    ignore(deleteInnerRef(newProps));
+    ignore(deleteProp(newProps, "innerRef"));
     createVariadicElement("div", newProps);
   };
 };
@@ -8698,7 +8699,7 @@ module ArrayDynamicComponent = {
   [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
-  let deleteInnerRef = [%raw "(newProps) => delete newProps.innerRef"];
+  let deleteProp = [%raw "(newProps, key) => delete newProps[key]"];
   let styles = (~var, _) =>
     CssJs.style(. [|
       CssJs.label("ArrayDynamicComponent"),
@@ -8714,7 +8715,8 @@ module ArrayDynamicComponent = {
       "ref": innerRefGet(props),
     };
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
-    ignore(deleteInnerRef(newProps));
+    ignore(deleteProp(newProps, "var"));
+    ignore(deleteProp(newProps, "innerRef"));
     createVariadicElement("div", newProps);
   };
 };
@@ -9666,7 +9668,7 @@ module SequenceDynamicComponent = {
   [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
-  let deleteInnerRef = [%raw "(newProps) => delete newProps.innerRef"];
+  let deleteProp = [%raw "(newProps, key) => delete newProps[key]"];
   let styles = (~size, _) => {
     Js.log("Logging when render");
     CssJs.style(. [|CssJs.width(size), CssJs.display(`block)|]);
@@ -9677,7 +9679,8 @@ module SequenceDynamicComponent = {
       "ref": innerRefGet(props),
     };
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
-    ignore(deleteInnerRef(newProps));
+    ignore(deleteProp(newProps, "size"));
+    ignore(deleteProp(newProps, "innerRef"));
     createVariadicElement("div", newProps);
   };
 };
@@ -10632,7 +10635,7 @@ module DynamicComponentWithDefaultValue = {
   [@bs.val] [@bs.module "react"]
   external createVariadicElement: (string, Js.t({..})) => React.element =
     "createElement";
-  let deleteInnerRef = [%raw "(newProps) => delete newProps.innerRef"];
+  let deleteProp = [%raw "(newProps, key) => delete newProps[key]"];
   let styles = (~var=CssJs.hex("333"), _) =>
     CssJs.style(. [|
       CssJs.label("DynamicComponentWithDefaultValue"),
@@ -10645,7 +10648,8 @@ module DynamicComponentWithDefaultValue = {
       "ref": innerRefGet(props),
     };
     let newProps = Js.Obj.assign(stylesObject, Obj.magic(props));
-    ignore(deleteInnerRef(newProps));
+    ignore(deleteProp(newProps, "var"));
+    ignore(deleteProp(newProps, "innerRef"));
     createVariadicElement("div", newProps);
   };
 };


### PR DESCRIPTION
This PR fixes https://github.com/davesnx/styled-ppx/issues/242

Removes the prop after being used for generating the styles and before the createElement call.