### PR TITLE
support melange 3 from opam

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -33,7 +33,7 @@
    (ppx_deriving_yojson (>= 3.7.0))
    (ppxlib (>= 0.27.0))
    (sedlex (>= 3.2))
-   (melange (>= 1.0.0))
+   (melange (>= 3.0.0))
    server-reason-react
    (reason-react (>= 0.13.0))
    (reason :with-dev-setup)

--- a/packages/css/native/shared/Css_AtomicTypes.ml
+++ b/packages/css/native/shared/Css_AtomicTypes.ml
@@ -2277,9 +2277,9 @@ module FontFamilyName = struct
   let toString x =
     match x with
     | `custom value ->
-      (match Std.String.get value 0 with
-      | {js|"|js} | {js|'|js} -> value
-      | _ -> ({js|"|js} ^ value) ^ {js|"|js})
+      let s = Std.String.get value 0 in
+      if s = {js|"|js} || s = {js|'|js} then value
+      else ({js|"|js} ^ value) ^ {js|"|js}
     | `serif -> {js|serif|js}
     | `sansSerif -> {js|sans-serif|js}
     | `cursive -> {js|cursive|js}
@@ -2423,12 +2423,12 @@ module Content = struct
   let text_to_string value =
     match value with
     | "" -> {js|''|js}
