### PR TITLE
Update hash function to match emotion

### DIFF
--- a/packages/emotion-hash/compare.js
+++ b/packages/emotion-hash/compare.js
@@ -1,0 +1,15 @@
+const { exit } = require('process');
+const emotion = require('./emotion-murmur');
+
+const input = process.argv[2];
+const js = emotion(input);
+let native = require('child_process').execSync(`dune exec styled-ppx.native_hash "${input}"`).toString();
+native = native.slice(0, -1); // ends with newline
+
+if (js != native) {
+    console.error(`js output differs from native, js=${js}, native=${native}`)
+    exit(1)
+} else {
+    console.log(js);
+    exit(0);
+}

--- a/packages/emotion-hash/dune
+++ b/packages/emotion-hash/dune
@@ -5,3 +5,12 @@
  (public_name styled-ppx.emotion-hash)
  (modules hash)
  (modes :standard melange))
+
+(executable
+ (name native_hash)
+ (public_name styled-ppx.native_hash)
+ (modules native_hash)
+ (libraries emotion_hash))
+
+(cram
+ (deps %{bin:styled-ppx.native_hash} %{bin:node} ./compare.js ./emotion-murmur.js))

--- a/packages/emotion-hash/emotion-murmur.js
+++ b/packages/emotion-hash/emotion-murmur.js
@@ -1,0 +1,82 @@
+// from: https://github.com/emotion-js/emotion/blob/f3b268f7c52103979402da919c9c0dd3f9e0e189/packages/hash/src/index.js
+// @flow
+/* eslint-disable */
+// Inspired by https://github.com/garycourt/murmurhash-js
+// Ported from https://github.com/aappleby/smhasher/blob/61a0530f28277f2e850bfc39600ce61d02b518de/src/MurmurHash2.cpp#L37-L86
+
+function murmur2(str) {
+    // 'm' and 'r' are mixing constants generated offline.
+    // They're not really 'magic', they just happen to work well.
+  
+    // const m = 0x5bd1e995;
+    // const r = 24;
+  
+    // Initialize the hash
+  
+    var h = 0
+  
+    // Mix 4 bytes at a time into the hash
+  
+    var k,
+      i = 0,
+      len = str.length
+    for (; len >= 4; ++i, len -= 4) {
+      k =
+        (str.charCodeAt(i) & 0xff) |
+        ((str.charCodeAt(++i) & 0xff) << 8) |
+        ((str.charCodeAt(++i) & 0xff) << 16) |
+        ((str.charCodeAt(++i) & 0xff) << 24)
+  
+      k =
+        /* Math.imul(k, m): */
+        (k & 0xffff) * 0x5bd1e995 + (((k >>> 16) * 0xe995) << 16)
+        console.log("K INIT", k.toString(16).substr(4, 12));
+        k ^= /* k >>> r: */ k >>> 24
+  
+      console.log("K FINAL", (k >>> 0).toString(16));
+      h =
+        /* Math.imul(k, m): */
+        ((k & 0xffff) * 0x5bd1e995 + (((k >>> 16) * 0xe995) << 16)) ^
+        /* Math.imul(h, m): */
+        ((h & 0xffff) * 0x5bd1e995 + (((h >>> 16) * 0xe995) << 16));
+      // console.log("loop", i+1);
+      // console.log("len", len);
+      // console.log("H iS:", (h >>> 0).toString(16));
+    }
+  
+    // Handle the last few bytes of the input array
+    // console.log("len", len);
+    // console.log("i", i);
+    // console.log("H iS:", (h >>> 0).toString(16));
+    switch (len) {
+      case 3:
+        h ^= (str.charCodeAt(i + 2) & 0xff) << 16
+      case 2:
+        // console.log("str", str);
+        // console.log("index", i + 1);
+        // console.log("ofchar", h ^ ((0x20 & 0xff)<< 8));
+        h ^= (str.charCodeAt(i + 1) & 0xff) << 8
+      case 1:
+        h ^= str.charCodeAt(i) & 0xff
+        h =
+          /* Math.imul(h, m): */
+          (h & 0xffff) * 0x5bd1e995 + (((h >>> 16) * 0xe995) << 16)
+    }
+    console.log("h prefinal", (h >>> 0));
+
+    // Do a few final mixes of the hash to ensure the last few
+    // bytes are well-incorporated.
+  
+    h ^= h >>> 13
+    console.log("ONE", ((h & 0xffff) * 0x5bd1e995) >>> 0);
+    console.log("TWO", (((h >>> 16) * 0xe995) << 16));
+    h =
+      /* Math.imul(h, m): */
+      (h & 0xffff) * 0x5bd1e995 + (((h >>> 16) * 0xe995) << 16)
+    console.log("h prealmostfinal", (h.toString(16)));
+    console.log("h shifted is:", ((h >>> 15).toString(16)));
+    console.log("H FINAL is:", ((h ^ (h >>> 15)) >>> 0).toString(16));
+    return ((h ^ (h >>> 15)) >>> 0).toString(36)
+  }
+
+module.exports = murmur2

