### PR TITLE
test some hash collision

### DIFF
--- a/packages/emotion/test/test_css_js_styles.ml
+++ b/packages/emotion/test/test_css_js_styles.ml
@@ -60,6 +60,38 @@ let selector_with_ppx () =
     (Printf.sprintf ".%s { color: #FF0000; } .%s  > * { color: #0000FF; }"
        className className)
 
+let hash_collision () =
+  let className1 =
+    let color, hoverColor, disabledColor = `var "alt-text--tertiary", `var "alt-text--primary", `var "alt-text--tertiary"
+    in
+    [%cx {|
+      color: $(color);
+  
+      :disabled {
+        color: $(disabledColor);
+      }
+  
+      :hover {
+        color: $(hoverColor);
+      }
+    |}]
+  in
+  let className2 =
+    let padding =`px 16
+    in
+    [%cx {|
+      display: flex;
+  
+      :before,
+      :after {
+        content: '';
+        flex: 0 0 $(padding);
+      }
+    |}]
+  in
+  let _css = render_style_tag () in
+  assert_string className1 className2
+
 (* let className =
      [%cx
        {|
@@ -275,6 +307,7 @@ let tests =
       case "keyframe" keyframe;
       case "duplicated_styles_unique" duplicated_styles_unique;
       case "selector_with_ppx" selector_with_ppx;
+      case "hash_collision" hash_collision;
       (* case "random_classname" random_classname; *)
       (* case "interpolated_selector_with_ppx" interpolated_selector_with_ppx; *)
       (* case "label_ppx_unique" label_ppx_unique; *)


### PR DESCRIPTION
Adds a test with a hash collision between two different blocks. Both blocks included in the test produce the hash `5m0cai`.