### PR TITLE
Docs clarification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,27 +6,26 @@ If you have questions about a specific PR, want to discuss a new API idea or a b
 
 ## What about if you have problems that cannot be discussed in a public?
 
-[David Sancho](https://github.com/davesnx) has a contact email on the GitHub profile, and happy to talk about any problems via those or a DM in [Twitter](https://twitter.com/davesnx).
+[David Sancho](https://github.com/davesnx) has a contact email on the GitHub profile, and is happy to talk about any problems via email or a DM in [Twitter](https://twitter.com/davesnx).
 
 ## Code contributions
 
 Here is a quick guide to doing code contributions to the repository.
 
 1. Find some issue you're interested in, or a feature that you'd like to tackle.
-   Also make sure that no one else is already working on it. We don't want you to be
-   disappointed.
+   Also make sure that no one else is already working on it. We don't want you to be disappointed.
 
-2. Fork, then clone: `git clone https://github.com/YOUR_USERNAME/styled-ppx.git`
+2. Fork, then clone: `git clone https://github.com/YOUR_USERNAME/styled-ppx.git`.
 
-3. Create a branch with a meaningful name for the issue: `git checkout -b fix-something`
+3. Create a branch with a meaningful name for the issue: `git checkout -b fix-something`.
 
-4. Setup the project
+4. Setup the project.
 
-5. Make your changes and commit: `git add` and `git commit`
+5. Make your changes and commit: `git add` and `git commit`.
 
-6. Make sure that the tests still pass: `make test_all` (if you ran `make init` a pre-psuh githook has been created for you to run each time you push)
+6. Make sure that the tests still pass: `make test_all` (if you ran `make init` a pre-psuh githook has been created for you to run each time you push).
 
-7. Push your branch: `git push -u origin your-branch-name`
+7. Push your branch: `git push -u origin your-branch-name`.
 
 8. Submit a pull request to the upstream styled-ppx repository.
 
@@ -41,7 +40,7 @@ Here is a quick guide to doing code contributions to the repository.
 - Make sure you have installed opam and yarn (1.x).
 - Run `make init` will setup the opam switch, install dependencies and some pinned packages.
 - Run `make build` will build the project or `make dev` to build and watch for changes.
-- Run `make test_all` to run all test suites
+- Run `make test_all` to run all test suites.
 
 ### Editor setup
 
@@ -53,7 +52,7 @@ Follow the generic installation steps from [Reason documentation](https://reason
 
 Aside from all test suites, check the [Makefile](./Makefile) for all the available commands.
 
-There are some end to end test to ensure all the ppx generation is working as expected, under the `e2e/` folder. Which contains
+There are some end-to-end tests to ensure all the ppx generation is working as expected, under the `e2e/` folder. Which contains
 
 ```bash
 $ tree -L 1 e2e
@@ -73,8 +72,8 @@ yarn test
 
 ## Release process
 
-- Each PR created will release a nighly release that you can install via npm.
-- Each stable release will happen once the package.json's verison is updated and merged in the main branch.
+- Each PR created will create a nightly release that you can install via npm.
+- Each stable release will happen once the package.json's version is updated and merged in the main branch.
 
 ## Credits
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Here is a quick guide to doing code contributions to the repository.
 - Make sure you have installed opam and yarn (1.x).
 - Run `make init` will setup the opam switch, install dependencies and some pinned packages.
 - Run `make build` will build the project or `make dev` to build and watch for changes.
-- Run `make test_all` to run all test suites.
+- Run `make test` to run all test suites.
 
 ### Editor setup
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Typed styled components for ReScript
 
-**styled-ppx** is a [ppx](https://tarides.com/blog/2019-05-09-an-introduction-to-ocaml-ppx-ecosystem) that brings styled components to ReScript. Built on top of [emotion](https://emotion.sh), it allows you to style apps safely, quickly, and with zero runtime overhead - just as you have always done it. styled-ppx allows you to create **React Components** with type-safe style definitions that don't rely on a different language ([DSL](https://en.wikipedia.org/wiki/Domain-specific_language)) except CSS.
+**styled-ppx** is a [ppx](https://tarides.com/blog/2019-05-09-an-introduction-to-ocaml-ppx-ecosystem) that brings styled components to ReScript. Built on top of [emotion](https://emotion.sh), it allows you to style apps safely, quickly, and performantly - just as you have always done it. styled-ppx allows you to create **React Components** with type-safe style definitions that don't rely on a different language ([DSL](https://en.wikipedia.org/wiki/Domain-specific_language)) except CSS.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Typed styled components for ReScript
 
-**styled-ppx** is the [ppx](https://tarides.com/blog/2019-05-09-an-introduction-to-ocaml-ppx-ecosystem) that brings styled components to ReScript. Build on top of [emotion](https://emotion.sh), it allows you to style apps safe, quickly, performant and as you always done it. Allows you to create **React Components** with type-safe style definitions that don't rely on a different language ([DSL](https://en.wikipedia.org/wiki/Domain-specific_language)) than CSS
+**styled-ppx** is a [ppx](https://tarides.com/blog/2019-05-09-an-introduction-to-ocaml-ppx-ecosystem) that brings styled components to ReScript. Built on top of [emotion](https://emotion.sh), it allows you to style apps safely, quickly, and with zero runtime overhead - just as you have always done it. styled-ppx allows you to create **React Components** with type-safe style definitions that don't rely on a different language ([DSL](https://en.wikipedia.org/wiki/Domain-specific_language)) except CSS.
 
 ## Usage
 
@@ -27,29 +27,29 @@ Add `"@davesnx/styled-ppx/ppx"` under bsconfig `"ppx-flags"`:
 }
 ```
 
-Read more about [getting started](https://styled-ppx.vercel.app/getting-started)
+Read more about [getting started](https://styled-ppx.vercel.app/getting-started).
 
 ## [Documentation](https://styled-ppx.vercel.app)
 
-For the entire documentation, visit [styled-ppx.vercel.app](https://styled-ppx.vercel.app)
+For the entire documentation, visit [styled-ppx.vercel.app](https://styled-ppx.vercel.app).
 
 ### Editor Support
 
-We provide editor extensions that brings syntax highlight, for now. (It will include IntelliSense or other [CSS-related](https://code.visualstudio.com/docs/languages/css) features).
+We provide an editor extension that brings syntax highlighting. (In the future it may include IntelliSense or other [CSS-related](https://code.visualstudio.com/docs/languages/css) features.)
 
 #### VSCode Extension
 
-Install the **[VSCode Extension](https://marketplace.visualstudio.com/items?itemName=davesnx.vscode-styled-ppx)**
+Install the **[VSCode Extension](https://marketplace.visualstudio.com/items?itemName=davesnx.vscode-styled-ppx)**.
 
 #### vim plugin
 
-Install the **[vim plugin](https://github.com/ahrefs/vim-styled-ppx/blob/main/README.md#installation)**
+Install the **[vim plugin](https://github.com/ahrefs/vim-styled-ppx/blob/main/README.md#installation)**.
 
-> If you are interested on another editor, please [fill an issue](https://github.com/davesnx/styled-ppx/issues/new).
+> If you are interested on another editor, please [file an issue](https://github.com/davesnx/styled-ppx/issues/new).
 
 ## Contributing
 
-We would love your help improving **styled-ppx**! Please see our contributing and community guidelines, they'll help you get set up locally and explain the whole process: [CONTRIBUTING.md](./CONTRIBUTING.md).
+We would love your help improving **styled-ppx**! Please see our contributing and community guidelines; they'll help you get set up locally and explain the whole process: [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## License
 

--- a/packages/website/pages/about.mdx
+++ b/packages/website/pages/about.mdx
@@ -10,36 +10,36 @@ Author and maintainer: [David Sancho](https://sancho.dev)
 
 # Motivation
 
-There are a few reasons why this project exists and why came to live.
+There are a few reasons why this project exists and why it came to live.
 
 ### There was a need
-In my experience, writing React with a CSS-in-JS library is one of the best combos for writing scalable design systems, UI libraries and applications. When I discovered Reason back in the days (arround 2018), it wasn't possible to bind to styled-components neither emotion. Even ([a](https://reasonml.chat/t/idiomatic-way-to-bind-to-styled-components/886) [f](https://reasonml.chat/t/styled-components-possible/554)[e](https://reasonml.chat/t/styling-solutions-reasonreact-as-of-aug-18/958)[w](https://reasonml.chat/t/options-and-best-practices-for-styling-in-reasonreact/261) [p](https://twitter.com/lyovson/status/1233397294311100417)[e](https://discord.gg/byjdYFH)[o](https://discord.gg/byjdYFH)[p](https://discord.gg/byjdYFH)[l](https://discord.gg/byjdYFH)[e](https://forum.rescript-lang.org/t/how-to-create-bindings-for-emotion-styled/2995) were asking for it.
+In my experience, writing React with a CSS-in-JS library is one of the best combos for writing scalable design systems, UI libraries and applications. When I discovered Reason back in the day (around 2018), it wasn't possible to bind to styled-components or emotion. Even ([a](https://reasonml.chat/t/idiomatic-way-to-bind-to-styled-components/886) [f](https://reasonml.chat/t/styled-components-possible/554)[e](https://reasonml.chat/t/styling-solutions-reasonreact-as-of-aug-18/958)[w](https://reasonml.chat/t/options-and-best-practices-for-styling-in-reasonreact/261) [p](https://twitter.com/lyovson/status/1233397294311100417)[e](https://discord.gg/byjdYFH)[o](https://discord.gg/byjdYFH)[p](https://discord.gg/byjdYFH)[l](https://discord.gg/byjdYFH)[e](https://forum.rescript-lang.org/t/how-to-create-bindings-for-emotion-styled/2995) were asking for it.
 
-During that time, there were a few efforts on bringing type-safety on top of CSS with [bs-css](https://github.com/giraud/bs-css) or [bs-emotion](https://github.com/ahrefs/bs-emotion). Even thought I liked that approach, it had a few drawbacks:
-- The need for learning a new DSL on top of CSS was tedious. Very fancy for simple properties, but almost impossible for more complex ones (a classic example `width: calc(100% - 20px){:css}` became `CssJs.width(calc(min, percent(100.), px(20))){:rescript}`). For the real world usage I endup using `CssJs.unsafe`.
-- The runtime is huge. The bundle-size of bs-css starts with 64kb and goes up considerably with the usage even with ReScript death code elimination.
-- The fact about having a runtime involved to only write safe CSS doesn't seem like a nice trade-off.
+During that time, there were a few efforts to bring type-safety to CSS with [bs-css](https://github.com/giraud/bs-css) and [bs-emotion](https://github.com/ahrefs/bs-emotion). Even though I liked that approach, it had a few drawbacks:
+- The need for learning a new DSL on top of CSS was tedious. Very fancy for simple properties, but almost impossible for more complex ones (a classic example `width: calc(100% - 20px){:css}` became `CssJs.width(calc(min, percent(100.), px(20))){:rescript}`). In real world usage I would end up using `CssJs.unsafe`.
+- The runtime was huge. The bundle-size of bs-css starts with 64kb and goes up considerably with the usage, even with ReScripts dead code elimination.
+- The fact of having a runtime involved to only write safe CSS doesn't seem like a nice trade-off.
 
 ### It's possible and a good solution
-Embedding CSS inside Reason/OCaml seemed like a bad idea at first, mostly since most CSS-in-JS solutions that use native CSS relied on a JavaScript feature that isn't available in Reason [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals).
+Embedding CSS inside Reason/OCaml seemed like a bad idea at first, mostly since most CSS-in-JS solutions that use native CSS relied on a JavaScript feature that isn't available in Reason: [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals).
 
 After discovering what a ppx was (*"a mechanism to embed other languages inside Reason"*), and it could mimic the template literals, I jumped straight into hacking a prototype that became this project.
 
-Embedding languages inside others, isn't a new concept, has been happening for a long time. In fact, the most common case of an embedded language is usually CSS inside HTML.
-Using CSS enables all sort of integrations: Editors, DevTools, prototyping tools, Github Copilot, etc. Even for designers that don't want to understand neither care about ReScript.
+Embedding languages inside others isn't a new concept and has been happening for a long time. In fact, the most common case of an embedded language is usually CSS inside HTML.
+Using CSS enables all sorts of integrations: Editors, DevTools, prototyping tools, Github Copilot, etc. Even for designers that don't want to understand or care about ReScript.
 
 ### It can be more powerful than the JavaScript equivalents
-Enabling type-safety into CSS is a nice to have, rather than a hard requirement, but nevertheless useful. styled-ppx brings an entire CSS compiler and type-chcker. This enables features from SASS (like supporting future CSS version features) with features from emotion to inline your styles and code together.
+Enabling type-safety in CSS is a nice to have, rather than a hard requirement, but nevertheless useful. styled-ppx brings an entire CSS compiler and type-chcker. This enables features from SASS (like supporting future CSS version features) with features from emotion to inline your styles and code together.
  Features that aren't implemented but are on the horizon are mostly related in extracting the CSS from the runtime and making your styles static at runtime and have zero run-time.
 
-To know more about how it works or what are the benefits I recommend to watch [my talk at ReasonSTHLM Meetup](https://www.youtube.com/watch?v=ekHCBZiCviM).
+To know more about how it works or what are the benefits I recommend you watch [my talk at ReasonSTHLM Meetup](https://www.youtube.com/watch?v=ekHCBZiCviM).
 
 ## Credits
 
-Here's a list of people that helped me and couldn't make it without them:
+Here's a list of people that helped me and I couldn't have made styled-ppx without them:
 
-- [Javier Chávarri](https://github.com/jchavarri): for the introduction to Reason. Teaching me all his knowledge about OCaml, AST, ppx rewritters and the help of boostrapping the project.
-- [Alessandro Strada](https://github.com/astrada): this project started with inspiration from [bs-css-ppx](https://github.com/astrada/ppx_bs_css)
+- [Javier Chávarri](https://github.com/jchavarri): for the introduction to Reason. Teaching me all his knowledge about OCaml, AST, ppx rewriters and the help of bootstrapping the project.
+- [Alessandro Strada](https://github.com/astrada): this project started with inspiration from [bs-css-ppx](https://github.com/astrada/ppx_bs_css).
 - [Eduardo Rafael](https://github.com/EduardoRFS/): to teach me how to write a compiler and a type-checker. His initial implementation of the CSS Value definition and the parser combinator.
 - [Rizo](https://github.com/rizo): for the help with the API design, discussions and great conversations about styling and CSS.
 - [Max Lantas](https://github.com/mnxn): for implementing the VSCode extension.

--- a/packages/website/pages/css-support.mdx
+++ b/packages/website/pages/css-support.mdx
@@ -17,7 +17,7 @@ There are a few levels of support in **styled-ppx**:
 🟠: Partially supported
 🔴: Not supported
 
-If you want to know which properties are supported, you can check our test here: https://github.com/davesnx/styled-ppx/blob/main/packages/ppx/test/css-support/test.re (commented ones aren't supported).
+If you want to know which properties are supported, you can check our test here: https://github.com/davesnx/styled-ppx/blob/main/packages/ppx/test/css-support/css-support.re (commented out ones are not supported).
 
 ---
 | **CSS Feature**                                              	| **Link**                                  	| **Supported** 	|
@@ -77,7 +77,7 @@ If you want to know which properties are supported, you can check our test here:
 | Filter Effects Module Level 1                                	| https://www.w3.org/TR/filter-effects-1    	| 🟠             	|
 | Media Queries Level 4                                        	| https://www.w3.org/TR/mediaqueries-4      	| 🟠             	|
 
-<small>This table has been generated manually, it can be outdated.</small>
+<small>This table has been generated manually and it might be outdated.</small>
 
 All references are found in [w3.org](https://www.w3.org)
 - [(CSS 1.0) Cascading Style Sheets Level 1](https://www.w3.org/TR/CSS1/) ✅

--- a/packages/website/pages/css-support.mdx
+++ b/packages/website/pages/css-support.mdx
@@ -8,7 +8,7 @@ The **styled-ppx** CSS parser supports [CSS Syntax Module Level 3](https://www.w
 
 There are a few levels of support in **styled-ppx**:
 - **Parser support**: The parser understands CSS3.
-- **Code generation support**: Can transform the CSS into [Css bindings] bindings.
+- **Code generation support**: Can transform the CSS into CSS bindings.
 - **Interpolation support**: We can interpolate values from outside of CSS creating type-safe holes.
 
 ## Detailed view of the parsing support

--- a/packages/website/pages/faq.mdx
+++ b/packages/website/pages/faq.mdx
@@ -6,9 +6,9 @@ title: Frequently asked questions
 
 ## Does it support Reason and OCaml syntax?
 
-Yes, both are supported. Even though code snippets are written in ReScript (for the sake of simplicity), you can still use Reason and OCaml syntaxes. Since its meant to be used in a browser, **styled-ppx** follows the same restrictions as ReScript.
+Yes, both are supported. Even though code snippets are written in ReScript (for the sake of simplicity), you can still use Reason and OCaml syntaxes. Since it is meant to be used in a browser, **styled-ppx** follows the same restrictions as ReScript.
 
 Also, our [VSCode extension](https://marketplace.visualstudio.com/items?itemName=davesnx.vscode-styled-ppx) supports ReScript, Reason, and OCaml syntaxes.
 
 The differences are around syntaxes are the string delimiters:
-Reason and OCaml uses `"` and `{||}`, while ReScript uses "\`". We recommend that you use `{||}` when it's a multi-line string.
+Reason and OCaml uses `"` and `{||}`, while ReScript uses ```. We recommend that you use `{||}` when it's a multi-line string.

--- a/packages/website/pages/getting-started.mdx
+++ b/packages/website/pages/getting-started.mdx
@@ -7,7 +7,7 @@ import Link from 'next/link'
 
 # Getting Started
 
-Depends on [rescript-react](https://github.com/rescript-lang/rescript-react), make sure you have it installed first.
+Depends on [rescript-react](https://github.com/rescript-lang/rescript-react). Please make sure you have it installed first.
 
 ### Install
 
@@ -34,8 +34,8 @@ The diff on `bsconfig.json` should contain the following:
 ```
 
 (Added in v0.40.0)
-- `@davesnx/styled-ppx/css` are the CSS bindings
-- `@davesnx/styled-ppx/emotion` are the bindings to emotion.sh
+- `@davesnx/styled-ppx/css` are the CSS bindings.
+- `@davesnx/styled-ppx/emotion` are the bindings to `emotion.sh`.
 
 ### Example
 
@@ -74,7 +74,7 @@ module Layout = %styled.div([|
 If you want to try it out, just fork https://github.com/davesnx/try-styled-ppx and follow the installation instructions there.
 
 ## Editor Support
-One of the downsides of embedding a language (CSS) into another (ReScript) is the limited editor support. Because of that, we provide editor extensions that bring syntax highlighting for the CSS inside the styled-ppx notation.
+One of the downsides of embedding a language (CSS) into another language (ReScript) is the limited editor support. Because of that, we provide an editor extension that brings syntax highlighting for the CSS inside the styled-ppx notation.
 
 #### VSCode Extension
 
@@ -99,4 +99,4 @@ Add `Plugin 'ahrefs/vim-styled-ppx'` to your `~/.vimrc` and run PluginInstall.
 $ git clone https://github.com/ahrefs/vim-styled-ppx ~/.vim/bundle/vim-log-highlighting
 ```
 
-> If you are interested on another editor, please [fill an issue](https://github.com/davesnx/styled-ppx/issues/new).
+> If you are interested on another editor, please [file an issue](https://github.com/davesnx/styled-ppx/issues/new).

--- a/packages/website/pages/index.mdx
+++ b/packages/website/pages/index.mdx
@@ -6,7 +6,7 @@ title: Introduction to styled-ppx
 
 **styled-ppx** is the [ppx](https://tarides.com/blog/2019-05-09-an-introduction-to-ocaml-ppx-ecosystem) that brings typed styled components to ReScript, allowing you to create **React Components** with type-safe style definitions that look like good old CSS.
 
-Built on top of [emotion](https://emotion.sh), so you can style your apps in a safe, familiar, and performant way.
+styled-ppx is built on top of [emotion](https://emotion.sh), so you can style your apps in a safe, familiar, and performant way.
 
 ```rescript
 module Center = %styled.div(`
@@ -24,11 +24,11 @@ module Center = %styled.div(`
 
 Highlights:
 
-- Type-safe CSS
-- Component-based styling
-- Implements utility helpers such as classname and css
-- There's no abstraction over standard CSS, it's neither a new language nor a [DSL](https://en.wikipedia.org/wiki/Domain-specific_language)
-- Supports the power of the underlying language: pattern-matching, composition, labelled arguments
-- Built on top of [emotion](https://emotion.sh)
+- Type-safe CSS.
+- Component-based styling.
+- Implements utility helpers such as `classname` and `css`.
+- There's no abstraction over standard CSS - it's neither a new language nor a [DSL](https://en.wikipedia.org/wiki/Domain-specific_language).
+- Supports the power of the underlying language: pattern-matching, composition, labelled arguments, etc.
+- Built on top of [emotion](https://emotion.sh).
 
-**styled-ppx** is a ppx, you can learn more about ppxs in [Tarides blog: Introduction to OCaml ppx ecosystem](https://tarides.com/blog/2019-05-09-an-introduction-to-ocaml-ppx-ecosystem). Generally speaking, they are similar to [babel plugins](https://babeljs.io/docs/en/plugins/). They run before the compilation of your code, and expands these notations (`%styled.div{:rescript}` or `%cx{:rescript}`) into valid ReScript code.
+**styled-ppx** is a ppx. You can learn more about ppxs in [Tarides blog: Introduction to OCaml ppx ecosystem](https://tarides.com/blog/2019-05-09-an-introduction-to-ocaml-ppx-ecosystem). Generally speaking, they are similar to [babel plugins](https://babeljs.io/docs/en/plugins/). They run before the compilation of your code, and expands styled-ppx notations (e.g., `%styled.div{:rescript}` or `%cx{:rescript}`) into valid ReScript code.

--- a/packages/website/pages/reference/array.mdx
+++ b/packages/website/pages/reference/array.mdx
@@ -27,7 +27,7 @@ let className = %cx([%css("display: flex;")])
 
 - Allowing composability and re-usability of CSS.
 - Useful to reference other variables, a function call or a pattern match.
-- Solves the migration from other systems (such as `bs-css`) and bypass `styled-ppx` parser that might not support a property.
+- Solves the migration problem from other systems (such as `bs-css`) and bypasses the `styled-ppx` parser which might not support a property.
 
 Here are some illustrative examples:
 
@@ -64,7 +64,7 @@ module Align = %styled.div(
 
 ### Usage with Dynamic components
 
-There's a nice composability where dynamic components and the Array API provides. You can create a component that can run any code before the styles. It will be called each time the component renders. Such as this example of runtime styles where it derives the color's background button based on a `variant` prop passed to a Theme module.
+There's a nice composability that dynamic components and the Array API provides. You can create a component that can run any code before the styles. It will be called each time the component renders. Such as this example of runtime styles where it derives the color's background button based on a `variant` prop passed to a Theme module.
 
 ```rescript
 module Button = %styled.button(
@@ -80,4 +80,4 @@ module Button = %styled.button(
 )
 ```
 
-Note: The returned expression (the last expression of the function) need to be an array of `Css.rules` (it can't be a reference or a function call). This is a limitation of ppxes where it needs to check the current AST to know which type is.
+Note: The returned expression (the last expression of the function) has to be an array of `Css.rules` (it can't be a reference or a function call). This is a limitation of ppxes where it needs to check the current AST to know which type is.

--- a/packages/website/pages/reference/classname.mdx
+++ b/packages/website/pages/reference/classname.mdx
@@ -6,7 +6,7 @@ title: className `cx` extension
 
 Aside from the styled extension, **styled-ppx** provides the `%cx{:rescript}` extension.
 
-`%cx{:rescript}` generates a className given one or more CSS Declarations. Useful to attach to a React's component via the `className` prop. Sometimes is hard to give the right name for a styled component or maybe those styles are only used once, that's why `%cx{:rescript}` exists.
+`%cx{:rescript}` generates a `className` given one or more CSS declarations. This is useful to attach to a React component via the `className` prop. Sometimes is hard to give the right name for a styled component or maybe those styles are only used once, that's why `%cx{:rescript}` exists.
 
 ## Examples
 
@@ -26,7 +26,7 @@ let fullWidth: string = %cx(`
 <div className=fullWidth> {React.string("Hello!")} </div>
 ```
 
-The value `fullWidth` is a string that contains a hash pointing to a style HTML tag in the `<head>`. If you want to concat with other styles, you can use the string concatenation operator (`++`):
+The value `fullWidth` is a string that contains a hash pointing to a style HTML tag in the `<head>`. If you want to concatenate it with other styles, you can use the string concatenation operator (`++`):
 
 ```rescript
 <div className=fullWidth ++ " " ++ "extra-classname"> {React.string("Hello!")} </div>
@@ -35,5 +35,5 @@ The value `fullWidth` is a string that contains a hash pointing to a style HTML 
 ## Features
 
 - Selectors, media queries and other nesting is supported in CSS declarations.
-- Interpolation is allowed. `%cx("color: $(Theme.colors.primary)"){:rescript}`
+- Interpolation is allowed. `%cx("color: $(Theme.colors.primary)"){:rescript}`.
 - Curly braces aren't allowed. `%cx("{ display: block; }"){:rescript}` will break.

--- a/packages/website/pages/reference/css.mdx
+++ b/packages/website/pages/reference/css.mdx
@@ -4,7 +4,7 @@ title: Rule `css` extension
 
 # Rule: `css` extension
 
-Generates a `Css.rule{:rescript}` given a single CSS rule as string. The `%css` extension is useful with combination with the [Array API](./array), to compose and re-use rules.
+Generates a `Css.rule{:rescript}` given a single CSS rule as string. The `%css` extension is useful in combination with the [Array API](./array) to compose and re-use rules.
 
 ## Example
 
@@ -14,6 +14,6 @@ let rule: Css.rule = %css("display: block")
 
 ## Features
 
-- Only single properties are allowed. Declaratiosn aren't. Declarations can contain selectors, rules only a pair of property/value. If you need a selector or more than one rule, use `%cx{:rescript}` instead.
+- Only single properties are allowed; declarations are not allowed. Declarations can contain selectors, but rules can only contain a single pairing of property and value. If you need a selector or more than one rule, use `%cx{:rescript}` instead.
 - The semi-colon in the last position is optional. `display: block;{:css}` and `display: block{:css}` are the same.
 - Curly braces aren't allowed. `{ display: block }{:css}` isn't valid.

--- a/packages/website/pages/reference/css.mdx
+++ b/packages/website/pages/reference/css.mdx
@@ -14,6 +14,6 @@ let rule: Css.rule = %css("display: block")
 
 ## Features
 
-- Only single properties are allowed; declarations are not allowed. Declarations can contain selectors, but rules can only contain a single pairing of property and value. If you need a selector or more than one rule, use `%cx{:rescript}` instead.
+- Only single properties are allowed, e.g., `color: blue`, and multiple declarations, e.g., `:hover { color: blue}` or `color: blue; background-color: red`, are not allowed. If you need to use a selector or use more than one rule, use `%cx{:rescript}` instead.
 - The semi-colon in the last position is optional. `display: block;{:css}` and `display: block{:css}` are the same.
 - Curly braces aren't allowed. `{ display: block }{:css}` isn't valid.

--- a/packages/website/pages/reference/dynamic-components.mdx
+++ b/packages/website/pages/reference/dynamic-components.mdx
@@ -4,9 +4,9 @@ title: Dynamic components
 
 # Dynamic components
 
-Dynamic components mean components that generate styles based on their props. You can derive styles from props, apply conditionally a variant or any logic.
+Dynamic components are components that generate styles based on their props. You can derive styles from props, apply a variant conditionally, or any other logic.
 
-`styled.{{tag}}` allows to be defined by a function, where it should return a string. This function is going to be available as props API for that component, including all props from the element. Like following:
+`styled.{{tag}}` can be defined by a function, where it should return a string. This function is going to be available via the props API for that component, including all props from the element. Like following:
 
 ```rescript
 module Dynamic = %styled.div(
@@ -21,11 +21,11 @@ module Dynamic = %styled.div(
 </Dynamic>
 ```
 
-Note: The returned expression (the last expression of the function) need to be an string (it can't be a reference or a function call). This is a limitation of ppxes where it needs to check the current AST to know which type is.
+Note: The returned expression (the last expression of the function) needs to be an string (it can't be a reference or a function call). This is a limitation of ppxes where it needs to check the current AST to know which type it is.
 
-All rules from [Interpolation](./interpolation) are applied here. In the example, `color` and `background` are `CssJs.Color.t{:rescript}` since it gets inferred from the CSS property. It's called type holes https://twitter.com/davesnx/status/1552305210558742528
+All the rules from [Interpolation](./interpolation) are applied here. In the example, `color` and `background` are `CssJs.Color.t{:rescript}` since it gets inferred from the CSS property. It's called type holes https://twitter.com/davesnx/status/1552305210558742528
 
 ### Collision
 
 If you create a dynamic component with a prop that collides with the name of a React prop, it will override it.
-For example if your dynamic component is defined with a prop "size" it will override [`size`](https://github.com/rescript-lang/rescript-react/blob/master/src/ReactDOM.res#L367) from makeProps. This mechanism is to ensure that you can name your props the way you want it.
+For example, if your dynamic component is defined with a prop "size" it will override [`size`](https://github.com/rescript-lang/rescript-react/blob/master/src/ReactDOM.res#L367) from makeProps. This mechanism is to ensure that you can name your props the way you want it.

--- a/packages/website/pages/reference/globals.mdx
+++ b/packages/website/pages/reference/globals.mdx
@@ -15,6 +15,6 @@ title: Inject global styles
 `)
 ```
 
-Recommend to not add `@font-face{:css}` defintions as globals. Consider adding the font directly to the HTML or in a `style.css` file. [More](https://andydavies.me/blog/2019/02/12/preloading-fonts-and-the-puzzle-of-priorities/).
+Recommend to not add `@font-face{:css}` definitions as globals. Consider adding the font directly to the HTML or in a `style.css` file. [More](https://andydavies.me/blog/2019/02/12/preloading-fonts-and-the-puzzle-of-priorities/).
 
-Since [emotion](https://emotion.sh) have a small run-time for those global styles to be applied to the DOM. In a regular style file this isn't an issue. Keeping `@fonts-face{:css}` or other `@imports{:css}` inside emotion will delay a bit their fetching and will cause a [Flash of Unestyled Text](https://css-tricks.com/fout-foit-foft/).
+Since [emotion](https://emotion.sh) has a small run-time for those global styles to be applied to the DOM. In a regular style file this isn't an issue. Keeping `@fonts-face{:css}` or other `@imports{:css}` inside emotion will delay a bit their fetching and will cause a [Flash of Unstyled Text](https://css-tricks.com/fout-foit-foft/).

--- a/packages/website/pages/reference/interpolation.mdx
+++ b/packages/website/pages/reference/interpolation.mdx
@@ -6,9 +6,7 @@ import Callout from 'nextra-theme-docs/callout'
 
 # Interpolation
 
-Interpolation allows to use any identifier as a value inside CSS. "any identifier" refers to any ReScript variables or [module accessors](https://rescript-lang.org/try?code=LYewJgrgNgpgBAFQBY2PAvHA3gKDnWAFzgHMAnGATzkwGEBnegKXoDoUAPACgCIAhAKJ8AInwAcPAJQ4AvjiA).
-
-Useful for reusing variables, handling themes or conditionally apply styles based on props at run-time.
+Interpolation allows you to use any identifier as a value inside CSS, where "any identifier" refers to any ReScript variables or [module accessors](https://rescript-lang.org/try?code=LYewJgrgNgpgBAFQBY2PAvHA3gKDnWAFzgHMAnGATzkwGEBnegKXoDoUAPACgCIAhAKJ8AInwAcPAJQ4AvjiA). This is useful for reusing variables, handling themes, or conditionally applying styles based on props at run-time.
 
 ```rescript
 module Component = %styled.div(`
@@ -22,7 +20,7 @@ module Component = %styled.div(`
 `)
 ```
 
-Interpolation works inside values, media-queries and selectors. It doesn't work for entire properties or any interpolation, which is slightly different from SASS/Less and other JavaScript-based solutions (such as styled-components or emotion) their interpolation is more dynamic and can be used everywhere.
+Interpolation works inside values, media-queries and selectors. It doesn't work for entire properties or any interpolation, which is slightly different from SASS/Less and other JavaScript-based solutions (such as styled-components or emotion) as their interpolation is more dynamic and can be used everywhere.
 
 <Callout>
   Don't confuse interpolation from [String Interpolation from ReScript](https://rescript-lang.org/docs/manual/latest/primitive-types#string-interpolation).
@@ -30,9 +28,9 @@ Interpolation works inside values, media-queries and selectors. It doesn't work 
 
 The rules for interpolation works the same way as [CSS variables](https://www.w3.org/TR/css-variables-1/#using-variables) (`var(){:css}`);
 
-**styled-ppx** forces you to be more rigit, with the promise of being type-safe, the same way as ReScript does ❤️. The dynamism from JavaScript-based solutions comes with the cost of unsafety.
+**styled-ppx** forces you to be more rigid but with the promise of being type-safe, which is the same way as ReScript does ❤️. The dynamism from JavaScript-based solutions comes with the cost of being unsafe.
 
-Here's an example: `margin-${whatever}: 10px` is valid in JavaScript, while isn't valid in **styled-ppx**. As explained above, this interpolation can't be applied to entire **properties**, neither half-properties.
+Here's an example: `margin-${whatever}: 10px` is valid in JavaScript, while isn't valid in **styled-ppx**. As explained above, this interpolation can't be applied to entire **properties** or half-properties.
 
 The solution is simple, you would handle all properties based on the dynamic value:
 
@@ -46,7 +44,7 @@ let margin = direction =>
   }
 ```
 
-If you aren't familiar with `%css{:rescript}` extension, take a look [in the `%css` section](./css)
+If you aren't familiar with `%css{:rescript}` extension, take a look [at the `%css` section](./css).
 
 ## Example
 
@@ -64,12 +62,12 @@ margin: $(Size.small) $(Size.small); // -> margin: 10px 10px;
 
 ## Features
 
-- Type-safety via type holes
-- Support for shorthand properties and interpolate on a value
+- Type-safety via type holes.
+- Support for shorthand properties and interpolate on a value.
 
 ## Type-safety
 
-We introduced here the API from [`CssJs`](./runtime) to define the value of `margin`. We expect you to use it to make sure the values are interpoilated with the right type. In the example above `margin` expects one of:
+The example above introduces the API from [`CssJs`](./runtime) to define the value of `margin`. We expect you to use it to make sure the values are interpoilated with the right type. In the example above `margin` expects one of:
 
 ```rescript
 auto | ch(float) | em(float) | ex(float) | rem(float) | vh(float) | vw(float) | vmin(float) | vmax(float) | px(int) | pxFloat(float) | cm(float) | mm(float) | inch(float) | pc(float) | pt(int) | zero | calc([ | add | sub], t, t) | percent(float)`
@@ -77,9 +75,9 @@ auto | ch(float) | em(float) | ex(float) | rem(float) | vh(float) | vw(float) | 
 
 Since `Size.small{:rescript}` is `px(int){:rescript}`, the type-checker would allow it.
 
-## A note about polymorphism of CSS
+## A note about the polymorphism of CSS
 
-There are plenty of properties on CSS that accept different types of values, the ones encountered challenging are `animation`, `box-shadow`/`text-shadow`, `background`, `transition` and `transform` to name a few. Not because are shorthand properties, but because they have values that are positional and optional at the same time.
+There are plenty of properties in CSS that accept different types of values. Some of the most challenging ones are `animation`, `box-shadow`/`text-shadow`, `background`, `transition` and `transform`, to name a few. These properties are not challenging because they are shorthand properties, but because they have values that are positional **<u>and</u>** optional at the same time.
 
 Let's look at `background`.
 
@@ -90,16 +88,16 @@ background: #fff url(img.png); /* The background is white with an image */
 background: url(img.png) no-repeat; /* The background is a non-repeating image */
 ```
 
-In this case, to interpolate the background's value like: `background: $(variable1) $(variable2)` the type-checker can't know the type of `$(variable1)` and `(variable2)` ahead of time, since there's a few possibilities of `background` valid. This is called [overload](https://www.typescriptlang.org/docs/handbook/declaration-files/by-example.html#overloaded-functions) in other languages and it's not available in ReScript to it's nature of a static typed language.
+In this case, to interpolate the background's value like: `background: $(variable1) $(variable2)` the type-checker can't know the type of `$(variable1)` and `(variable2)` ahead of time, because there are numerous possibilities for a valid `background` CSS property. This is called an [overload](https://www.typescriptlang.org/docs/handbook/declaration-files/by-example.html#overloaded-functions) in other languages and it's not available in ReScript due to it's nature of being a static typed language.
 
 ## What if a property isn't supported
 
 First, if you have the time, please [open an issue](https://github.com/davesnx/styled-ppx/issues/new). Most properties are trivial to add support for.
-If time isn't your best friend: There's a workaround for unsupported properties.
+If time isn't your best friend then there's a workaround for unsupported properties.
 
-There's no way to add unsafe behaviour on CSS definitions. Prefer to keep improving the overall safety via requests/issues than allowing a method for unsafe to all. It will loose the purpose of **styled-ppx**.
+There is no way to add unsafe behaviour to CSS definitions. We prefer to keep improving the overall safety of styled-ppx via requests/issues rather than allowing a method for unsafe functionality - doing so would negate the whole purpose of **styled-ppx**.
 
-The workaround is to use the [Array API](./array) to generate `%cx{:rescript}` calls, like this example:
+The workaround is to use the [Array API](./array) to generate `%cx{:rescript}` calls. For example:
 
 ```rescript
 let block: Css.Rule.t = %css("display: block")

--- a/packages/website/pages/reference/keyframe.mdx
+++ b/packages/website/pages/reference/keyframe.mdx
@@ -26,4 +26,4 @@ module Component = %styled.div(`
 
 - Braces are optional. `%keyframe({ ... }){:rescript}` and `%keyframe(...){:rescript}` are the same.
 - The keyframe name is defined outside of the CSS.
-- The type of the keyframe is `string`, but hidden in an [opaque type](https://reasonml.github.io/docs/en/type#opaque-types)
+- The type of the keyframe is `string`, but hidden in an [opaque type](https://reasonml.github.io/docs/en/type#opaque-types).

--- a/packages/website/pages/reference/media-queries.mdx
+++ b/packages/website/pages/reference/media-queries.mdx
@@ -4,7 +4,7 @@ title: Media Queries
 
 # Media queries
 
-The extensions `cx` and `styled` support media-queries (and any [`at_rule`](https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule)), on the other hand `css` it doesn't, since it only generates one Rule.
+The extensions `cx` and `styled` support media-queries (and any [`at_rule`](https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule)); on the other hand, `css` does not because it only generates one Rule.
 
 ```rescript
 let container = %cx(`

--- a/packages/website/pages/reference/react-ref.mdx
+++ b/packages/website/pages/reference/react-ref.mdx
@@ -37,4 +37,4 @@ let make = () => {
 }
 ```
 
-All information related with React's Ref is explained in [rescript's docs](https://rescript-lang.org/docs/react/latest/forwarding-refs).
+All information related to React's Ref is explained in the [rescript's docs](https://rescript-lang.org/docs/react/latest/forwarding-refs).

--- a/packages/website/pages/reference/selectors.mdx
+++ b/packages/website/pages/reference/selectors.mdx
@@ -4,7 +4,7 @@ title: Selectors
 
 # Selectors
 
-The extensions `cx` and `styled` support selectors, on the other hand `css` it doesn't, since it only generates one Rule.
+The extensions `cx` and `styled` support selectors; on the other hand `css` does not because it only generates one Rule.
 
 The syntax is similar to SASS but the only difference is that for nesting you need to use `&` in front of each selector.
 
@@ -19,7 +19,7 @@ let link = %cx(`
 ```
 > Note: Selectors can be nested within your CSS which will be attached to the classname generated (in this case by `cx`)
 
-More than one level of selectors is not supported. It might compile but will generate the wrong result.
+More than one level of selectors is not supported. It might compile but it will generate the wrong result.
 
 The support for selectors is CSS Selectors Level 3 and the more stable part of level 4 (currently in draft).
 

--- a/packages/website/pages/reference/styled-components.mdx
+++ b/packages/website/pages/reference/styled-components.mdx
@@ -6,7 +6,7 @@ import Callout from 'nextra-theme-docs/callout'
 
 # Styled components
 
-`styled.{{tag}}` is the extension that allows to create React Components from the styles of the element.
+`styled.{{tag}}` is the extension that allows you to create React Components from the styles of the element.
 All HTML Elements are available under `styled.{{tag}}`. An example of it will be:
 
 ```rescript
@@ -47,10 +47,10 @@ module Input = %styled.input(`
 ```
 
 <Callout>
-  You can extend the styles from a component via `className` prop.
+  You can extend the styles from a component via the `className` prop.
 </Callout>
 
-#### Extend styles with className
+#### Extend styles with `className`
 
 Following the example above, you can extend the styles of the input component by passing the `className` prop.
 It's not recommended to use `className` prop to extend the styles of a component, but it's useful when you need to extend the styles of a component from a third-party library.


### PR DESCRIPTION
Minor updates to the docs to fix spelling errors and to add some clarifications. Still some questions:

1) I'm not sure what you are trying to say with [this line](https://github.com/davesnx/styled-ppx/blob/main/packages/website/pages/reference/css.mdx#L17). I have tried to rephrase it as: 

> - Only single properties are allowed; declarations are not allowed. Declarations can contain selectors, but rules can only contain a single pairing of property and value. If you need a selector or more than one rule, use `%cx{:rescript}` instead.

But I'm not sure if this makes sense as I don't really understand the original line.

2) Is there a missing link on [this line](https://github.com/davesnx/styled-ppx/blob/main/packages/website/pages/css-support.mdx#L11)? `[Css bindings]` is in square brackets but I don't know why.