--- a/packages/emotion-hash/emotion-murmur.js
+++ b/packages/emotion-hash/emotion-murmur.js
@@ -5,78 +5,63 @@
 // Ported from https://github.com/aappleby/smhasher/blob/61a0530f28277f2e850bfc39600ce61d02b518de/src/MurmurHash2.cpp#L37-L86
 
 function murmur2(str) {
-    // 'm' and 'r' are mixing constants generated offline.
-    // They're not really 'magic', they just happen to work well.
-  
-    // const m = 0x5bd1e995;
-    // const r = 24;
-  
-    // Initialize the hash
-  
-    var h = 0
-  
-    // Mix 4 bytes at a time into the hash
-  
-    var k,
-      i = 0,
-      len = str.length
-    for (; len >= 4; ++i, len -= 4) {
-      k =
-        (str.charCodeAt(i) & 0xff) |
-        ((str.charCodeAt(++i) & 0xff) << 8) |
-        ((str.charCodeAt(++i) & 0xff) << 16) |
-        ((str.charCodeAt(++i) & 0xff) << 24)
-  
-      k =
-        /* Math.imul(k, m): */
-        (k & 0xffff) * 0x5bd1e995 + (((k >>> 16) * 0xe995) << 16)
-        console.log("K INIT", k.toString(16).substr(4, 12));
-        k ^= /* k >>> r: */ k >>> 24
-  
-      console.log("K FINAL", (k >>> 0).toString(16));
-      h =
-        /* Math.imul(k, m): */
-        ((k & 0xffff) * 0x5bd1e995 + (((k >>> 16) * 0xe995) << 16)) ^
-        /* Math.imul(h, m): */
-        ((h & 0xffff) * 0x5bd1e995 + (((h >>> 16) * 0xe995) << 16));
-      // console.log("loop", i+1);
-      // console.log("len", len);
-      // console.log("H iS:", (h >>> 0).toString(16));
-    }
-  
-    // Handle the last few bytes of the input array
-    // console.log("len", len);
-    // console.log("i", i);
-    // console.log("H iS:", (h >>> 0).toString(16));
-    switch (len) {
-      case 3:
-        h ^= (str.charCodeAt(i + 2) & 0xff) << 16
-      case 2:
-        // console.log("str", str);
-        // console.log("index", i + 1);
-        // console.log("ofchar", h ^ ((0x20 & 0xff)<< 8));
-        h ^= (str.charCodeAt(i + 1) & 0xff) << 8
-      case 1:
-        h ^= str.charCodeAt(i) & 0xff
-        h =
-          /* Math.imul(h, m): */
-          (h & 0xffff) * 0x5bd1e995 + (((h >>> 16) * 0xe995) << 16)
-    }
-    console.log("h prefinal", (h >>> 0));
+  // 'm' and 'r' are mixing constants generated offline.
+  // They're not really 'magic', they just happen to work well.
 
-    // Do a few final mixes of the hash to ensure the last few
-    // bytes are well-incorporated.
-  
-    h ^= h >>> 13
-    console.log("ONE", ((h & 0xffff) * 0x5bd1e995) >>> 0);
-    console.log("TWO", (((h >>> 16) * 0xe995) << 16));
+  // const m = 0x5bd1e995;
+  // const r = 24;
+
+  // Initialize the hash
+
+  var h = 0
+
+  // Mix 4 bytes at a time into the hash
+
+  var k,
+    i = 0,
+    len = str.length
+  for (; len >= 4; ++i, len -= 4) {
+    k =
+      (str.charCodeAt(i) & 0xff) |
+      ((str.charCodeAt(++i) & 0xff) << 8) |
+      ((str.charCodeAt(++i) & 0xff) << 16) |
+      ((str.charCodeAt(++i) & 0xff) << 24)
+
+    k =
+      /* Math.imul(k, m): */
+      (k & 0xffff) * 0x5bd1e995 + (((k >>> 16) * 0xe995) << 16)
+    k ^= /* k >>> r: */ k >>> 24
+
     h =
+      /* Math.imul(k, m): */
+      ((k & 0xffff) * 0x5bd1e995 + (((k >>> 16) * 0xe995) << 16)) ^
       /* Math.imul(h, m): */
-      (h & 0xffff) * 0x5bd1e995 + (((h >>> 16) * 0xe995) << 16)
-    console.log("h prealmostfinal", (h.toString(16)));
-    console.log("h shifted is:", ((h >>> 15).toString(16)));
-    console.log("H FINAL is:", ((h ^ (h >>> 15)) >>> 0).toString(16));
-    return ((h ^ (h >>> 15)) >>> 0).toString(36)
+      ((h & 0xffff) * 0x5bd1e995 + (((h >>> 16) * 0xe995) << 16))
   }
+
+  // Handle the last few bytes of the input array
+
+  switch (len) {
+    case 3:
+      h ^= (str.charCodeAt(i + 2) & 0xff) << 16
+    case 2:
+      h ^= (str.charCodeAt(i + 1) & 0xff) << 8
+    case 1:
+      h ^= str.charCodeAt(i) & 0xff
+      h =
+        /* Math.imul(h, m): */
+        (h & 0xffff) * 0x5bd1e995 + (((h >>> 16) * 0xe995) << 16)
+  }
+
+  // Do a few final mixes of the hash to ensure the last few
+  // bytes are well-incorporated.
+
+  h ^= h >>> 13
+  h =
+    /* Math.imul(h, m): */
+    (h & 0xffff) * 0x5bd1e995 + (((h >>> 16) * 0xe995) << 16)
+
+  return ((h ^ (h >>> 15)) >>> 0).toString(36)
+}
 
 module.exports = murmur2

