### PR TITLE
Support nth-* syntax from Selectors Level 4

### DIFF
--- a/packages/parser/test/css_lexer_test.re
+++ b/packages/parser/test/css_lexer_test.re
@@ -48,21 +48,22 @@ describe("CSS Lexer", ({test, _}) => {
     /* TODO: COMBINATOR or DELIM(+)? */
     ({|+|}, [COMBINATOR("+")]),
     ({|,|}, [COMMA]),
-    /* TODO: Store Number as float/int */
     ({|-45.6|}, [NUMBER("-45.6")]),
+    ({|45%|}, [NUMBER("45"), PERCENTAGE]),
+    ({|2n|}, [DIMENSION(("2", "n"))]),
     /* TODO: Store Float_dimension as float/int */
     /* TODO: Store dimension as a variant */
-    ({|45.6px|}, [FLOAT_DIMENSION(("45.6", "px", Length))]),
+    ({|45.6px|}, [FLOAT_DIMENSION(("45.6", "px"))]),
+    ({|10px|}, [FLOAT_DIMENSION(("10", "px"))]),
     ({|--potato|}, [IDENT("--potato")]),
     ({|-|}, [DELIM("-")]),
-    ({|.7|}, [NUMBER(".7")]),
     ({|.|}, [DOT]),
     ({|*|}, [ASTERISK]),
     ({|&|}, [AMPERSAND]),
     ({|:|}, [COLON]),
     ({|::|}, [DOUBLE_COLON]),
     ({|;|}, [SEMI_COLON]),
-    /* TODO: Support comments on the lexer phase? */
+    /* TODO: Support comments in the lexer? */
     /* ({|<!--|}, [CDO]), */
     /* ({|-->|}, [CDC]), */
     ({|<|}, [DELIM("<")]),
@@ -70,6 +71,7 @@ describe("CSS Lexer", ({test, _}) => {
     ({|@|}, [DELIM("@")]),
     ({|[|}, [LEFT_BRACKET]),
     ({|]|}, [RIGHT_BRACKET]),
+    ({|0.7|}, [NUMBER("0.7")]),
     ({|12345678.9|}, [NUMBER("12345678.9")]),
     ({|bar|}, [IDENT("bar")]),
     ({||}, [EOF]),
@@ -79,11 +81,11 @@ describe("CSS Lexer", ({test, _}) => {
       {|calc(10px + 10px)|},
       [
         FUNCTION("calc"),
-        FLOAT_DIMENSION(("10", "px", Length)),
+        FLOAT_DIMENSION(("10", "px")),
         WS,
         COMBINATOR("+"),
         WS,
-        FLOAT_DIMENSION(("10", "px", Length)),
+        FLOAT_DIMENSION(("10", "px")),
         RIGHT_PAREN,
       ],
     ),
@@ -91,10 +93,10 @@ describe("CSS Lexer", ({test, _}) => {
       {|calc(10px+ 10px)|},
       [
         FUNCTION("calc"),
-        FLOAT_DIMENSION(("10", "px", Length)),
+        FLOAT_DIMENSION(("10", "px")),
         COMBINATOR("+"),
         WS,
-        FLOAT_DIMENSION(("10", "px", Length)),
+        FLOAT_DIMENSION(("10", "px")),
         RIGHT_PAREN,
       ],
     ),

--- a/packages/parser/test/css_parser_test.re
+++ b/packages/parser/test/css_parser_test.re
@@ -61,7 +61,7 @@ describe("CSS Parser", ({test, _}) => {
   List.iter(
     ((input, output)) =>
       test(
-        "should succeed lexing: " ++ input,
+        "should succeed parsing: " ++ input,
         ({expect, _}) => {
           let stylesheet: Types.Stylesheet.t = parse(input) |> Result.get_ok;
           let inputTokens = Debug.render_stylesheet(stylesheet);

--- a/packages/ppx/test/native/Selector_test.re
+++ b/packages/ppx/test/native/Selector_test.re
@@ -41,15 +41,51 @@ let selectors_css_tests = [
     [%expr [%cx {js|[id="baz"] {}|js}]],
     [%expr CssJs.style(. [|CssJs.selector(. {js|[id="baz"]|js}, [||])|])],
   ),
-  /* (
+  (
     "nth-child(even)",
     [%expr [%cx "&:nth-child(even) {}"]],
     [%expr CssJs.style(. [|CssJs.selector(. {js|&:nth-child(even)|js}, [||])|])],
-  ), */
-  /* (
+  ),
+  (
+    "nth-child(odd)",
+    [%expr [%cx "&:nth-child(odd) {}"]],
+    [%expr CssJs.style(. [|CssJs.selector(. {js|&:nth-child(odd)|js}, [||])|])],
+  ),
+  (
     "nth-child(3n+1)",
     [%expr [%cx "&:nth-child(3n+1) {}"]],
     [%expr CssJs.style(. [|CssJs.selector(. {js|&:nth-child(3n+1)|js}, [||])|])],
+  ),
+  (
+    ":nth-child(2n)",
+    [%expr [%cx "&:nth-child(2n) {}"]],
+    [%expr CssJs.style(. [|CssJs.selector(. {js|&:nth-child(2n)|js}, [||])|])],
+  ),
+  (
+    ":nth-child(n)",
+    [%expr [%cx "&:nth-child(n) {}"]],
+    [%expr CssJs.style(. [|CssJs.selector(. {js|&:nth-child(n)|js}, [||])|])],
+  ),
+  (
+    ":nth-child(10n-1)",
+    [%expr [%cx "&:nth-child(10n-1) {}"]],
+    [%expr CssJs.style(. [|CssJs.selector(. {js|&:nth-child(10n-1)|js}, [||])|])],
+  ),
+  (
+    ":nth-child( 10n -1 )",
+    [%expr [%cx "&:nth-child( 10n -1 ) {}"]],
+    [%expr CssJs.style(. [|CssJs.selector(. {js|&:nth-child(10n-1)|js}, [||])|])],
+  ),
+  /* TODO: Support all cases */
+  /* (
+    ":nth-child( 10n - 1 )",
+    [%expr [%cx "&:nth-child( 10n - 1 ) {}"]],
+    [%expr CssJs.style(. [|CssJs.selector(. {js|&:nth-child(10n-1)|js}, [||])|])],
+  ), */
+  /* (
+    ":nth-child(-n+2)",
+    [%expr [%cx "&:nth-child(-n+2) {}"]],
+    [%expr CssJs.style(. [|CssJs.selector(. {js|&:nth-child(-n+2)|js}, [||])|])],
   ), */
 
   /* Compound */

--- a/packages/ppx/test/native/Static_test.re
+++ b/packages/ppx/test/native/Static_test.re
@@ -30,14 +30,19 @@ let extract_tests = array_expr => {
   );
 };
 
+let openMockBsCss = [[%stri open MockBsCss]];
+let ignoreWarning33 = [[%stri [@warning "-33"]]];
+let mapExpected = ((expected, _)) => [%stri let _ = [%e expected]];
+
 let write_tests_to_file = (
   tests: list((expression, expression)),
   file
 ) => {
   let code =
     tests
-    |> List.map(((expected, _)) => [%stri let _ = [%e expected]])
-    |> List.append([[%stri open MockBsCss]])
+    |> List.map(mapExpected)
+    |> List.append(openMockBsCss)
+    |> List.append(ignoreWarning33)
     |> Pprintast.string_of_structure;
   let fd = open_out(file);
   output_string(fd, code);
@@ -385,12 +390,10 @@ let properties_static_css_tests = [%expr
       [%css "word-wrap: normal"],
       CssJs.wordWrap(`normal)
     ),
-    /*
-      not supported by bs-css
-      (
+    (
       [%css "text-align: start"],
       CssJs.textAlign(`start)
-    ), */
+    ),
     (
       [%css "text-align: left"],
       CssJs.textAlign(`left)
@@ -454,6 +457,11 @@ let properties_static_css_tests = [%expr
       [%css "flex: none"],
       CssJs.flex(`none)
     ),
+    /* bs-css doesn't support it */
+    /* (
+      [%css "width: calc(100px)"],
+      CssJs.width(`calc(`add, `percent(100.), `pxFloat(32.)))
+    ), */
     (
       [%css "width: calc(100% + 32px)"],
       CssJs.width(`calc(`add, `percent(100.), `pxFloat(32.)))


### PR DESCRIPTION
Changed a few things here and left a bunch out to not make this PR huge. We don't follow the spec 100% since our lexing for numbers isn't good enough, but we support the most common cases.

I skip the Selectors Level 5 (which isn't implemented in any browser)

Here's the tests:
```
  (
    "nth-child(even)",
    [%expr [%cx "&:nth-child(even) {}"]],
    [%expr CssJs.style(. [|CssJs.selector(. {js|&:nth-child(even)|js}, [||])|])],
  ),
  (
    "nth-child(odd)",
    [%expr [%cx "&:nth-child(odd) {}"]],
    [%expr CssJs.style(. [|CssJs.selector(. {js|&:nth-child(odd)|js}, [||])|])],
  ),
  (
    "nth-child(3n+1)",
    [%expr [%cx "&:nth-child(3n+1) {}"]],
    [%expr CssJs.style(. [|CssJs.selector(. {js|&:nth-child(3n+1)|js}, [||])|])],
  ),
  (
    ":nth-child(2n)",
    [%expr [%cx "&:nth-child(2n) {}"]],
    [%expr CssJs.style(. [|CssJs.selector(. {js|&:nth-child(2n)|js}, [||])|])],
  ),
  (
    ":nth-child(n)",
    [%expr [%cx "&:nth-child(n) {}"]],
    [%expr CssJs.style(. [|CssJs.selector(. {js|&:nth-child(n)|js}, [||])|])],
  ),
  (
    ":nth-child(10n-1)",
    [%expr [%cx "&:nth-child(10n-1) {}"]],
    [%expr CssJs.style(. [|CssJs.selector(. {js|&:nth-child(10n-1)|js}, [||])|])],
  ),
  (
    ":nth-child( 10n -1 )",
    [%expr [%cx "&:nth-child( 10n -1 ) {}"]],
    [%expr CssJs.style(. [|CssJs.selector(. {js|&:nth-child(10n-1)|js}, [||])|])],
  ),
  /* TODO: Support all cases */
  /* (
    ":nth-child( 10n - 1 )",
    [%expr [%cx "&:nth-child( 10n - 1 ) {}"]],
    [%expr CssJs.style(. [|CssJs.selector(. {js|&:nth-child(10n-1)|js}, [||])|])],
  ), */
  /* (
    ":nth-child(-n+2)",
    [%expr [%cx "&:nth-child(-n+2) {}"]],
    [%expr CssJs.style(. [|CssJs.selector(. {js|&:nth-child(-n+2)|js}, [||])|])],
  ), */
```

I tried to bring the Reason_css_lexer logic into it but endup with massive changes cross parser/lexer/types and problems from those changes. I discarted and add the minimum hacks to support almost all cases.

- Added nth_function as a token
- Removed dimension from FLOAT_DIMENSION
