### PR TITLE
Fixing a bunch of issues with parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@davesnx/styled-ppx",
-  "version": "0.38.1",
+  "version": "0.39.0",
   "description": "Typed styled components in ReScript",
   "author": "David Sancho <dsnxmoreno@gmail.com>",
   "license": "BSD-2",

--- a/packages/parser/lib/css_lexer.re
+++ b/packages/parser/lib/css_lexer.re
@@ -633,7 +633,7 @@ let rec get_next_token = buf => {
     } else {
       WS;
     }
-  /* -moz-* */
+  /* | "n" => Parser.N */
   | ("-", ident) => Parser.IDENT(latin1(buf))
   /* --variable */
   | ("-", "-", ident) => Parser.IDENT(latin1(buf))

--- a/packages/parser/lib/css_lexer.re
+++ b/packages/parser/lib/css_lexer.re
@@ -704,7 +704,7 @@ let parse_string =
 
 let parse_declaration_list = (~container_lnum=?, ~pos=?, input: string) => {
   parse_string(
-    ~skip_whitespace=true,
+    ~skip_whitespace=false,
     ~container_lnum?,
     ~pos?,
     Parser.declaration_list,

--- a/packages/parser/lib/css_parser.mly
+++ b/packages/parser/lib/css_parser.mly
@@ -239,7 +239,7 @@ declaration: d = declaration_without_eof; EOF { d }
 
 declaration_without_eof:
   /* property: value; */
-  | property = loc(IDENT) WS? COLON WS?
+  | WS? property = loc(IDENT) WS? COLON WS?
     value = loc(values) WS?
     important = loc(boption(IMPORTANT)) WS? SEMI_COLON? {
     { name = property;

--- a/packages/parser/lib/css_parser.mly
+++ b/packages/parser/lib/css_parser.mly
@@ -222,7 +222,7 @@ style_rule:
     }
   }
 
-values: xs = nonempty_list(loc(value)) { xs }
+values: xs = nonempty_list(loc(skip_ws(value))) { xs }
 
 declarations:
   | xs = nonempty_list(rule) SEMI_COLON? { xs }

--- a/packages/parser/lib/css_parser.mly
+++ b/packages/parser/lib/css_parser.mly
@@ -250,10 +250,8 @@ declaration_without_eof:
   }
 
 nth_payload:
+  /* TODO implement [of <complex-selector-list>]? */
   /* | complex = complex_selector_list; { NthSelector complex } */
-  /* even, odd */
-  /* | EVEN { Nth Even } */
-  /* | ODD { Nth Odd } */
   /* <An+B> */
   /* 2 */
   | a = NUMBER { Nth (A (int_of_string a)) }

--- a/packages/parser/lib/css_parser.mly
+++ b/packages/parser/lib/css_parser.mly
@@ -53,7 +53,7 @@ stylesheet: s = stylesheet_without_eof; EOF { s }
 stylesheet_without_eof: rs = loc(list(rule)) { rs }
 
 declaration_list:
-  | EOF { ([], Lex_buffer.make_loc $startpos $endpos) }
+  | WS? EOF { ([], Lex_buffer.make_loc $startpos $endpos) }
   | ds = loc(declarations) EOF { ds }
 
 /* keyframe may contain {} */

--- a/packages/parser/lib/css_parser.mly
+++ b/packages/parser/lib/css_parser.mly
@@ -253,9 +253,12 @@ declaration: d = declaration_without_eof; EOF { d }
 
 declaration_without_eof:
   /* property: value; */
-  | WS? property = loc(IDENT) WS? COLON WS?
-    value = loc(values) WS?
-    important = loc(boption(IMPORTANT)) WS? SEMI_COLON? {
+  | WS? property = loc(IDENT)
+    WS? COLON
+    WS? value = loc(values)
+    WS? important = loc(boption(IMPORTANT))
+    WS? SEMI_COLON?
+    WS? {
     { name = property;
       value;
       important;

--- a/packages/parser/lib/css_parser.mly
+++ b/packages/parser/lib/css_parser.mly
@@ -239,8 +239,8 @@ style_rule:
 values: xs = nonempty_list(loc(skip_ws(value))) { xs }
 
 declarations:
-  | xs = nonempty_list(rule) SEMI_COLON? { xs }
-  | xs = separated_nonempty_list(SEMI_COLON, rule) SEMI_COLON? { xs }
+  | WS? xs = nonempty_list(rule) SEMI_COLON? { xs }
+  | WS? xs = separated_nonempty_list(SEMI_COLON, rule) SEMI_COLON? { xs }
 
 %inline rule:
   /* Rule can have declarations, since we have nesting, so both style_rules and

--- a/packages/parser/lib/css_types.re
+++ b/packages/parser/lib/css_types.re
@@ -148,7 +148,8 @@ and nth_payload =
   | NthSelector(list(complex_selector))
 [@deriving show({with_path: false})]
 and nth =
-  | NthIdent(string)
-  | A(string)
-  | AN(string)
-  | ANB(string, string, string);
+  | Even
+  | Odd
+  | A(int)
+  | AN(int)
+  | ANB(int, string, int);

--- a/packages/ppx/src/css_to_emotion.re
+++ b/packages/ppx/src/css_to_emotion.re
@@ -255,16 +255,17 @@ and render_selector = (selector: selector) => {
       }
     | Pseudo_class(psc) => render_pseudo_selector(psc)
   and render_nth =
-    fun
-    | NthIdent(i) when i == "even" => i
-    | NthIdent(i) when i == "odd" => i
-    | NthIdent(i) when i == "n" => i
     /* TODO: Add location in ast, pass it here */
-    | NthIdent(ident) =>
-      Lexer.grammar_error(Location.none, "'" ++ ident ++ "' is invalid")
-    | A(a) => a
-    | AN(an) => an ++ "n"
-    | ANB(a, op, b) => a ++ "n" ++ op ++ b
+    fun
+    | Even => "even"
+    | Odd => "odd"
+    | A(a) => Int.to_string(a)
+    | AN(an) when an == 1 => "n"
+    | AN(an) when an == (-1) => "-n"
+    | AN(an) => Int.to_string(an) ++ "n"
+    | ANB(a, op, b) when a == 1 => "n" ++ op ++ Int.to_string(b)
+    | ANB(a, op, b) when a == (-1) => "-n" ++ op ++ Int.to_string(b)
+    | ANB(a, op, b) => Int.to_string(a) ++ "n" ++ op ++ Int.to_string(b)
   and render_nth_payload =
     fun
     | Nth(nth) => render_nth(nth)

--- a/packages/ppx/test/native/At_rule_test.re
+++ b/packages/ppx/test/native/At_rule_test.re
@@ -108,6 +108,18 @@ let keyframe_tests = [
     ],
   ),
   (
+    {|%keyframe "0%, 50%, 3% { color: red } 100% { color: green }"|},
+    [%expr [%keyframe "0%, 50%, 3% { color: red } 100% { color: green }"]],
+    [%expr
+      CssJs.keyframes(. [|
+        (0, [|CssJs.color(CssJs.red)|]),
+        (50, [|CssJs.color(CssJs.red)|]),
+        (3, [|CssJs.color(CssJs.red)|]),
+        (100, [|CssJs.color(CssJs.green)|]),
+      |])
+    ],
+  ),
+  (
     {|%keyframe "0% { color: red } 100% { color: green }"|},
     [%expr [%keyframe "{ 0% { color: red } 100% { color: green }}"]],
     [%expr

--- a/packages/ppx/test/native/Selector_test.re
+++ b/packages/ppx/test/native/Selector_test.re
@@ -77,6 +77,13 @@ let simple_tests = [
     ],
   ),
   (
+    ":nth-child(-n+3)",
+    [%expr [%cx "&:nth-child(-n+3) {}"]],
+    [%expr
+      CssJs.style(. [|CssJs.selector(. {js|&:nth-child(-n+3)|js}, [||])|])
+    ],
+  ),
+  (
     ":nth-child( 10n -1 )",
     [%expr [%cx "&:nth-child(10n-1) {}"]],
     [%expr

--- a/packages/ppx/test/native/Selector_test.re
+++ b/packages/ppx/test/native/Selector_test.re
@@ -95,17 +95,13 @@ let simple_tests = [
     [%expr [%cx ".a, .b {}"]],
     [%expr CssJs.style(. [|CssJs.selector(. {js|.a, .b|js}, [||])|])],
   ),
-  /* TODO: Support all cases */
-  /* (
-       ":nth-child( 10n - 1 )",
-       [%expr [%cx "&:nth-child( 10n - 1 ) {}"]],
-       [%expr CssJs.style(. [|CssJs.selector(. {js|&:nth-child(10n-1)|js}, [||])|])],
-     ), */
-  /* (
-       ":nth-child(-n+2)",
-       [%expr [%cx "&:nth-child(-n+2) {}"]],
-       [%expr CssJs.style(. [|CssJs.selector(. {js|&:nth-child(-n+2)|js}, [||])|])],
-     ), */
+  (
+    ":nth-child(-n+2)",
+    [%expr [%cx "&:nth-child(-n+2) {}"]],
+    [%expr
+      CssJs.style(. [|CssJs.selector(. {js|&:nth-child(-n+2)|js}, [||])|])
+    ],
+  ),
 ];
 
 let compound_tests = [

--- a/packages/ppx/test/native/Selector_test.re
+++ b/packages/ppx/test/native/Selector_test.re
@@ -436,8 +436,28 @@ let nested_tests = [
     ],
   ),
   (
+    ".a .b",
+    [%expr [%cx "display: block; .a .b {}"]],
+    [%expr
+      CssJs.style(. [|
+        CssJs.display(`block),
+        CssJs.selector(. {js|.a .b|js}, [||]),
+      |])
+    ],
+  ),
+  (
+    "& .a .b",
+    [%expr [%cx "display: block; & .a .b {}"]],
+    [%expr
+      CssJs.style(. [|
+        CssJs.display(`block),
+        CssJs.selector(. {js|& .a .b|js}, [||]),
+      |])
+    ],
+  ),
+  (
     ".$(aaa) { .$(bbb) { } }",
-    [%expr [%cx ".$(aaa) { .$(bbb){} }"]],
+    [%expr [%cx ".$(aaa) { .$(bbb) {} }"]],
     [%expr
       CssJs.style(. [|
         CssJs.selector(.

--- a/packages/ppx/test/native/Static_test.re
+++ b/packages/ppx/test/native/Static_test.re
@@ -631,6 +631,30 @@ let properties_static_css_tests = [
     Css.color(`var({js|--main-c|js})),
     [%expr CssJs.color(`var({js|--main-c|js}))],
   ),
+  (
+    [%css "box-shadow: 12px 12px 2px 1px rgba(0, 0, 255, 0.2)"],
+    [%expr [%css "box-shadow: 12px 12px 2px 1px rgba(0, 0, 255, 0.2)"]],
+    Css.boxShadows([|
+      Shadow.box(
+        ~x=`pxFloat(12.),
+        ~y=`pxFloat(12.),
+        ~blur=`pxFloat(2.),
+        ~spread=`pxFloat(1.),
+        `rgba((0, 0, 255, `num(0.2))),
+      ),
+    |]),
+    [%expr
+      CssJs.boxShadows([|
+        CssJs.Shadow.box(
+          ~x=`pxFloat(12.),
+          ~y=`pxFloat(12.),
+          ~blur=`pxFloat(2.),
+          ~spread=`pxFloat(1.),
+          `rgba((0, 0, 255, `num(0.2))),
+        ),
+      |])
+    ],
+  ),
   /* (
        [%css "color: var(--main-c, #fff)"],
        [%expr [%css "color: var(--main-c, #fff)"]],
@@ -706,7 +730,7 @@ let runner = tests =>
           let pp_expr = (ppf, x) =>
             Fmt.pf(ppf, "%S", Pprintast.string_of_expression(x));
           let check_expr = testable(pp_expr, (==));
-          check(check_expr, "", input, expected);
+          check(check_expr, "", expected, input);
         },
       );
     },

--- a/packages/ppx/test/native/Whitespace_test.re
+++ b/packages/ppx/test/native/Whitespace_test.re
@@ -5,6 +5,7 @@ let loc = Location.none;
 
 let tests =
   [
+    ("ignore in empty", [%expr [%cx " "]], [%expr [%cx ""]]),
     ("ignore in style_rule", [%expr [%cx ".bar{}"]], [%expr [%cx ".bar {}"]]),
     (
       "ignore in style_rule",
@@ -83,6 +84,18 @@ let tests =
       "ignore space on values, such as box-shadow",
       [%expr [%cx "box-shadow:    12px 12px 2px 1px rgba(0, 0, 255, 0.2)"]],
       [%expr [%cx "box-shadow: 12px 12px 2px 1px rgba(0, 0, 255, 0.2)"]],
+    ),
+    (
+      "ignore space on values, such as box-shadow",
+      [%expr
+        [%cx
+          {|
+  /* standard width 240px - standard padding 8px * 2 */
+  width: 214px;
+|}
+        ]
+      ],
+      [%expr [%cx {| width: 214px;|}]],
     ),
     (
       "html, body, #root, .class",

--- a/packages/ppx/test/native/Whitespace_test.re
+++ b/packages/ppx/test/native/Whitespace_test.re
@@ -86,7 +86,7 @@ let tests =
       [%expr [%cx "box-shadow: 12px 12px 2px 1px rgba(0, 0, 255, 0.2)"]],
     ),
     (
-      "ignore space on values, such as box-shadow",
+      "ignore space before/after comments values",
       [%expr
         [%cx
           {|
@@ -96,6 +96,15 @@ let tests =
         ]
       ],
       [%expr [%cx {| width: 214px;|}]],
+    ),
+    (
+      "ignore space after comments after rules",
+      [%expr
+        [%cx {|
+  width: 100%; /* otherwise will overflow container */
+|}]
+      ],
+      [%expr [%cx {| width: 100%; |}]],
     ),
     (
       "html, body, #root, .class",

--- a/packages/ppx/test/native/Whitespace_test.re
+++ b/packages/ppx/test/native/Whitespace_test.re
@@ -80,6 +80,11 @@ let tests =
       [%expr [%css "background-image: url('img_tree.gif' )"]],
     ),
     (
+      "ignore space on values, such as box-shadow",
+      [%expr [%cx "box-shadow:    12px 12px 2px 1px rgba(0, 0, 255, 0.2)"]],
+      [%expr [%cx "box-shadow: 12px 12px 2px 1px rgba(0, 0, 255, 0.2)"]],
+    ),
+    (
       "html, body, #root, .class",
       [%expr
         [%styled.global

--- a/packages/renderer/ast_renderer.re
+++ b/packages/renderer/ast_renderer.re
@@ -32,7 +32,7 @@ switch (input, help) {
 | (None, _) => render_help()
 | (Some(css), _) =>
   try(
-    Css_lexer.parse_keyframes(~container_lnum, ~pos, css)
+    Css_lexer.parse_declaration_list(~container_lnum, ~pos, css)
     |> Css_types.pp_rule_list(Format.std_formatter)
   ) {
   | exn =>

--- a/packages/renderer/ast_renderer.re
+++ b/packages/renderer/ast_renderer.re
@@ -32,7 +32,7 @@ switch (input, help) {
 | (None, _) => render_help()
 | (Some(css), _) =>
   try(
-    Css_lexer.parse_declaration_list(~container_lnum, ~pos, css)
+    Css_lexer.parse_keyframes(~container_lnum, ~pos, css)
     |> Css_types.pp_rule_list(Format.std_formatter)
   ) {
   | exn =>

--- a/packages/website/pages/reference/selectors.mdx
+++ b/packages/website/pages/reference/selectors.mdx
@@ -19,6 +19,8 @@ let link = %cx(`
 ```
 > Note: Selectors can be nested within your CSS which will be attached to the classname generated (in this case by `cx`)
 
+More than one level of selectors is not supported. It might compile but will generate the wrong result.
+
 The support for selectors is CSS Selectors Level 3 and the more stable part of level 4 (currently in draft).
 
 ## Interpolation in selectors


### PR DESCRIPTION
- BREAKING CHANGE: Selectors now don't require to have &.
- Fixing keyframe supports multiple percentages: 0%, 10% { color: blue }
- Fixing a miss-conception about nth-payload on pseudo-selectors: nth-child(n), nth-child(-n), nth-child(n+3).