--- a/packages/emotion-hash/hash.ml
+++ b/packages/emotion-hash/hash.ml
@@ -42,34 +42,20 @@ let default str =
     in
 
     let k = add (mul (k land 0xffffl) m) (mul (k lsr 16) 0xe995l lsl 16) in
-    print_endline (Printf.sprintf "K INIT: %lx" k);
     let k = k lxor (k lsr r) in
 
-    print_endline (Printf.sprintf "K FINAL: %lx" k);
     h :=
       add (mul (k land 0xffffl) m) (mul (k lsr 16) 0xe995l lsl 16)
       lxor add (mul (!h land 0xffffl) m) (mul (!h lsr 16) 0xe995l lsl 16);
 
     i := !i + 4;
     len := !len - 4
-    (* print_endline (Printf.sprintf "loop %d" !i);
-       print_endline (Printf.sprintf "len %d" !len);
-       print_endline (Printf.sprintf "H is: %lx" !h) *)
   done;
-
-  (* print_endline (Printf.sprintf "len: %d" !len);
-     print_endline (Printf.sprintf "i: %d" !i);
-     print_endline (Printf.sprintf "H is: %lx" !h); *)
 
   (* Handle the last few bytes of the input array *)
   let () =
     if !len = 3 then h := !h lxor ((of_char str.[!i + 2] land 0xffl) lsl 16);
     if !len >= 2 then begin
-      (* print_endline "here";
-         print_endline str;
-         print_endline (Printf.sprintf "INDXE %d" (!i + 1));
-         print_endline
-           (Printf.sprintf "ofchar %ld" (!h lxor ((0x20l land 0xffl) lsl 8))); *)
       h := !h lxor ((of_char str.[!i + 1] land 0xffl) lsl 8)
     end;
     if !len >= 1 then begin
@@ -81,23 +67,6 @@ let default str =
   (* Do a few final mixes of the hash to ensure the last few
      bytes are well-incorporated. *)
   h := !h lxor (!h lsr 13);
