### PR TITLE
feat: add inline type annotation on codegen when generating code with interpolation

### DIFF
--- a/packages/ppx/test/css-support/test.expected.re
+++ b/packages/ppx/test/css-support/test.expected.re
@@ -1776,7 +1776,7 @@ CssJs.unsafe({js|WebkitTextFillColor|js}, {js| $(Color.Text.primary)|js});
 CssJs.unsafe({js|animation|js}, {js| none|js});
 CssJs.unsafe({js|appearance|js}, {js| none|js});
 CssJs.unsafe({js|aspectRatio|js}, {js| 21 / 8|js});
-CssJs.backgroundColor(c);
+(CssJs.backgroundColor(c): CssJs.rule);
 CssJs.unsafe({js|bottom|js}, "unset");
 CssJs.boxShadows(`none);
 CssJs.unsafe({js|breakInside|js}, {js| avoid|js});

--- a/packages/ppx/test/native/Interpolation_test.re
+++ b/packages/ppx/test/native/Interpolation_test.re
@@ -10,9 +10,9 @@ let compare = (input, expected, {expect, _}) => {
 };
 
 let properties_variable_css_tests = [
-  /* (
+  (
     [%expr [%css "color: $(mono100);"]],
-    [%expr CssJs.color(mono100)]
+    [%expr (CssJs.color(mono100) : CssJs.rule)]
   ),
   (
     [%expr [%css "margin: $(Size.big) $(Size.small);"]],
@@ -20,7 +20,7 @@ let properties_variable_css_tests = [
   ),
   (
     [%expr [%css "color: $(mono100);"]],
-    [%expr CssJs.color(mono100)]
+    [%expr (CssJs.color(mono100) : CssJs.rule)]
   ),
   (
     [%expr [%css "padding: $(Size.small) 0px;"]],
@@ -36,43 +36,43 @@ let properties_variable_css_tests = [
   ),
   (
     [%expr [%css "width: $(width);"]],
-    [%expr CssJs.width(width)]
+    [%expr (CssJs.width(width) : CssJs.rule)]
   ),
   (
     [%expr [%css "max-width: $(max);"]],
-    [%expr CssJs.maxWidth(max)]
+    [%expr (CssJs.maxWidth(max) : CssJs.rule)]
   ),
   (
     [%expr [%css "height: $(height);"]],
-    [%expr CssJs.height(height)]
+    [%expr (CssJs.height(height) : CssJs.rule)]
   ),
   (
     [%expr [%css "border-radius: $(border);"]],
-    [%expr CssJs.borderRadius(border)]
+    [%expr (CssJs.borderRadius(border) : CssJs.rule)]
   ),
   (
     [%expr [%css "font-size: $(font);"]],
-    [%expr CssJs.fontSize(font)]
+    [%expr (CssJs.fontSize(font) : CssJs.rule)]
   ),
   (
     [%expr [%css "font-family: $(mono);"]],
-    [%expr CssJs.fontFamily(mono)]
+    [%expr (CssJs.fontFamily(mono) : CssJs.rule)]
   ),
   (
     [%expr [%css "line-height: $(lh);"]],
-    [%expr CssJs.lineHeight(lh)]
+    [%expr (CssJs.lineHeight(lh) : CssJs.rule)]
   ),
   (
     [%expr [%css "z-index: $(zLevel);"]],
-    [%expr CssJs.zIndex(zLevel)]
+    [%expr (CssJs.zIndex(zLevel) : CssJs.rule)]
   ),
   (
     [%expr [%css "left: $(left);"]],
-    [%expr CssJs.left(left)]
+    [%expr (CssJs.left(left) : CssJs.rule)]
   ),
   (
     [%expr [%css "text-decoration-color: $(decorationColor);"]],
-    [%expr CssJs.textDecorationColor(decorationColor)]
+    [%expr (CssJs.textDecorationColor(decorationColor) : CssJs.rule)]
   ),
   /* (
     [%expr [%css "background-image: $(wat);" ]],
@@ -104,12 +104,12 @@ let properties_variable_css_tests = [
         color
       )
     |])]
-  ), */
+  ),
   /* Add border */
   /* Add text-shadow */
 ];
 
-describe("Should bind to bs-css with interpolatated variables", ({test, _}) => {
+describe("Should bind to bs-css with interpolated variables", ({test, _}) => {
   properties_variable_css_tests |>
     List.iteri((_index, (result, expected)) =>
       test(

--- a/packages/ppx/test/snapshot/test.expected.re
+++ b/packages/ppx/test/snapshot/test.expected.re
@@ -5848,9 +5848,9 @@ module StringInterpolation = {
   let styles =
     CssJs.style(. [|
       CssJs.label("StringInterpolation"),
-      CssJs.color(Theme.var),
-      CssJs.backgroundColor(black),
-      CssJs.borderColor(Theme.Border.black),
+      (CssJs.color(Theme.var): CssJs.rule),
+      (CssJs.backgroundColor(black): CssJs.rule),
+      (CssJs.borderColor(Theme.Border.black): CssJs.rule),
       CssJs.display(`block),
     |]);
   let make = (props: makeProps) => {
@@ -6842,7 +6842,7 @@ module DynamicComponent = {
   let styles = (~var, _) =>
     CssJs.style(. [|
       CssJs.label("DynamicComponent"),
-      CssJs.color(var),
+      (CssJs.color(var): CssJs.rule),
       CssJs.display(`block),
     |]);
   let make = (props: makeProps('var)) => {
@@ -9788,7 +9788,10 @@ module SequenceDynamicComponent = {
   };
   let styles = (~size, _) => {
     Js.log("Logging when render");
-    CssJs.style(. [|CssJs.width(size), CssJs.display(`block)|]);
+    CssJs.style(. [|
+      (CssJs.width(size): CssJs.rule),
+      CssJs.display(`block),
+    |]);
   };
   let make = (props: makeProps('size)) => {
     let className =
@@ -10767,7 +10770,7 @@ module DynamicComponentWithDefaultValue = {
     CssJs.style(. [|
       CssJs.label("DynamicComponentWithDefaultValue"),
       CssJs.display(`block),
-      CssJs.color(var),
+      (CssJs.color(var): CssJs.rule),
     |]);
   let make = (props: makeProps('var)) => {
     let className =
@@ -13711,7 +13714,7 @@ module DynamicComponentWithSequence = {
     let color = Theme.button(variant);
     CssJs.style(. [|
       CssJs.display(`inlineFlex),
-      CssJs.color(color),
+      (CssJs.color(color): CssJs.rule),
       CssJs.width(`percent(100.)),
     |]);
   };
@@ -14692,8 +14695,8 @@ module DynamicComponentWithArray = {
       CssJs.label("DynamicComponentWithArray"),
       CssJs.width(`percent(100.)),
       CssJs.display(`block),
-      CssJs.color(color),
-      CssJs.width(size),
+      (CssJs.color(color): CssJs.rule),
+      (CssJs.width(size): CssJs.rule),
     |]);
   let make = (props: makeProps('color, 'size)) => {
     let className =
@@ -14707,7 +14710,8 @@ module DynamicComponentWithArray = {
     createVariadicElement("button", newProps);
   };
 };
-let sharedStylesBetweenDynamicComponents = color => CssJs.color(color);
+let sharedStylesBetweenDynamicComponents = (color): CssJs.rule =>
+  CssJs.color(color);
 module DynamicCompnentWithLetIn = {
   [@bs.deriving abstract]
   type makeProps('color) = {


### PR DESCRIPTION
Alternative to #283

Since notating types everywhere adds a lot of noise, this only add type notation when there is an interpolation.

This happens on `transform_with_variable`, so the properties that call `emit_shorthand` directly and handle `Variable` manually don't have type notation