### PR TITLE
Add test to show missing error locations when applying styled-ppx.lib

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.8)
+(lang dune 3.7)
 (cram enable)
 
 (using menhir 2.0)

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.7)
+(lang dune 3.8)
 (cram enable)
 
 (using menhir 2.0)

--- a/packages/ppx/test/snapshot/reason/error-locations.t
+++ b/packages/ppx/test/snapshot/reason/error-locations.t
@@ -1,69 +1,35 @@
   $ cat > main.ml <<EOF
-  > type config = {
-  >   leading: bool [@bs.optional];
-  >   trailing: bool [@bs.optional];
-  > } [@@deriving abstract]
+  > let foo != syntax_error
   > EOF
 
   $ cat > dune-project <<EOF
   > (lang dune 3.8)
-  > (using melange 0.1)
   > EOF
 
   $ cat > dune <<EOF
-  > (melange.emit
-  >  (target melange)
-  >  (alias mel)
-  >  (modules main)
-  >  (preprocess
-  >   (pps melange.ppx))
-  >  (module_systems commonjs))
+  > (executable
+  >  (name main))
   > EOF
 
-Preprocessing with melange.ppx shows the error on the right location
+Shows errors in right locations
 
-  $ dune build @mel
-  File "main.ml", line 3, characters 12-16:
-  3 |   trailing: bool [@bs.optional];
-                  ^^^^
-  Error: [@bs.optional] must appear on a type explicitly annotated with `option'
+  $ dune build main.exe
+  File "main.ml", line 1, characters 8-10:
+  1 | let foo != syntax_error
+              ^^
+  Error: Syntax error
   [1]
 
   $ cat > dune <<EOF
-  > (melange.emit
-  >  (target melange)
-  >  (alias mel)
-  >  (modules main)
+  > (executable
+  >  (name main)
   >  (preprocess
-  >   (pps melange.ppx styled-ppx.lib))
-  >  (module_systems commonjs))
+  >   (pps styled-ppx.lib)))
   > EOF
 
-Preprocessing with melange.ppx and styled-ppx.lib loses the error location information
+Preprocessing with styled-ppx.lib loses the error location information
 
-  $ dune build @mel
-  File "_none_", line 1:
-  Error: Unexpected error [@bs.optional] must appear on a type explicitly annotated with `option'
-  [1]
-
-  $ cat > main.ml <<EOF
-  > let foo != syntax_error
-  > EOF
-
-Any syntax error is missing locations
-
-  $ cat > dune <<EOF
-  > (melange.emit
-  >  (target melange)
-  >  (alias mel)
-  >  (modules main)
-  >  (preprocess
-  >   (pps styled-ppx.lib))
-  >  (module_systems commonjs))
-  > EOF
-
-  $ dune build @mel
+  $ dune build main.exe
   File "_none_", line 1:
   Error: Unexpected error Unexpected error Syntaxerr.Error(_)
   [1]
-

--- a/packages/ppx/test/snapshot/reason/error-locations.t
+++ b/packages/ppx/test/snapshot/reason/error-locations.t
@@ -1,0 +1,69 @@
+  $ cat > main.ml <<EOF
+  > type config = {
+  >   leading: bool [@bs.optional];
+  >   trailing: bool [@bs.optional];
+  > } [@@deriving abstract]
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.8)
+  > (using melange 0.1)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target melange)
+  >  (alias mel)
+  >  (modules main)
+  >  (preprocess
+  >   (pps melange.ppx))
+  >  (module_systems commonjs))
+  > EOF
+
+Preprocessing with melange.ppx shows the error on the right location
+
+  $ dune build @mel
+  File "main.ml", line 3, characters 12-16:
+  3 |   trailing: bool [@bs.optional];
+                  ^^^^
+  Error: [@bs.optional] must appear on a type explicitly annotated with `option'
+  [1]
+
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target melange)
+  >  (alias mel)
+  >  (modules main)
+  >  (preprocess
+  >   (pps melange.ppx styled-ppx.lib))
+  >  (module_systems commonjs))
+  > EOF
+
+Preprocessing with melange.ppx and styled-ppx.lib loses the error location information
+
+  $ dune build @mel
+  File "_none_", line 1:
+  Error: Unexpected error [@bs.optional] must appear on a type explicitly annotated with `option'
+  [1]
+
+  $ cat > main.ml <<EOF
+  > let foo != syntax_error
+  > EOF
+
+Any syntax error is missing locations
+
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target melange)
+  >  (alias mel)
+  >  (modules main)
+  >  (preprocess
+  >   (pps styled-ppx.lib))
+  >  (module_systems commonjs))
+  > EOF
+
+  $ dune build @mel
+  File "_none_", line 1:
+  Error: Unexpected error Unexpected error Syntaxerr.Error(_)
+  [1]
+


### PR DESCRIPTION
Adds a cram test to show that locations are missing when syntactic errors happen when using `styled-ppx.lib`.