-  let () = print_endline (Printf.sprintf "ONE %ld" (mul (!h land 0xffffl) m)) in
-  let () =
-    print_endline (Printf.sprintf "TWO %ld" (mul (!h lsr 16) 0xe995l lsl 16))
-  in
-  h :=
-      add
-        (mul (!h land 0xffffl) (m))
-        (mul (!h lsr 16) 0xe995l lsl 16);
-  let () = print_endline (Printf.sprintf "H prealmostfinal is: %lx" !h) in
-  let () = print_endline (Printf.sprintf "H shifted is: %lx" (!h lsr 15)) in
-  let () =
-    print_endline
-      (Printf.sprintf "H test is: %s" (to_base36_string 0xf77f8879l))
-  in
 
-  print_endline (Printf.sprintf "H FINAL is: %lx" !h);
-  print_endline
-    (Printf.sprintf "FINAL %s"
-       (to_base36_string (!h lxor (!h lsr 15) land 0xffffffffl)));
+  h := add (mul (!h land 0xffffl) m) (mul (!h lsr 16) 0xe995l lsl 16);
   to_base36_string (!h lxor (!h lsr 15) land 0xffffffffl)

--- a/packages/emotion-hash/hash.ml
+++ b/packages/emotion-hash/hash.ml
@@ -1,133 +1,103 @@
-let ( << ) = Int32.shift_left
-let ( & ) = Int32.logand
-let ( ||| ) = Int32.logor
-let ( * ) = Int32.mul
-let ( >>> ) = Int32.shift_right
-let ( ++ ) = Int32.add
-let ( ^ ) = Int32.logxor
-
-let to_base36 (num : Int32.t) =
-  let rec to_base36' (num : Int32.t) =
-    if num = 0l then []
+let to_base36_string n =
+  let open Int32 in
+  let base36_chars = "0123456789abcdefghijklmnopqrstuvwxyz" in
+  let rec convert_to_base36 acc n =
+    if n = 0l then acc
     else (
-      let quotient = Int32.div num 36l in
-      let remainder = Int32.rem num 36l in
-      (match remainder with
-      | 10l -> "a"
-      | 11l -> "b"
-      | 12l -> "c"
-      | 13l -> "d"
-      | 14l -> "e"
-      | 15l -> "f"
-      | 16l -> "g"
-      | 17l -> "h"
-      | 18l -> "i"
-      | 19l -> "j"
-      | 20l -> "k"
-      | 21l -> "l"
-      | 22l -> "m"
-      | 23l -> "n"
-      | 24l -> "o"
-      | 25l -> "p"
-      | 26l -> "q"
-      | 27l -> "r"
-      | 28l -> "s"
-      | 29l -> "t"
-      | 30l -> "u"
-      | 31l -> "v"
-      | 32l -> "w"
-      | 33l -> "x"
-      | 34l -> "y"
-      | 35l -> "z"
-      | _ -> string_of_int (Int32.to_int remainder))
-      :: to_base36' quotient)
+      let quotient = unsigned_div n 36l in
+      let remainder = unsigned_rem n 36l in
+      let char_at_remainder =
+        String.make 1 (String.get base36_chars (to_int remainder))
+      in
+      convert_to_base36 (char_at_remainder :: acc) quotient)
   in
-  num |> to_base36' |> List.rev |> String.concat ""
+  if n = 0l then "0" else String.concat "" (convert_to_base36 [] n)
 
