### PR TITLE
relax ppxlib constraint

### DIFF
--- a/styled-ppx.opam
+++ b/styled-ppx.opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml-migrate-parsetree" {= "2.4.0"}
   "ocaml" {= "4.14.0"}
   "ppx_deriving" {= "5.2.1"}
-  "ppxlib" {= "0.27.0"}
+  "ppxlib" {>= "0.27.0"}
   "reason" {= "3.8.2"}
   "sedlex" {= "3.0"}
   "ocaml-lsp-server" {dev}


### PR DESCRIPTION
Pinning to exact version makes it impossible for styled-ppx to be installed with other packages like melange `reactjs-jsx-ppx`:

https://github.com/melange-re/melange/blob/68c6eff82ed056feed809d6cc82558e8697b965b/reactjs-jsx-ppx.opam#L12