-    | {js|""|js} -> {js|''|js}
+    | "\"\"" -> {js|''|js}
     | value ->
       (match Js.String.get value 0, Js.String.length value with
-      | {js|"|js}, 1 -> {js|'"'|js}
-      | {js|'|js}, 1 -> {js|"'"|js}
-      | {js|"|js}, _ | {js|'|js}, _ -> value
+      | "\"", 1 -> {js|'"'|js}
+      | "'", 1 -> {js|"'"|js}
+      | "\"", _ | "'", _ -> value
       | _ -> {js|"|js} ^ value ^ {js|"|js})
 
   let toString x =

--- a/packages/css/native/shared/Css_AtomicTypes.ml
+++ b/packages/css/native/shared/Css_AtomicTypes.ml
@@ -2277,9 +2277,9 @@ module FontFamilyName = struct
   let toString x =
     match x with
     | `custom value ->
-      let s = Std.String.get value 0 in
-      if s = {js|"|js} || s = {js|'|js} then value
-      else ({js|"|js} ^ value) ^ {js|"|js}
+      (match Std.String.get value 0 with
+      | "\"" | "'" -> value
+      | _ -> ({js|"|js} ^ value) ^ {js|"|js})
     | `serif -> {js|serif|js}
     | `sansSerif -> {js|sans-serif|js}
     | `cursive -> {js|cursive|js}

--- a/packages/emotion/js/Css.ml
+++ b/packages/emotion/js/Css.ml
@@ -7,12 +7,12 @@ include Css_Legacy_Core.Make (struct
   type renderer = Js.Json.t
 
   external injectRaw : string -> unit = "injectGlobal"
-  [@@mel.module "@emotion/css"] [@@bs.module "@emotion/css"]
+  [@@mel.module "@emotion/css"] [@@mel.module "@emotion/css"]
 
   let renderRaw _ css = injectRaw css
 
   external injectRawRules : Js.Json.t -> unit = "injectGlobal"
-  [@@mel.module "@emotion/css"] [@@bs.module "@emotion/css"]
+  [@@mel.module "@emotion/css"] [@@mel.module "@emotion/css"]
 
   let injectRules selector rules =
     injectRawRules (Js.Dict.fromArray [| selector, rules |] |. Js.Json.object_)
@@ -21,13 +21,13 @@ include Css_Legacy_Core.Make (struct
     injectRawRules (Js.Dict.fromArray [| selector, rules |] |. Js.Json.object_)
 
   external mergeStyles : styleEncoding array -> styleEncoding = "cx"
-  [@@mel.module "@emotion/css"] [@@bs.module "@emotion/css"]
+  [@@mel.module "@emotion/css"] [@@mel.module "@emotion/css"]
 
   external make : Js.Json.t -> styleEncoding = "css"
-  [@@mel.module "@emotion/css"] [@@bs.module "@emotion/css"]
+  [@@mel.module "@emotion/css"] [@@mel.module "@emotion/css"]
 
   external makeAnimation : Js.Json.t Js.Dict.t -> string = "keyframes"
-  [@@mel.module "@emotion/css"] [@@bs.module "@emotion/css"]
+  [@@mel.module "@emotion/css"] [@@mel.module "@emotion/css"]
 
   let makeKeyframes frames = makeAnimation frames
   let renderKeyframes _ frames = makeAnimation frames
@@ -36,7 +36,7 @@ end)
 type cache
 
 external cache : cache = "cache"
-[@@mel.module "@emotion/cache"] [@@bs.module "@emotion/cache"]
+[@@mel.module "@emotion/cache"] [@@mel.module "@emotion/cache"]
 
 let fontFace ~fontFamily ~src ?fontStyle ?fontWeight ?fontDisplay ?sizeAdjust ()
     =

--- a/packages/emotion/js/CssJs.ml
+++ b/packages/emotion/js/CssJs.ml
@@ -7,12 +7,12 @@ include Css_Js_Core.Make (struct
   type renderer = Js.Json.t
 
   external injectRaw : string -> unit = "injectGlobal"
-  [@@mel.module "@emotion/css"] [@@bs.module "@emotion/css"]
+  [@@mel.module "@emotion/css"] [@@mel.module "@emotion/css"]
 
   let renderRaw _ css = injectRaw css
 
   external injectRawRules : Js.Json.t -> unit = "injectGlobal"
-  [@@mel.module "@emotion/css"] [@@bs.module "@emotion/css"]
+  [@@mel.module "@emotion/css"] [@@mel.module "@emotion/css"]
 
   let injectRules selector rules =
     injectRawRules (Js.Dict.fromArray [| selector, rules |] |. Js.Json.object_)
@@ -21,13 +21,13 @@ include Css_Js_Core.Make (struct
     injectRawRules (Js.Dict.fromArray [| selector, rules |] |. Js.Json.object_)
 
   external mergeStyles : styleEncoding array -> styleEncoding = "cx"
-  [@@mel.module "@emotion/css"] [@@bs.module "@emotion/css"]
+  [@@mel.module "@emotion/css"] [@@mel.module "@emotion/css"]
 
   external make : Js.Json.t -> styleEncoding = "css"
-  [@@mel.module "@emotion/css"] [@@bs.module "@emotion/css"]
+  [@@mel.module "@emotion/css"] [@@mel.module "@emotion/css"]
 
   external makeAnimation : Js.Json.t Js.Dict.t -> string = "keyframes"
-  [@@mel.module "@emotion/css"] [@@bs.module "@emotion/css"]
+  [@@mel.module "@emotion/css"] [@@mel.module "@emotion/css"]
 
   let makeKeyframes frames = makeAnimation frames
   let renderKeyframes _ frames = makeAnimation frames
@@ -36,7 +36,7 @@ end)
 type cache
 
 external cache : cache = "cache"
-[@@mel.module "@emotion/cache"] [@@bs.module "@emotion/cache"]
+[@@mel.module "@emotion/cache"] [@@mel.module "@emotion/cache"]
 
 let fontFace ~fontFamily ~src ?fontStyle ?fontWeight ?fontDisplay ?sizeAdjust ()
     =

--- a/packages/ppx/src/platform_attributes.re
+++ b/packages/ppx/src/platform_attributes.re
@@ -89,7 +89,7 @@ module MelangeAttributes = {
     Builder.attribute(~name=withLoc(~loc, "u"), ~loc, ~payload=PStr([]));
   };
 
-  /* [@deriving abstract] */
+  /* [@deriving jsProperties, getSet] */
   let derivingAbstract = (~loc) =>
     Helper.Attr.mk(
       withLoc("deriving", ~loc),
@@ -97,7 +97,19 @@ module MelangeAttributes = {
         Helper.Str.mk(
           ~loc,
           Pstr_eval(
-            Helper.Exp.ident(~loc, withLoc(Lident("abstract"), ~loc)),
+            Helper.Exp.tuple(
+              ~loc,
+              [
+                Helper.Exp.ident(
+                  ~loc,
+                  withLoc(Lident("jsProperties"), ~loc),
+                ),
+                Helper.Exp.ident(
+                  ~loc,
+                  withLoc(Lident("getSet"), ~loc),
+                ),
+              ],
+            ),
             [],
           ),
         ),

--- a/packages/ppx/test/snapshot/reason/bs-config-missing-jsx.t/run.t
+++ b/packages/ppx/test/snapshot/reason/bs-config-missing-jsx.t/run.t
@@ -10,7 +10,7 @@
   $ standalone --impl output.ml -o output.ml
   $ refmt --parse ml --print re output.ml
   module ArrayDynamicComponent = {
-    [@deriving abstract]
+    [@deriving (jsProperties, getSet)]
     type makeProps('var) = {
       [@mel.optional]
       innerRef: option(ReactDOM.domRef),

--- a/packages/ppx/test/snapshot/reason/dynamic-array.t/run.t
+++ b/packages/ppx/test/snapshot/reason/dynamic-array.t/run.t
@@ -2,7 +2,7 @@
   $ standalone --impl output.ml -o output.ml
   $ refmt --parse ml --print re output.ml
   module ArrayDynamicComponent = {
-    [@deriving abstract]
+    [@deriving (jsProperties, getSet)]
     type makeProps('var) = {
       [@mel.optional]
       innerRef: option(ReactDOM.domRef),

--- a/packages/ppx/test/snapshot/reason/dynamic-interpolation-default-value.t/run.t
+++ b/packages/ppx/test/snapshot/reason/dynamic-interpolation-default-value.t/run.t
@@ -2,7 +2,7 @@
   $ standalone --impl output.ml -o output.ml
   $ refmt --parse ml --print re output.ml
   module DynamicComponentWithDefaultValue = {
-    [@deriving abstract]
+    [@deriving (jsProperties, getSet)]
     type makeProps('var) = {
       [@mel.optional]
       innerRef: option(ReactDOM.domRef),

--- a/packages/ppx/test/snapshot/reason/dynamic-interpolation.t/run.t
+++ b/packages/ppx/test/snapshot/reason/dynamic-interpolation.t/run.t
@@ -2,7 +2,7 @@
   $ standalone --impl output.ml -o output.ml
   $ refmt --parse ml --print re output.ml
   module DynamicComponent = {
-    [@deriving abstract]
+    [@deriving (jsProperties, getSet)]
     type makeProps('var) = {
       [@mel.optional]
       innerRef: option(ReactDOM.domRef),

--- a/packages/ppx/test/snapshot/reason/dynamic-sequence.t/run.t
+++ b/packages/ppx/test/snapshot/reason/dynamic-sequence.t/run.t
@@ -2,7 +2,7 @@
   $ standalone --impl output.ml -o output.ml
   $ refmt --parse ml --print re output.ml
   module SequenceDynamicComponent = {
-    [@deriving abstract]
+    [@deriving (jsProperties, getSet)]
     type makeProps('size) = {
       [@mel.optional]
       innerRef: option(ReactDOM.domRef),
@@ -974,7 +974,7 @@
     };
   };
   module DynamicComponentWithSequence = {
-    [@deriving abstract]
+    [@deriving (jsProperties, getSet)]
     type makeProps('variant) = {
       [@mel.optional]
       innerRef: option(ReactDOM.domRef),

--- a/packages/ppx/test/snapshot/reason/dynamic-with-array.t/run.t
+++ b/packages/ppx/test/snapshot/reason/dynamic-with-array.t/run.t
@@ -2,7 +2,7 @@
   $ standalone --impl output.ml -o output.ml
   $ refmt --parse ml --print re output.ml
   module DynamicComponentWithArray = {
-    [@deriving abstract]
+    [@deriving (jsProperties, getSet)]
     type makeProps('color, 'size) = {
       [@mel.optional]
       innerRef: option(ReactDOM.domRef),

--- a/packages/ppx/test/snapshot/reason/dynamic-with-ident.t/run.t
+++ b/packages/ppx/test/snapshot/reason/dynamic-with-ident.t/run.t
@@ -2,7 +2,7 @@
   $ standalone --impl output.ml -o output.ml
   $ refmt --parse ml --print re output.ml
   module DynamicCompnentWithIdent = {
-    [@deriving abstract]
+    [@deriving (jsProperties, getSet)]
     type makeProps('a) = {
       [@mel.optional]
       innerRef: option(ReactDOM.domRef),

--- a/packages/ppx/test/snapshot/reason/dynamic-with-sequence-out-scope.t/run.t
+++ b/packages/ppx/test/snapshot/reason/dynamic-with-sequence-out-scope.t/run.t
@@ -4,7 +4,7 @@
   let sharedStylesBetweenDynamicComponents = (color): CssJs.rule =>
     CssJs.color(color);
   module DynamicCompnentWithLetIn = {
-    [@deriving abstract]
+    [@deriving (jsProperties, getSet)]
     type makeProps('color) = {
       [@mel.optional]
       innerRef: option(ReactDOM.domRef),

--- a/packages/ppx/test/snapshot/reason/dynamic.t/run.t
+++ b/packages/ppx/test/snapshot/reason/dynamic.t/run.t
@@ -2,7 +2,7 @@
   $ standalone --impl output.ml -o output.ml
   $ refmt --parse ml --print re output.ml
   module DynamicComponent = {
-    [@deriving abstract]
+    [@deriving (jsProperties, getSet)]
     type makeProps('var) = {
       [@mel.optional]
       innerRef: option(ReactDOM.domRef),

--- a/packages/ppx/test/snapshot/reason/keyframes.t/run.t
+++ b/packages/ppx/test/snapshot/reason/keyframes.t/run.t
@@ -7,7 +7,7 @@
       (100, [|CssJs.opacity(1.)|]),
     |]);
   module FadeIn = {
-    [@deriving abstract]
+    [@deriving (jsProperties, getSet)]
     type makeProps = {
       [@mel.optional]
       innerRef: option(ReactDOM.domRef),

--- a/packages/ppx/test/snapshot/reason/media-queries-and-selectors-interpolation.t/run.t
+++ b/packages/ppx/test/snapshot/reason/media-queries-and-selectors-interpolation.t/run.t
@@ -4,7 +4,7 @@
   let width = "120px";
   let orientation = "landscape";
   module SelectorWithInterpolation = {
-    [@deriving abstract]
+    [@deriving (jsProperties, getSet)]
     type makeProps = {
       [@mel.optional]
       innerRef: option(ReactDOM.domRef),

--- a/packages/ppx/test/snapshot/reason/media-queries-and-selectors.t/run.t
+++ b/packages/ppx/test/snapshot/reason/media-queries-and-selectors.t/run.t
@@ -2,7 +2,7 @@
   $ standalone --impl output.ml -o output.ml
   $ refmt --parse ml --print re output.ml
   module SelectorsMediaQueries = {
-    [@deriving abstract]
+    [@deriving (jsProperties, getSet)]
     type makeProps = {
       [@mel.optional]
       innerRef: option(ReactDOM.domRef),

--- a/packages/ppx/test/snapshot/reason/media-queries-with-calc.t/run.t
+++ b/packages/ppx/test/snapshot/reason/media-queries-with-calc.t/run.t
@@ -2,7 +2,7 @@
   $ standalone --impl output.ml -o output.ml
   $ refmt --parse ml --print re output.ml
   module MediaQueryCalc = {
-    [@deriving abstract]
+    [@deriving (jsProperties, getSet)]
     type makeProps = {
       [@mel.optional]
       innerRef: option(ReactDOM.domRef),

--- a/packages/ppx/test/snapshot/reason/static-array.t/run.t
+++ b/packages/ppx/test/snapshot/reason/static-array.t/run.t
@@ -2,7 +2,7 @@
   $ standalone --impl output.ml -o output.ml
   $ refmt --parse ml --print re output.ml
   module ArrayStatic = {
-    [@deriving abstract]
+    [@deriving (jsProperties, getSet)]
     type makeProps = {
       [@mel.optional]
       innerRef: option(ReactDOM.domRef),

--- a/packages/ppx/test/snapshot/reason/static-doble-quotes-string.t/run.t
+++ b/packages/ppx/test/snapshot/reason/static-doble-quotes-string.t/run.t
@@ -2,7 +2,7 @@
   $ standalone --impl output.ml -o output.ml
   $ refmt --parse ml --print re output.ml
   module SingleQuoteStrings = {
-    [@deriving abstract]
+    [@deriving (jsProperties, getSet)]
     type makeProps = {
       [@mel.optional]
       innerRef: option(ReactDOM.domRef),

--- a/packages/ppx/test/snapshot/reason/static-interpolation.t/run.t
+++ b/packages/ppx/test/snapshot/reason/static-interpolation.t/run.t
@@ -9,7 +9,7 @@
   };
   let black = CssJs.hex("000");
   module StringInterpolation = {
-    [@deriving abstract]
+    [@deriving (jsProperties, getSet)]
     type makeProps = {
       [@mel.optional]
       innerRef: option(ReactDOM.domRef),

--- a/packages/ppx/test/snapshot/reason/static-multi-line-string.t/run.t
+++ b/packages/ppx/test/snapshot/reason/static-multi-line-string.t/run.t
@@ -2,7 +2,7 @@
   $ standalone --impl output.ml -o output.ml
   $ refmt --parse ml --print re output.ml
   module MultiLineStrings = {
-    [@deriving abstract]
+    [@deriving (jsProperties, getSet)]
     type makeProps = {
       [@mel.optional]
       innerRef: option(ReactDOM.domRef),

--- a/packages/ppx/test/snapshot/reason/static-open-property.t/run.t
+++ b/packages/ppx/test/snapshot/reason/static-open-property.t/run.t
@@ -2,7 +2,7 @@
   $ standalone --impl output.ml -o output.ml
   $ refmt --parse ml --print re output.ml
   module OneSingleProperty = {
-    [@deriving abstract]
+    [@deriving (jsProperties, getSet)]
     type makeProps = {
       [@mel.optional]
       innerRef: option(ReactDOM.domRef),

--- a/packages/ppx/test/snapshot/reason/static-self-closing-element.t/run.t
+++ b/packages/ppx/test/snapshot/reason/static-self-closing-element.t/run.t
@@ -2,7 +2,7 @@
   $ standalone --impl output.ml -o output.ml
   $ refmt --parse ml --print re output.ml
   module SelfClosingElement = {
-    [@deriving abstract]
+    [@deriving (jsProperties, getSet)]
     type makeProps = {
       [@mel.optional]
       innerRef: option(ReactDOM.domRef),

--- a/styled-ppx.opam
+++ b/styled-ppx.opam
@@ -17,7 +17,7 @@ depends: [
   "ppx_deriving_yojson" {>= "3.7.0"}
   "ppxlib" {>= "0.27.0"}
   "sedlex" {>= "3.2"}
-  "melange" {>= "1.0.0"}
+  "melange" {>= "3.0.0"}
   "server-reason-react"
   "reason-react" {>= "0.13.0"}
   "reason" {with-dev-setup}
@@ -43,9 +43,8 @@ build: [
 ]
 dev-repo: "git+https://github.com/davesnx/styled-ppx.git"
 pin-depends: [
-  ["melange.dev" "git+https://github.com/melange-re/melange#300e323d3634e6de7c3d65dca9276a6d68410b5e"]
   ["reason.dev" "https://github.com/reasonml/reason/archive/f92f7ecc228d19ebf4d9d0214792da7b45472766.tar.gz"]
-  ["reason-react.dev" "https://github.com/reasonml/reason-react/archive/2a43311df12eb3988fd9729098928e6b03cfaa07.tar.gz"]
-  ["reason-react-ppx.dev" "https://github.com/reasonml/reason-react/archive/2a43311df12eb3988fd9729098928e6b03cfaa07.tar.gz"]
+  ["reason-react.dev" "https://github.com/reasonml/reason-react/archive/1f084f4ecf380b2144809065e5935a41866eab3f.tar.gz"]
+  ["reason-react-ppx.dev" "https://github.com/reasonml/reason-react/archive/1f084f4ecf380b2144809065e5935a41866eab3f.tar.gz"]
   ["server-reason-react.dev" "https://github.com/ml-in-barcelona/server-reason-react/archive/04374f5fc974b9da47d8d27acd875f20e208377b.tar.gz"]
 ]

--- a/styled-ppx.opam.template
+++ b/styled-ppx.opam.template
@@ -1,7 +1,6 @@
 pin-depends: [
-  ["melange.dev" "git+https://github.com/melange-re/melange#300e323d3634e6de7c3d65dca9276a6d68410b5e"]
   ["reason.dev" "https://github.com/reasonml/reason/archive/f92f7ecc228d19ebf4d9d0214792da7b45472766.tar.gz"]
-  ["reason-react.dev" "https://github.com/reasonml/reason-react/archive/2a43311df12eb3988fd9729098928e6b03cfaa07.tar.gz"]
-  ["reason-react-ppx.dev" "https://github.com/reasonml/reason-react/archive/2a43311df12eb3988fd9729098928e6b03cfaa07.tar.gz"]
+  ["reason-react.dev" "https://github.com/reasonml/reason-react/archive/1f084f4ecf380b2144809065e5935a41866eab3f.tar.gz"]
+  ["reason-react-ppx.dev" "https://github.com/reasonml/reason-react/archive/1f084f4ecf380b2144809065e5935a41866eab3f.tar.gz"]
   ["server-reason-react.dev" "https://github.com/ml-in-barcelona/server-reason-react/archive/04374f5fc974b9da47d8d27acd875f20e208377b.tar.gz"]
 ]


### PR DESCRIPTION
Updates `styled-ppx` to use `melange.3.0.0` from opam.

- Update opam file (bump lower bound for melange)
- Remove pin for melange
- Replaces usages of `js` strings in patterns (which triggered an error)
- `deriving abstract` -> `deriving jsProperties, getSet`
- `bs.module` -> `mel.module`