### PR TITLE
Parser improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@davesnx/styled-ppx",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "description": "Typed styled components in ReScript",
   "author": "David Sancho <dsnxmoreno@gmail.com>",
   "license": "MIT",

--- a/packages/parser/css_lexer.re
+++ b/packages/parser/css_lexer.re
@@ -165,7 +165,10 @@ let ident_char = [%sedlex.regexp?
 
 let ident = [%sedlex.regexp? (Opt('-'), ident_start, Star(ident_char))];
 
-let variable_name = [%sedlex.regexp? (Star(ident_char))];
+let variable_ident_char = [%sedlex.regexp?
+  '_' | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | non_ascii | escape | '\''
+];
+let variable_name = [%sedlex.regexp? (Star(variable_ident_char))];
 let module_variable = [%sedlex.regexp? (variable_name, '.')];
 let variable = [%sedlex.regexp? ('$', '(', Opt(Star(module_variable)), variable_name, ')')];
 

--- a/packages/parser/css_parser.mly
+++ b/packages/parser/css_parser.mly
@@ -318,12 +318,15 @@ id_selector: h = HASH { Selector.Id h }
 /* <class-selector> = '.' <ident-token> */
 class_selector: DOT; c = IDENT { Selector.Class c };
 
+
 /* <subclass-selector> = <id-selector> | <class-selector> | <attribute-selector> | <pseudo-class-selector> */
 subclass_selector:
   | id = id_selector { id }
   | c = class_selector { c }
   | a = attribute_selector { a }
   | pcs = pseudo_class_selector { Selector.Pseudo_class pcs }
+  /* .$(Variable) as subclass_selector */
+  | DOT; v = VARIABLE { Selector.ClassVariable v };
 ;
 
 selector:
@@ -352,8 +355,6 @@ simple_selector:
   | ASTERISK; { Selector.Universal }
   /* $(Module.value) {} */
   | v = VARIABLE { Selector.Variable v }
-  /* .$(Module.value) {} */
-  | DOT; v = VARIABLE { Selector.ClassVariable v }
   /* a {} */
   | type_ = TAG; { Selector.Type type_ }
   /* #a, .a, a:visited, a[] */

--- a/packages/parser/css_types.re
+++ b/packages/parser/css_types.re
@@ -96,11 +96,11 @@ and Selector: {
     | Type(string)
     | Subclass(subclass_selector)
     | Variable(list(string))
-    | ClassVariable(list(string))
     | Percentage(string)
   and subclass_selector =
     | Id(string)
     | Class(string)
+    | ClassVariable(list(string))
     | Attribute(attribute_selector)
     | Pseudo_class(pseudo_selector)
   and attribute_selector =

--- a/packages/ppx/src/css_to_emotion.re
+++ b/packages/ppx/src/css_to_emotion.re
@@ -160,7 +160,7 @@ and render_declaration = (d: Declaration.t): list(Parsetree.expression) => {
   | Error(`Invalid_value(value)) =>
     grammar_error(
       loc,
-      "Invalid value: '" ++ value ++ "' in property '" ++ property ++ "'",
+      "Invalid value: '" ++ String.trim(value) ++ "' in property '" ++ property ++ "'",
     )
   };
 }
@@ -191,7 +191,6 @@ and render_selector = (selector: Selector.t) => {
     | Type(v) => v
     | Subclass(v) => render_subclass_selector(v)
     | Variable(v) => render_variable_as_string(v)
-    | ClassVariable(v) => "." ++ render_variable_as_string(v)
     | Percentage(_v) =>
       /* TODO: Add locations to Selector.t */
       grammar_error(Location.none, "Percentage is not a valid selector")
@@ -199,6 +198,7 @@ and render_selector = (selector: Selector.t) => {
     fun
     | Id(v) => "#" ++ v
     | Class(v) => "." ++ v
+    | ClassVariable(v) => "." ++ render_variable_as_string(v)
     | Attribute(Attr_value(v)) => "[" ++ v ++ "]"
     | Attribute(To_equal({name, kind, value})) =>  {
       let value = switch (value) {
@@ -345,7 +345,6 @@ let render_keyframes = (declarations: Declaration_list.t
         | Universal => grammar_error(loc, invalid_prelude_value("*"))
         | Subclass(_) => grammar_error(loc, invalid_prelude_value_opaque)
         | Variable(_) => grammar_error(loc, invalid_prelude_value_opaque)
-        | ClassVariable(_) => grammar_error(loc, invalid_prelude_value_opaque)
         }
      }
      | _ => grammar_error(loc, invalid_selector);

--- a/packages/ppx/test/native/Interpolation_test.re
+++ b/packages/ppx/test/native/Interpolation_test.re
@@ -107,6 +107,10 @@ let properties_variable_css_tests = [
   ), */
   /* Add border */
   /* Add text-shadow */
+  /* (
+    [%expr [%css "color: $(color');"]],
+    [%expr CssJs.color(color')]
+  ), */
 ];
 
 describe("Should bind to bs-css with interpolatated variables", ({test, _}) => {

--- a/packages/ppx/test/native/Interpolation_test.re
+++ b/packages/ppx/test/native/Interpolation_test.re
@@ -107,10 +107,10 @@ let properties_variable_css_tests = [
   ), */
   /* Add border */
   /* Add text-shadow */
-  /* (
+  (
     [%expr [%css "color: $(color');"]],
     [%expr CssJs.color(color')]
-  ), */
+  ),
 ];
 
 describe("Should bind to bs-css with interpolatated variables", ({test, _}) => {

--- a/packages/ppx/test/native/Selector_test.re
+++ b/packages/ppx/test/native/Selector_test.re
@@ -181,6 +181,11 @@ let selectors_css_tests = [
     [%expr CssJs.style(. [|CssJs.selector(. {js|& .|js} ++ Variables.selector_query, [||])|])],
   ),
   (
+    "&.$(Variables.selector_query)",
+    [%expr [%cx "&.$(Variables.selector_query) {}"]],
+    [%expr CssJs.style(. [|CssJs.selector(. {js|&.|js} ++ Variables.selector_query, [||])|])],
+  ),
+  (
     "& a[target=\"_blank\"]",
     [%expr [%cx {|& a[target="_blank"] {}|}]],
     [%expr CssJs.style(. [| CssJs.selector(. {js|& a[target="_blank"]|js}, [||])|])],

--- a/packages/reason-css-lexer/lib/Token.re
+++ b/packages/reason-css-lexer/lib/Token.re
@@ -25,7 +25,66 @@ type token =
   | LEFT_PARENS // <(-token>
   | RIGHT_PARENS // <)-token>
   | LEFT_CURLY // <{-token>
-  | RIGHT_CURLY; // <}-token>
+  | RIGHT_CURLY // <}-token>
+;
+
+let string_of_char = c => String.make(1, c);
+
+let humanize = fun
+  | EOF => "the end"
+  | IDENT(str) => "ident " ++ str
+  | BAD_IDENT => "bad ident"
+  | FUNCTION(f) => "function " ++ f
+  | AT_KEYWORD(at) => "@ " ++ at
+  | HASH(h, _) => "hash: #" ++ h
+  | STRING(s) => {|string "|} ++ s ++ {|"|}
+  | BAD_STRING(_) => "bad string"
+  | URL(u) => "url " ++ u
+  | BAD_URL => "bad url"
+  | DELIM(d) => "delimiter " ++ d
+  | NUMBER(f) => "number: " ++ string_of_float(f)
+  | PERCENTAGE(f) => "percentage: " ++ string_of_float(f) ++ string_of_char('%')
+  | DIMENSION(f, s) => "dimension: " ++ string_of_float(f) ++ s
+  | WHITESPACE => "whitespace"
+  | CDO => "<!--"
+  | CDC => "-->"
+  | COLON => ":"
+  | SEMICOLON => ";"
+  | COMMA => ","
+  | LEFT_SQUARE => "["
+  | RIGHT_SQUARE => "]"
+  | LEFT_PARENS => "("
+  | RIGHT_PARENS => ")"
+  | LEFT_CURLY => "{"
+  | RIGHT_CURLY => "}";
+
+let humanize_without_payload = fun
+  | EOF => "the end"
+  | IDENT(_) => "ident"
+  | BAD_IDENT => "bad ident"
+  | FUNCTION(_) => "function"
+  | AT_KEYWORD(_) => "@"
+  | HASH(_, _) => "hash: #"
+  | STRING(_) => "string"
+  | BAD_STRING(_) => "bad string"
+  | URL(_) => "url"
+  | BAD_URL => "bad url"
+  | DELIM(_) => "delimiter "
+  | NUMBER(_) => "number"
+  | PERCENTAGE(_) => "percentage"
+  | DIMENSION(_, _) => "dimension: (e.g. 10px)"
+  | WHITESPACE => "whitespace: ' '"
+  | CDO => "<!--"
+  | CDC => "-->"
+  | COLON => ":"
+  | SEMICOLON => ";"
+  | COMMA => ","
+  | LEFT_SQUARE => "["
+  | RIGHT_SQUARE => "]"
+  | LEFT_PARENS => "("
+  | RIGHT_PARENS => ")"
+  | LEFT_CURLY => "{"
+  | RIGHT_CURLY => "}";
 
 type error =
   | Invalid_code_point

--- a/packages/reason-css-lexer/lib/Tokenizer.re
+++ b/packages/reason-css-lexer/lib/Tokenizer.re
@@ -11,8 +11,9 @@ let non_ascii_code_point = [%sedlex.regexp? Sub(any, '\000' .. '\128')]; // grea
 let identifier_start_code_point = [%sedlex.regexp?
   'a' .. 'z' | 'A' .. 'Z' | non_ascii_code_point | '_'
 ];
+/* Added "'" to identifier to enable Language Variables */
 let identifier_code_point = [%sedlex.regexp?
-  identifier_start_code_point | digit | '-'
+  identifier_start_code_point | digit | '-' | "'"
 ];
 let non_printable_code_point = [%sedlex.regexp?
   '\000' .. '\b' | '\011' | '\014' .. '\031' | '\127'
@@ -22,10 +23,6 @@ let whitespace = [%sedlex.regexp? Plus('\n' | '\t' | ' ')];
 let ident_char = [%sedlex.regexp?
   '_' | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' | non_ascii_code_point | escape
 ];
-
-let variable_name = [%sedlex.regexp? (Star(ident_char))];
-let module_variable = [%sedlex.regexp? (variable_name, '.')];
-let variable = [%sedlex.regexp? (Opt(Star(module_variable)), variable_name)];
 
 let (let.ok) = Result.bind;
 
@@ -152,6 +149,7 @@ let consume_identifier = buf => {
     };
   read("");
 };
+
 let handle_consume_identifier =
   fun
   | Error((_, error)) => Error((BAD_IDENT, error))
@@ -258,6 +256,7 @@ let consume_ident_like = buf => {
 
   // TODO: should it return IDENT() when error?
   let.ok string = consume_identifier(buf) |> handle_consume_identifier;
+
   switch%sedlex (buf) {
   | '(' =>
     switch (string) {

--- a/packages/reason-css-lexer/test/Tokenizer_test.re
+++ b/packages/reason-css-lexer/test/Tokenizer_test.re
@@ -93,6 +93,8 @@ describe("Tokenizer", ({test, _}) => {
       16,
     ),
     ({|calc(10%)|}, [FUNCTION("calc"), PERCENTAGE(10.), RIGHT_PARENS], 9),
+    ({|$(Module.variable)|}, [DELIM("$"), LEFT_PARENS, IDENT("Module"), DELIM("."), IDENT("variable"), RIGHT_PARENS], 18),
+    ({|$(Module.variable')|}, [DELIM("$"), LEFT_PARENS, IDENT("Module"), DELIM("."), IDENT("variable'"), RIGHT_PARENS], 19),
   ];
 
   success_tests_data

--- a/packages/reason-css-parser/lib/Rule.re
+++ b/packages/reason-css-parser/lib/Rule.re
@@ -126,7 +126,11 @@ module Pattern = {
     token(
       fun
       | token when token == expected => Ok()
-      | token => Error(["expected " ++ show_token(expected) ++ ". got " ++ show_token(token)]),
+      | token => {
+        let expected = humanize(expected);
+        let got = humanize(token);
+        Error(["Expected '" ++ expected ++ "' but instead got " ++ got])
+      }
     );
   let value = (value, rule) => Match.bind(rule, () => Match.return(value));
 };

--- a/packages/reason-css-parser/lib/Standard.re
+++ b/packages/reason-css-parser/lib/Standard.re
@@ -221,11 +221,11 @@ let interpolation = {
   let.bind_match _ = Pattern.expect(LEFT_PARENS);
   let.bind_match path = {
     let.bind_match path = Modifier.zero_or_more({
-      let.bind_match ident = custom_ident;
+      let.bind_match ident = ident;
       let.bind_match _ = Pattern.expect(DELIM("."));
       return_match(ident)
     });
-    let.bind_match ident = custom_ident;
+    let.bind_match ident = ident;
     return_match(path @ [ident])
   };
   let.bind_match _ = Pattern.expect(RIGHT_PARENS);

--- a/packages/reason-css-parser/test/Standard_test.re
+++ b/packages/reason-css-parser/test/Standard_test.re
@@ -140,4 +140,12 @@ describe("Standard values", ({test, _}) => {
     expect.result(parse("[a-b]")).toBe(Ok(((), ["a-b"], ())));
     expect.result(parse("asd")).toBeError();
   });
+
+  /* variable */
+  test("variable", ({expect, _}) => {
+    let parse = parse([%value "<interpolation>"]);
+    expect.result(parse("$(Module.value)")).toBe(Ok(["Module", "value"]));
+    expect.result(parse("$(Module'.value')")).toBe(Ok(["Module'", "value'"]));
+    expect.result(parse("asd")).toBeError();
+  });
 });

--- a/packages/renderer/ast_renderer.re
+++ b/packages/renderer/ast_renderer.re
@@ -82,15 +82,15 @@ and render_selector = (ast: Selector.t) => {
     | Ampersand => "Ampersand"
     | Type(v) => "Type(" ++ v ++ ")"
     | Subclass(v) => "Subclass(" ++ render_subclass_selector(v) ++ ")"
-    | Variable(v) => "Variable(" ++ String.concat(".", v) ++ ")"
-    | ClassVariable(v) => "ClassVariable(" ++ String.concat(".", v) ++ ")"
+    | Variable(v) => "Variable(" ++ render_variable(v) ++ ")"
     | Percentage(p) => "Percentage(" ++ p ++ ")"
   and render_subclass_selector: subclass_selector => string =
     fun
     | Id(v) => "Id(" ++ v ++ ")"
     | Class(v) => "Class(" ++ v ++ ")"
     | Attribute(attr) => "Attribute(" ++ render_attribute(attr) ++ ")"
-    | Pseudo_class(psc) => render_pseudo_selector(psc)
+    | Pseudo_class(psc) => "Pseudo_class(" ++ render_pseudo_selector(psc) ++ ")"
+    | ClassVariable(v) => "ClassVariable(" ++ render_variable(v) ++ ")"
   and render_attribute =
     fun
     | Attr_value(v) => "Attr_value(" ++ v ++ ")"
@@ -115,7 +115,8 @@ and render_selector = (ast: Selector.t) => {
       ++ name
       ++ ", "
       ++ render_selector(selector)
-      ++ "))";
+      ++ "))"
+  and render_variable = v => String.concat(".", v);
 
   let rec render_compound_selector = (compound_selector: compound_selector) => {
     let simple_selector =

--- a/packages/string_interpolation/src/transform.ml
+++ b/packages/string_interpolation/src/transform.ml
@@ -33,7 +33,7 @@ module Parser = struct
         [%sedlex.regexp? (letter | '_'), Star (letter | '0' .. '9' | '_')]
       in
       let case_ident =
-        [%sedlex.regexp? ('a' .. 'z' | '_'), Star (letter | '0' .. '9' | '_')]
+        [%sedlex.regexp? ('a' .. 'z' | '_' | '\''), Star (letter | '0' .. '9' | '_')]
       in
       let variable = [%sedlex.regexp? Star (ident, '.'), case_ident] in
       let interpolation = [%sedlex.regexp? "$(", variable, ")"] in

--- a/packages/website/pages/reference/interpolation.mdx
+++ b/packages/website/pages/reference/interpolation.mdx
@@ -16,11 +16,18 @@ module Component = %styled.div(`
 )
 ```
 
+```rescript
+module Component = %styled.div(`
+  max-width: $(maxWidth);
+)
+```
+
+Interpolation works inside values, media-queries and selectors. It doesn't work for entire properties or any interpolation, which is slightly different from SASS/Less and other JavaScript-based solutions (such as styled-components or emotion) their interpolation is more dynamic and can be used everywhere.
+
 <Callout>
   Don't confuse interpolation from [String Interpolation from ReScript](https://rescript-lang.org/docs/manual/latest/primitive-types#string-interpolation).
 </Callout>
 
-Interpolation works inside values, media-queries and selectors. It doesn't work for entire properties, which is slightly different from other JavaScript-based solutions (such as styled-components or emotion) their interpolation is more dynamic and can be used everywhere.
 
 **styled-ppx** forces you to be more rigit, with the promise of being type-safe, the same way as ReScript does ❤️. The dynamism from JavaScript-based solutions comes with the cost of unsafety.
 

--- a/packages/website/pages/reference/interpolation.mdx
+++ b/packages/website/pages/reference/interpolation.mdx
@@ -61,6 +61,11 @@ margin: $(Size.small) 0; // -> margin: 10px 0;
 margin: $(Size.small) $(Size.small); // -> margin: 10px 10px;
 ```
 
+## Features
+
+- Type-safety via type holes
+- Support for shorthand properties and interpolate on a value
+
 ## Type-safety
 
 We introduced here the API from [bs-css](https://github.com/giraud/bs-css) to define the value of `margin`. We expect you to use it to make sure the values are interpoilated with the right type. In the example above `margin` expects one of:


### PR DESCRIPTION
- Fixes https://github.com/davesnx/styled-ppx/issues/272
- Changes ClassVariable from single_selector to subclass. Allowing `.$()` and `div .$()`.
- Improves errors on property parser