-let to_css (number : Int32.t) = number |> to_base36
+let default str =
+  let open Int32 in
+  let ( lor ) = logor in
+  let ( land ) = logand in
+  let ( lsl ) = shift_left in
+  let ( lsr ) = shift_right_logical in
+  let ( lxor ) = logxor in
+  (* 'm' and 'r' are mixing constants generated offline.
+     They're not really 'magic', they just happen to work well. *)
+  let m = 0x5bd1e995l in
+  let r = 24 in
 
-(*
-    The murmur2 hashing is based on @emotion/hash, which is based on
-    https://github.com/garycourt/murmurhash-js and ported from
-    https://github.com/aappleby/smhasher/blob/61a0530f28277f2e850bfc39600ce61d02b518de/src/MurmurHash2.cpp#L37-L86.
-    Reference: https://github.com/emotion-js/emotion/blob/main/packages/hash/src/index.js
+  (* Initialize the hash *)
+  let h = ref 0l in
 
-    It's an ongoing effort to have a hashing function, currently okish. *)
-let murmur2 (str : string) =
-  let length = String.length str in
-  (* var h = 0 *)
-  let hash = ref 0l in
-  (* var k *)
-  let k = ref 0l in
-  (* len = str.length *)
-  let len = ref length in
-  (* i = 0, *)
-  let index = ref 0 in
-  while !index + 4 <= length do
-    let char_code_1 = Int32.of_int (Char.code str.[!index]) in
-    let char_code_2 = Int32.of_int (Char.code str.[!index + 1]) in
-    let char_code_3 = Int32.of_int (Char.code str.[!index + 2]) in
-    let char_code_4 = Int32.of_int (Char.code str.[!index + 3]) in
-    (* k =
-       (str.charCodeAt(i) & 0xff) |
-       ((str.charCodeAt(++i) & 0xff) << 8) |
-       ((str.charCodeAt(++i) & 0xff) << 16) |
-       ((str.charCodeAt(++i) & 0xff) << 24) *)
-    k :=
-      char_code_1
-      ||| (char_code_2 << 8)
-      ||| (char_code_3 << 16)
-      ||| (char_code_4 << 24);
-    (* k =
-       (k & 0xffff) * 0x5bd1e995 + (((k >>> 16) * 0xe995) << 16) *)
-    k :=
-      ((!k & 0xffffl) * 0x5bd1e995l) ++ (((!k >>> 16) * 0x5bd1e995l) & 0xffffl)
-      << 16;
-    (* k ^=  k >>> 24 *)
-    k := !k ^ (!k >>> 24);
-    k :=
-      ((!k & 0xffffl) * 0x5bd1e995l) ++ (((!k >>> 16) * 0x5bd1e995l) & 0xffffl)
-      << 16;
-    (* h =
-       ((k & 0xffff) * 0x5bd1e995 + (((k >>> 16) * 0xe995) << 16)) ^
-       ((h & 0xffff) * 0x5bd1e995 + (((h >>> 16) * 0xe995) << 16)) *)
-    hash :=
-      (((!hash & 0xffffl) * 0x5bd1e995l)
-       ++ (((!hash >>> 16) * 0x5bd1e995l) & 0xffffl)
-      << 16)
-      ^ !k;
-    index := !index + 1;
+  (* Mix 4 bytes at a time into the hash *)
+  let i = ref 0 in
+  let len = ref (String.length str) in
+  let of_char c = of_int (int_of_char c) in
+  while !len >= 4 do
+    let k =
+      of_char str.[!i]
+      land 0xffl
+      lor ((of_char str.[!i + 1] land 0xffl) lsl 8)
+      lor ((of_char str.[!i + 2] land 0xffl) lsl 16)
+      lor ((of_char str.[!i + 3] land 0xffl) lsl 24)
+    in
+
+    let k = add (mul (k land 0xffffl) m) (mul (k lsr 16) 0xe995l lsl 16) in
+    print_endline (Printf.sprintf "K INIT: %lx" k);
+    let k = k lxor (k lsr r) in
+
+    print_endline (Printf.sprintf "K FINAL: %lx" k);
+    h :=
+      add (mul (k land 0xffffl) m) (mul (k lsr 16) 0xe995l lsl 16)
+      lxor add (mul (!h land 0xffffl) m) (mul (!h lsr 16) 0xe995l lsl 16);
+
+    i := !i + 4;
     len := !len - 4
+    (* print_endline (Printf.sprintf "loop %d" !i);
+       print_endline (Printf.sprintf "len %d" !len);
+       print_endline (Printf.sprintf "H is: %lx" !h) *)
   done;
 
+  (* print_endline (Printf.sprintf "len: %d" !len);
+     print_endline (Printf.sprintf "i: %d" !i);
+     print_endline (Printf.sprintf "H is: %lx" !h); *)
+
   (* Handle the last few bytes of the input array *)
-  (match !len with
-  | 3 ->
-    (* h ^= (str.charCodeAt(i + 2) & 0xff) << 16 *)
-    hash := !hash ^ (Int32.of_int (Char.code str.[!index + 2]) << 16)
-  | 2 ->
-    (* h ^= (str.charCodeAt(i + 1) & 0xff) << 8 *)
-    hash := !hash ^ (Int32.of_int (Char.code str.[!index + 1]) << 8)
-  | 1 ->
-    (* h ^= str.charCodeAt(i) & 0xff *)
-    hash := !hash ^ Int32.of_int (Char.code str.[!index]);
-    (* h =
-       (h & 0xffff) * 0x5bd1e995 + (((h >>> 16) * 0xe995) << 16) *)
-    hash :=
-      ((!hash & 0xffffl) * 0x5bd1e995l)
-      ++ (((!hash >>> 16) * 0x5bd1e995l) & 0xffffl)
-      << 16
-  | _ -> ());
+  let () =
+    if !len = 3 then h := !h lxor ((of_char str.[!i + 2] land 0xffl) lsl 16);
+    if !len >= 2 then begin
+      (* print_endline "here";
+         print_endline str;
+         print_endline (Printf.sprintf "INDXE %d" (!i + 1));
+         print_endline
+           (Printf.sprintf "ofchar %ld" (!h lxor ((0x20l land 0xffl) lsl 8))); *)
+      h := !h lxor ((of_char str.[!i + 1] land 0xffl) lsl 8)
+    end;
+    if !len >= 1 then begin
+      h := !h lxor (of_char str.[!i] land 0xffl);
+      h := add (mul (!h land 0xffffl) m) (mul (!h lsr 16) 0xe995l lsl 16)
+    end
+  in
 
-  (* Do a few final mixes of the hash to ensure the last few bytes are well-incorporated. *)
+  (* Do a few final mixes of the hash to ensure the last few
+     bytes are well-incorporated. *)
+  h := !h lxor (!h lsr 13);
+  let () = print_endline (Printf.sprintf "ONE %ld" (mul (!h land 0xffffl) m)) in
+  let () =
+    print_endline (Printf.sprintf "TWO %ld" (mul (!h lsr 16) 0xe995l lsl 16))
+  in
+  h :=
+      add
+        (mul (!h land 0xffffl) (m))
+        (mul (!h lsr 16) 0xe995l lsl 16);
+  let () = print_endline (Printf.sprintf "H prealmostfinal is: %lx" !h) in
+  let () = print_endline (Printf.sprintf "H shifted is: %lx" (!h lsr 15)) in
+  let () =
+    print_endline
+      (Printf.sprintf "H test is: %s" (to_base36_string 0xf77f8879l))
+  in
 
-  (* h ^= h >>> 13 *)
-  hash := !hash ^ (!hash >>> 13);
-  (* h =
-     (h & 0xffff) * 0x5bd1e995 + (((h >>> 16) * 0xe995) << 16) *)
-  hash :=
-    ((!hash & 0xffffl) * 0x5bd1e995l) ++ ((!hash >>> 16) * 0x5bd1e995l << 16);
-  (* (h ^ (h >>> 15)) >>> 0 *)
-  !hash ^ (!hash >>> 15) >>> 0
-
-let default (str : string) = str |> murmur2 |> to_css
+  print_endline (Printf.sprintf "H FINAL is: %lx" !h);
+  print_endline
+    (Printf.sprintf "FINAL %s"
+       (to_base36_string (!h lxor (!h lsr 15) land 0xffffffffl)));
+  to_base36_string (!h lxor (!h lsr 15) land 0xffffffffl)

--- a/packages/emotion-hash/hash.t
+++ b/packages/emotion-hash/hash.t
@@ -78,3 +78,10 @@
   1w4us3o
   $ node ./compare.js "z-index: 10"
   7au0g0
+
+The following two rule sets produced the same hash (see https://github.com/davesnx/styled-ppx/pull/376)
+
+  $ node ./compare.js "color:var(--alt-text--tertiary);:disabled{color:var(--alt-text--tertiary);}:hover{color:var(--alt-text--primary);}"
+  66bc4u
+  $ node ./compare.js "display:flex;:before, :after{content:'';flex:0 0 16px;}"
+  ab0yh7

--- a/packages/emotion-hash/hash.t
+++ b/packages/emotion-hash/hash.t
@@ -1,0 +1,80 @@
+  $ node ./compare.js ""
+  0
+  $ node ./compare.js "something "
+  5aqktu
+  $ node ./compare.js "something"
+  crsxd7
+  $ node ./compare.js "padding: 0;"
+  14em68c
+  $ node ./compare.js "paddinxg: 1;"
+  103fxnp
+  $ node ./compare.js "padding: 0px;"
+  1mqllfw
+  $ node ./compare.js "padding: 2px;"
+  1kgw61x
+  $ node ./compare.js "color: #323337"
+  v3ltn7
+  $ node ./compare.js "color: #323335"
+  pru0h8
+  $ node ./compare.js "font-size: 32px;"
+  1aeywr2
+  $ node ./compare.js "font-size: 33px;"
+  xts11q
+  $ node ./compare.js "display: block"
+  1ni8fbp
+  $ node ./compare.js "display: blocki"
+  1rb2f34
+  $ node ./compare.js "display: block;"
+  avwy6
+  $ node ./compare.js "display: flex"
+  18hxz5k
+  $ node ./compare.js "display: flex;"
+  17vxl0k
+  $ node ./compare.js "color: #333;"
+  m97760
+  $ node ./compare.js "font-size: 22px;"
+  1m7bgz5
+  $ node ./compare.js "font-size: 40px;"
+  pm5q90
+  $ node ./compare.js "line-height: 22px;"
+  lehwic
+  $ node ./compare.js "display: flex; font-size: 33px"
+  c8y5k7
+  $ node ./compare.js "background-color: red"
+  mhqmk0
+  $ node ./compare.js "width: 100%"
+  71gbl7
+  $ node ./compare.js "height: 100%"
+  t3ccau
+  $ node ./compare.js "min-width: auto"
+  13s44nx
+  $ node ./compare.js "min-height: auto"
+  8zn0wa
+  $ node ./compare.js "max-width: 100vw"
+  qilhjh
+  $ node ./compare.js "max-height: 100vh"
+  1tmr74f
+  $ node ./compare.js "margin: 3px"
+  1dpky6u
+  $ node ./compare.js "border: 1px solid red"
+  1j0fwx2
+  $ node ./compare.js "border: none"
+  zn5chm
+  $ node ./compare.js "border-color: grey"
+  7nfkvr
+  $ node ./compare.js "border-radius: 6px"
+  wyudoy
+  $ node ./compare.js "font-family: Inter"
+  1bfbb9d
+  $ node ./compare.js "font-style: italic"
+  9i7il8
+  $ node ./compare.js "font-weight: 400"
+  1q1joro
+  $ node ./compare.js "position: absolute"
+  1vmrgk7
+  $ node ./compare.js "position: relative"
+  1dcu5cj
+  $ node ./compare.js "z-index: 9999999"
+  1w4us3o
+  $ node ./compare.js "z-index: 10"
+  7au0g0

--- a/packages/emotion-hash/native_hash.ml
+++ b/packages/emotion-hash/native_hash.ml
@@ -1,0 +1,9 @@
+let () =
+  if Array.length Sys.argv <> 2 then (
+    Printf.eprintf "Usage: %s <input_string>\n" Sys.argv.(0);
+    exit 1
+  );
+
+  let input_string = Sys.argv.(1) in
+  let result = Emotion_hash.Hash.default input_string in
+  print_endline result

--- a/packages/emotion/test/test_css_hash.ml
+++ b/packages/emotion/test/test_css_hash.ml
@@ -4,7 +4,6 @@ let check_equality (input, expected) =
   ( quoted input,
     `Quick,
     fun () ->
-      print_endline (Emotion_hash.Hash.default input);
       (Alcotest.check Alcotest.string)
         (quoted input ^ " should hash")
         expected

--- a/packages/emotion/test/test_css_hash.ml
+++ b/packages/emotion/test/test_css_hash.ml
@@ -4,6 +4,7 @@ let check_equality (input, expected) =
   ( quoted input,
     `Quick,
     fun () ->
+      print_endline (Emotion_hash.Hash.default input);
       (Alcotest.check Alcotest.string)
         (quoted input ^ " should hash")
         expected
@@ -11,46 +12,46 @@ let check_equality (input, expected) =
 
 let data =
   [
-    "", "";
-    "something ", "pcredg";
-    "something", "vcob5v";
-    "padding: 0;", "6gat1f";
-    "paddinxg: 1;", "fzg3kw";
-    "padding: 0px;", "1vbv0c";
-    "padding: 2px;", "qt3f5x";
-    "color: #323337", "xdhv30";
-    "color: #323335", "nltzyu";
-    "font-size: 32px;", "gyv1i7";
-    "font-size: 33px;", "80ebse";
-    "display: block", "8mvhhy";
-    "display: blocki", "dd7692";
-    "display: block;", "350rwu";
-    "display: flex", "rfni09";
-    "display: flex;", "qpdvh3";
-    "color: #333;", "lxmcf8";
-    "font-size: 22px;", "o8xlm6";
-    "font-size: 40px;", "ipwjhb";
-    "line-height: 22px;", "r0jscr";
-    "display: flex; font-size: 33px", "ezi7t6";
-    "background-color: red", "l1121p";
-    "width: 100%", "jwcljb";
-    "height: 100%", "ndyh71";
-    "min-width: auto", "ypc7co";
-    "min-height: auto", "ua6m7";
-    "max-width: 100vw", "6292a4";
-    "max-height: 100vh", "oihm23";
-    "margin: 3px", "rqx6bn";
-    "border: 1px solid red", "hoqo05";
-    "border: none", "1kvnc3";
-    "border-color: grey", "rij9tm";
-    "border-radius: 6px", "gm9ptx";
-    "font-family: Inter", "1ibdwf";
-    "font-style: italic", "3azxi";
-    "font-weight: 400", "9ry02o";
-    "position: absolute", "9pm8sf";
-    "position: relative", "8egqwf";
-    "z-index: 9999999", "1ncuwq";
-    "z-index: 10", "xei54";
+    "", "0";
+    "something ", "5aqktu";
+    "something", "crsxd7";
+    "padding: 0;", "14em68c";
+    "paddinxg: 1;", "103fxnp";
+    "padding: 0px;", "1mqllfw";
+    "padding: 2px;", "1kgw61x";
+    "color: #323337", "v3ltn7";
+    "color: #323335", "pru0h8";
+    "font-size: 32px;", "1aeywr2";
+    "font-size: 33px;", "xts11q";
+    "display: block", "1ni8fbp";
+    "display: blocki", "1rb2f34";
+    "display: block;", "avwy6";
+    "display: flex", "18hxz5k";
+    "display: flex;", "17vxl0k";
+    "color: #333;", "m97760";
+    "font-size: 22px;", "1m7bgz5";
+    "font-size: 40px;", "pm5q90";
+    "line-height: 22px;", "lehwic";
+    "display: flex; font-size: 33px", "c8y5k7";
+    "background-color: red", "mhqmk0";
+    "width: 100%", "71gbl7";
+    "height: 100%", "t3ccau";
+    "min-width: auto", "13s44nx";
+    "min-height: auto", "8zn0wa";
+    "max-width: 100vw", "qilhjh";
+    "max-height: 100vh", "1tmr74f";
+    "margin: 3px", "1dpky6u";
+    "border: 1px solid red", "1j0fwx2";
+    "border: none", "zn5chm";
+    "border-color: grey", "7nfkvr";
+    "border-radius: 6px", "wyudoy";
+    "font-family: Inter", "1bfbb9d";
+    "font-style: italic", "9i7il8";
+    "font-weight: 400", "1q1joro";
+    "position: absolute", "1vmrgk7";
+    "position: relative", "1dcu5cj";
+    "z-index: 9999999", "1w4us3o";
+    "z-index: 10", "7au0g0";
   ]
 
 let tests = "Hash", List.map check_equality data


### PR DESCRIPTION
Updates the hash function in native so that it behaves exactly like the original one in emotion.

This has the advantage that there's no need to patch any existing user of styled-ppx & server-reason-react to override the emotion/hash function on the melange build, plus we lower the chances of collision / issues in the hashing algorithm as the original Emotion hash has been tested over time.

The PR also adds some basic cram test to make sure the results returned by each implementation are the same.

@davesnx Feel free to discard or take anything from the PR.