### PR TITLE
Feat: create a ClassVariable .

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@davesnx/styled-ppx",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "Typed styled components in ReScript",
   "author": "David Sancho <dsnxmoreno@gmail.com>",
   "license": "MIT",

--- a/packages/parser/css_parser.mly
+++ b/packages/parser/css_parser.mly
@@ -342,6 +342,8 @@ simple_selector:
   | ASTERISK; { Selector.Universal }
   /* $(Module.value) {} */
   | v = VARIABLE { Selector.Variable v }
+  /* .$(Module.value) {} */
+  | DOT; v = VARIABLE { Selector.ClassVariable v }
   /* a {} */
   | type_ = TAG; { Selector.Type type_ }
   /* #a, .a, a:visited, a[] */

--- a/packages/parser/css_types.re
+++ b/packages/parser/css_types.re
@@ -96,6 +96,7 @@ and Selector: {
     | Type(string)
     | Subclass(subclass_selector)
     | Variable(list(string))
+    | ClassVariable(list(string))
     | Percentage(string)
   and subclass_selector =
     | Id(string)

--- a/packages/ppx/src/css_to_emotion.re
+++ b/packages/ppx/src/css_to_emotion.re
@@ -191,6 +191,7 @@ and render_selector = (selector: Selector.t) => {
     | Type(v) => v
     | Subclass(v) => render_subclass_selector(v)
     | Variable(v) => render_variable_as_string(v)
+    | ClassVariable(v) => "." ++ render_variable_as_string(v)
     | Percentage(_v) =>
       /* TODO: Add locations to Selector.t */
       grammar_error(Location.none, "Percentage is not a valid selector")
@@ -344,6 +345,7 @@ let render_keyframes = (declarations: Declaration_list.t
         | Universal => grammar_error(loc, invalid_prelude_value("*"))
         | Subclass(_) => grammar_error(loc, invalid_prelude_value_opaque)
         | Variable(_) => grammar_error(loc, invalid_prelude_value_opaque)
+        | ClassVariable(_) => grammar_error(loc, invalid_prelude_value_opaque)
         }
      }
      | _ => grammar_error(loc, invalid_selector);

--- a/packages/ppx/test/native/Selector_test.re
+++ b/packages/ppx/test/native/Selector_test.re
@@ -176,6 +176,11 @@ let selectors_css_tests = [
     [%expr CssJs.style(. [|CssJs.selector(. {js|& |js} ++ Variables.selector_query, [||])|])],
   ),
   (
+    "& .$(Variables.selector_query)",
+    [%expr [%cx "& .$(Variables.selector_query) {}"]],
+    [%expr CssJs.style(. [|CssJs.selector(. {js|& .|js} ++ Variables.selector_query, [||])|])],
+  ),
+  (
     "& a[target=\"_blank\"]",
     [%expr [%cx {|& a[target="_blank"] {}|}]],
     [%expr CssJs.style(. [| CssJs.selector(. {js|& a[target="_blank"]|js}, [||])|])],

--- a/packages/renderer/ast_renderer.re
+++ b/packages/renderer/ast_renderer.re
@@ -83,6 +83,7 @@ and render_selector = (ast: Selector.t) => {
     | Type(v) => "Type(" ++ v ++ ")"
     | Subclass(v) => "Subclass(" ++ render_subclass_selector(v) ++ ")"
     | Variable(v) => "Variable(" ++ String.concat(".", v) ++ ")"
+    | ClassVariable(v) => "ClassVariable(" ++ String.concat(".", v) ++ ")"
     | Percentage(p) => "Percentage(" ++ p ++ ")"
   and render_subclass_selector: subclass_selector => string =
     fun

--- a/packages/website/pages/guides.mdx
+++ b/packages/website/pages/guides.mdx
@@ -16,6 +16,23 @@ let link = %cx(`
 `)
 ```
 
+## Interpolation in selectors
+
+```rescript
+let highlighted = %cx(`
+  padding: 4px;
+  outline: 1px solid red;
+`)
+
+let link = %cx(`
+  color: $(Color.Text.body);
+
+  & .$(highlighted) {
+    padding: 0px;
+  }
+`)
+```
+
 ## Interpolation in Media queries
 
 ```rescript


### PR DESCRIPTION
It's very useful to have a way to interpolate with classes such as:

```
let lastCell = [%cx {||}]

let contentCell = [%cx {|
  padding: $(NewSize.px8) $(NewSize.px4);

  & $(lastCell) {
    padding-right: 0;
  }
|}]
```

Since `lastCell` is a class, you would need to append the dot for the interpolation to make sense, this felt like too low level.

We use this kind of selectors all over the place in ahrefs. This seems like a big deal.

Created a ClassVariable to solve this particular problem.