### PR TITLE
Cleanup Css_lexer from #372

### DIFF
--- a/packages/parser/lib/Parser_location.ml
+++ b/packages/parser/lib/Parser_location.ml
@@ -1,0 +1,3 @@
+let to_ppxlib_location ?(loc_ghost = false) (start_pos : Lexing.position)
+  (end_pos : Lexing.position) : Ppxlib.Location.t =
+  { loc_start = start_pos; loc_end = end_pos; loc_ghost }

--- a/packages/parser/lib/Tokens.re
+++ b/packages/parser/lib/Tokens.re
@@ -1,14 +1,16 @@
+module Parser = Css_parser;
+
 [@deriving show({with_path: false})]
 type token =
   | EOF
   | IDENT(string) // <ident-token>
-  | BAD_IDENT // TODO: this is needed?
+  | BAD_IDENT // TODO: Since we don't allow broken syntax, is this needed?
   | FUNCTION(string) // <function-token>
   | AT_KEYWORD(string) // <at-keyword-token>
   | HASH(string, [ | `ID | `UNRESTRICTED]) // <hash-token>
   | STRING(string) // <string-token>
   | URL(string) // <url-token>
-  | BAD_URL // <bad-url-token>
+  | BAD_URL // <bad-url-token> TODO: Since we don't allow broken syntax, is this needed?
   | DELIM(string) // <delim-token>
   | NUMBER(float) // <number-token>
   | PERCENTAGE(float) // <percentage-token>
@@ -63,8 +65,6 @@ let humanize =
   | RIGHT_PAREN => ")"
   | LEFT_BRACE => "{"
   | RIGHT_BRACE => "}";
-
-module Parser = Css_parser;
 
 /* TODO: This should render Token, not Parser.token */
 let token_to_string =

--- a/packages/parser/lib/Tokens.re
+++ b/packages/parser/lib/Tokens.re
@@ -66,6 +66,7 @@ let humanize =
 
 module Parser = Css_parser;
 
+/* TODO: This should render Token, not Parser.token */
 let token_to_string =
   fun
   | Parser.EOF => ""
@@ -113,6 +114,7 @@ let token_to_string =
   | BAD_URL => "bad url"
   | BAD_IDENT => "bad indent";
 
+/* TODO: This should print Token, not Parser.token */
 let token_to_debug =
   fun
   | Parser.EOF => "EOF"

--- a/packages/parser/lib/css_lexer.re
+++ b/packages/parser/lib/css_lexer.re
@@ -934,7 +934,7 @@ let from_string = string => {
   read([]);
 };
 
-let parse = input => {
+let tokenize = input => {
   let buffer = Sedlexing.Utf8.from_string(input);
   let rec from_string = acc => {
     switch (get_next_tokens_with_location(buffer)) {

--- a/packages/parser/lib/css_lexer.rei
+++ b/packages/parser/lib/css_lexer.rei
@@ -1,0 +1,28 @@
+module Types = Css_types;
+module Parser = Css_parser;
+module Location = Ppxlib.Location;
+
+/** Signals a lexing error at the provided source location. */
+exception LexingError((Lexing.position, Lexing.position, string));
+
+/** Makes the lexer be aware of whitespaces or not */
+let skip_whitespace: ref(bool);
+
+type token_with_location = {
+  txt: result(Tokens.token, (Tokens.token, Tokens.error)),
+  loc: Types.loc,
+};
+
+let get_next_token: Sedlexing.lexbuf => Parser.token;
+let get_next_tokens_with_location:
+  Sedlexing.lexbuf => (Parser.token, Lexing.position, Lexing.position);
+let from_string: string => result(list(token_with_location), [> | `Frozen]);
+let tokenize:
+  string =>
+  result(list((Parser.token, Lexing.position, Lexing.position)), string);
+let render_token: Parser.token => string;
+let position_to_string: Lexing.position => string;
+let debug_token: ((Parser.token, Lexing.position, Lexing.position)) => string;
+let to_string: list((Parser.token, 'a, 'b)) => string;
+let to_debug:
+  list((Parser.token, Lexing.position, Lexing.position)) => string;

--- a/packages/parser/lib/css_parser.mly
+++ b/packages/parser/lib/css_parser.mly
@@ -2,6 +2,8 @@
 
 open Css_types
 
+let make_loc = Parser_location.to_ppxlib_location
+
 %}
 
 %token EOF
@@ -60,7 +62,7 @@ stylesheet: s = stylesheet_without_eof; EOF { s }
 stylesheet_without_eof: rs = loc(list(rule)) { rs }
 
 declaration_list:
-  | WS? EOF { ([], Parser_location.make $startpos $endpos) }
+  | WS? EOF { ([], make_loc $startpos $endpos) }
   | ds = loc(declarations) EOF { ds }
 
 /* keyframe may contain {} */
@@ -72,7 +74,7 @@ keyframes:
 
 /* Adds location as a tuple */
 loc(X): x = X {
-  (x, Parser_location.make $startpos(x) $endpos(x))
+  (x, make_loc $startpos(x) $endpos(x))
 }
 
 /* Handle skipping whitespace */
@@ -243,7 +245,7 @@ at_rule:
     { name;
       prelude;
       block = Rule_list ds;
-      loc = Parser_location.make $startpos $endpos;
+      loc = make_loc $startpos $endpos;
     }
   }
   /* @media (min-width: 16rem) {} */
@@ -253,31 +255,31 @@ at_rule:
     { name;
       prelude;
       block = Rule_list b;
-      loc = Parser_location.make $startpos $endpos;
+      loc = make_loc $startpos $endpos;
     }
   }
   /* @keyframes animationName { ... } */
   | name = loc(AT_KEYFRAMES) WS?
     i = IDENT WS?
     block = brace_block(keyframe) {
-    let prelude = (Ident i, Parser_location.make $startpos(i) $endpos(i)) in
-    let block = Rule_list (block, Parser_location.make $startpos $endpos) in
+    let prelude = (Ident i, make_loc $startpos(i) $endpos(i)) in
+    let block = Rule_list (block, make_loc $startpos $endpos) in
     { name;
       prelude;
       block;
-      loc = Parser_location.make $startpos $endpos;
+      loc = make_loc $startpos $endpos;
     }
   }
   /* @keyframes animationName {} */
   | name = loc(AT_KEYFRAMES) WS?
     i = IDENT WS?
     s = loc(empty_brace_block) {
-    let prelude = ((Ident i), Parser_location.make $startpos(i) $endpos(i)) in
+    let prelude = ((Ident i), make_loc $startpos(i) $endpos(i)) in
     let empty_block = Rule_list s in
     ({ name;
       prelude;
       block = empty_block;
-      loc = Parser_location.make $startpos $endpos;
+      loc = make_loc $startpos $endpos;
     }): at_rule
   }
   /* @charset */
@@ -286,7 +288,7 @@ at_rule:
     { name;
       prelude = xs;
       block = Empty;
-      loc = Parser_location.make $startpos $endpos;
+      loc = make_loc $startpos $endpos;
     }
   }
   /* @support { ... } */
@@ -298,7 +300,7 @@ at_rule:
     { name;
       prelude = xs;
       block = Stylesheet s;
-      loc = Parser_location.make $startpos $endpos;
+      loc = make_loc $startpos $endpos;
     }
   }
 
@@ -309,10 +311,10 @@ keyframe_style_rule:
   /* from {} to {} */
   | WS? id = IDENT WS?
     declarations = brace_block(loc(declarations)) WS? {
-    let prelude = [(SimpleSelector (Type id), Parser_location.make $startpos(id) $endpos(id))] in
+    let prelude = [(SimpleSelector (Type id), make_loc $startpos(id) $endpos(id))] in
     Style_rule {
-      prelude = (prelude, Parser_location.make $startpos(id) $endpos(id));
-      loc = Parser_location.make $startpos $endpos;
+      prelude = (prelude, make_loc $startpos(id) $endpos(id));
+      loc = make_loc $startpos $endpos;
       block = declarations;
     }
   }
@@ -320,10 +322,10 @@ keyframe_style_rule:
   | WS? p = percentage; WS?
     declarations = brace_block(loc(declarations)) WS? {
     let item = Percentage p in
-    let prelude = [(SimpleSelector item, Parser_location.make $startpos(p) $endpos(p))] in
+    let prelude = [(SimpleSelector item, make_loc $startpos(p) $endpos(p))] in
     Style_rule {
-      prelude = (prelude, Parser_location.make $startpos(p) $endpos(p));
-      loc = Parser_location.make $startpos $endpos;
+      prelude = (prelude, make_loc $startpos(p) $endpos(p));
+      loc = make_loc $startpos $endpos;
       block = declarations;
     }
   }
@@ -332,11 +334,11 @@ keyframe_style_rule:
     let prelude = percentages
       |> List.map (fun percent -> Percentage percent)
       |> List.map (fun p ->
-        (SimpleSelector p, Parser_location.make $startpos(percentages) $endpos(percentages))
+        (SimpleSelector p, make_loc $startpos(percentages) $endpos(percentages))
       ) in
     Style_rule {
-      prelude = (prelude, Parser_location.make $startpos(percentages) $endpos(percentages));
-      loc = Parser_location.make $startpos $endpos;
+      prelude = (prelude, make_loc $startpos(percentages) $endpos(percentages));
+      loc = make_loc $startpos $endpos;
       block = declarations;
     }
     (* TODO: Handle separated_list(COMMA, percentage) *)
@@ -352,14 +354,14 @@ style_rule:
     block = loc(empty_brace_block) {
     { prelude;
       block;
-      loc = Parser_location.make $startpos $endpos;
+      loc = make_loc $startpos $endpos;
     }
   }
   | prelude = loc(selector_list) WS?
     declarations = brace_block(loc(declarations)) {
     { prelude;
       block = declarations;
-      loc = Parser_location.make $startpos $endpos;
+      loc = make_loc $startpos $endpos;
     }
   }
 
@@ -389,7 +391,7 @@ declaration_without_eof:
     { name = property;
       value;
       important;
-      loc = Parser_location.make $startpos $endpos;
+      loc = make_loc $startpos $endpos;
     }
   }
 

--- a/packages/parser/lib/css_parser.mly
+++ b/packages/parser/lib/css_parser.mly
@@ -111,20 +111,19 @@ only_operator: o = MEDIA_QUERY_OPERATOR { o }
 /* "not" */
 not_operator: n = MEDIA_QUERY_OPERATOR { n }
 /* "screen" */
-screen_media_type: smt =  SCREEN_MEDIA_TYPE { smt }
+screen_media_type: smt = SCREEN_MEDIA_TYPE { smt }
 /* "print" */
-print_media_type: pmt =  PRINT_MEDIA_TYPE { pmt }
+print_media_type: pmt = PRINT_MEDIA_TYPE { pmt }
 /* "all" */
-all_media_type: amt =  ALL_MEDIA_TYPE { amt }
+all_media_type: amt = ALL_MEDIA_TYPE { amt }
 
 /* https://www.w3.org/TR/mediaqueries-5/#mq-syntax */
-
 mf_value:
   | v = INTERPOLATION { Variable v }
   | v = value { v }
 
 /* <mf-plain> = <mf-name> : <mf-value> */
-mf_plain: mf = IDENT WS? COLON WS? mf_value { mf } 
+mf_plain: mf = IDENT WS? COLON WS? mf_value { mf }
 
 /* <mf-lt> = '<' '='? */
 mf_lt: mflt = less_than equal_sign? { mflt }
@@ -144,9 +143,9 @@ mf_comparison:
       | <mf-value> <mf-lt> <mf-name> <mf-lt> <mf-value>
       | <mf-value> <mf-gt> <mf-name> <mf-gt> <mf-value> */
 mf_range:
-  | xs = IDENT WS mf_comparison WS mf_value { xs } 
+  | xs = IDENT WS mf_comparison WS mf_value { xs }
   | mf_value WS xs = mf_comparison WS IDENT { xs }
-  | mf_value WS xs = mf_lt WS IDENT WS mf_lt WS mf_value { xs } 
+  | mf_value WS xs = mf_lt WS IDENT WS mf_lt WS mf_value { xs }
   | mf_value WS xs = mf_gt WS IDENT WS mf_gt WS mf_value { xs }
 
 screen_or_print_media_type:
@@ -154,7 +153,7 @@ screen_or_print_media_type:
   | mt = print_media_type { mt }
 
 mf_boolean:
- // TODO: IDENT is not safely parsed.
+  /* TODO: IDENT is not safely parsed */
   | i = IDENT WS? { i }
   | all_mt = all_media_type WS? { all_mt }
   | mt = screen_or_print_media_type WS? { mt }
@@ -163,7 +162,7 @@ mf_boolean:
 
 /* <media-feature> = ( [ <mf-plain> | <mf-boolean> | <mf-range> ] ) */
 media_feature:
-// TODO: property & value in mf_plain are not safely parsed.
+  /* TODO: property & value in mf_plain are not safely parsed */
   | mfp = mf_plain { mfp }
   | mfb = mf_boolean { mfb }
   | mfr = mf_range { mfr }
@@ -203,7 +202,7 @@ media_or_star:
 media_and_or_star:
   | xs = media_and_star { xs }
   | xs = media_or_star { xs }
-  
+
 /* <media-condition> = <media-not> | <media-in-parens> [ <media-and>* | <media-or>* ] */
 media_condition:
   | mn = media_not { mn }
@@ -340,9 +339,8 @@ keyframe_style_rule:
       loc = Parser_location.make $startpos $endpos;
       block = declarations;
     }
+    (* TODO: Handle separated_list(COMMA, percentage) *)
   }
-  /* TODO: Handle separated_list(COMMA, percentage) */
-;
 
 selector_list:
   | selector = loc(selector) WS? { [selector] }
@@ -412,8 +410,8 @@ nth_payload:
     let b = int_of_string b in
     Nth (ANB (((int_of_string (fst a)), combinator, b)))
   }
-  /* This is a hackish solution where combinator isn't cached because the lexer
-  assignes the `-` to NUMBER. This could be solved by leftassoc */
+  /* This is a hackish solution where combinator isn't catched because the lexer
+  assignes the `-` to NUMBER. This could be solved by leftassoc or the lexer */
   | a = DIMENSION WS? b = NUMBER {
     let b = Int.abs (int_of_string (b)) in
     Nth (ANB (((int_of_string (fst a)), "-", b)))

--- a/packages/parser/lib/css_types.re
+++ b/packages/parser/lib/css_types.re
@@ -1,3 +1,4 @@
+/* We have records with identical field names. Type inference can sometimes struggle to determine which field you're referring to. This ambiguity can lead to compiler warnings or errors, we disable it with -30 because we always construct this with annotations in those cases. */
 [@warning "-30"];
 
 module Location = Ppxlib.Location;

--- a/packages/parser/lib/driver.re
+++ b/packages/parser/lib/driver.re
@@ -15,12 +15,12 @@ let parse = (skip_whitespaces, lexbuf, parser) => {
   };
 
   try(Ok(menhir(parser, next_token))) {
-  | Lexer.LexingError((pos, msg)) =>
-    let loc = Parser_location.make(pos, pos);
+  | Lexer.LexingError((start_pos, end_pos, msg)) =>
+    let loc = Parser_location.to_ppxlib_location(start_pos, end_pos);
     Error((loc, msg));
   | _ =>
     let (token, start_pos, end_pos) = last_token^;
-    let loc = Parser_location.make(start_pos, end_pos);
+    let loc = Parser_location.to_ppxlib_location(start_pos, end_pos);
     let msg =
       Printf.sprintf(
         "Parse error while reading token '%s'",

--- a/packages/parser/lib/dune
+++ b/packages/parser/lib/dune
@@ -6,6 +6,6 @@
  (name styled_ppx_css_parser)
  (wrapped false)
  (public_name styled-ppx.css-parser)
- (libraries sedlex menhirLib str ppxlib)
+ (libraries sedlex menhirLib ppxlib)
  (preprocess
   (pps sedlex.ppx ppx_deriving.show)))

--- a/packages/parser/lib/parser_location.re
+++ b/packages/parser/lib/parser_location.re
@@ -1,9 +1,0 @@
-module Location = Ppxlib.Location;
-
-let make =
-    (~loc_ghost=false, start_pos: Lexing.position, end_pos: Lexing.position)
-    : Location.t => {
-  loc_start: start_pos,
-  loc_end: end_pos,
-  loc_ghost,
-};

--- a/packages/parser/test/Tokenizer_test.re
+++ b/packages/parser/test/Tokenizer_test.re
@@ -1,15 +1,16 @@
 open Alcotest;
 
+module Lexer = Css_lexer;
+
 let parse = input => {
-  open Css_lexer;
   let values =
-    switch (from_string(input)) {
+    switch (Lexer.from_string(input)) {
     | Ok(values) => values
-    | Error(`Frozen) => failwith("Parser got frozen")
+    | Error(`Frozen) => failwith("Lexer got frozen")
     };
 
-  let {loc, _} = List.hd(values);
-  let values = values |> List.map(({txt, _}) => txt);
+  let Lexer.{loc, _} = List.hd(values);
+  let values = values |> List.map((Lexer.{txt, _}) => txt);
   (loc, values);
 };
 
@@ -38,6 +39,7 @@ let list_tokens_to_string = tokens =>
 
 let tests =
   [
+    ({||}, [EOF], 0),
     (" \n\t ", [Tokens.WS], 4),
     ({|"something"|}, [STRING("something")], 11),
     // TODO: is that right?
@@ -65,7 +67,6 @@ let tests =
     ({|]|}, [RIGHT_BRACKET], 1),
     ({|12345678.9|}, [NUMBER(12345678.9)], 10),
     ({|bar|}, [IDENT("bar")], 3),
-    ({||}, [EOF], 0),
     ({|!|}, [DELIM("!")], 1),
     ("1 / 1", [NUMBER(1.), WS, DELIM("/"), WS, NUMBER(1.)], 5),
     (

--- a/packages/parser/test/css_lexer_test.re
+++ b/packages/parser/test/css_lexer_test.re
@@ -13,9 +13,9 @@ let success_tests =
     ({|(|}, [LEFT_PAREN]),
     ({|)|}, [RIGHT_PAREN]),
     /* TODO: Treat +1 to NUMBER and not COMBINATOR + NUMBER */
-    /* ({|+12.3|}, [NUMBER("12.3")]), */
+    ({|+12.3|}, [COMBINATOR("+"), NUMBER("12.3")]),
     ({|+ 12.3|}, [COMBINATOR("+"), WS, NUMBER("12.3")]),
-    /* TODO: Deambiguate + sign. Either COMBINATOR(+) or DELIM(+) */
+    /* TODO: Disambiguate + sign. Either COMBINATOR(+) or DELIM(+) */
     ({|+|}, [COMBINATOR("+")]),
     ({|,|}, [COMMA]),
     ({|45.6|}, [NUMBER("45.6")]),

--- a/packages/parser/test/css_lexer_test.re
+++ b/packages/parser/test/css_lexer_test.re
@@ -113,7 +113,7 @@ let success_tests_data =
   /* TODO: Supported escaped "@" and others */
   /* ("\\@desu", [IDENT("@desu")]), */
   |> List.mapi((_index, (input, output)) => {
-       let okInput = Css_lexer.parse(input) |> Result.get_ok;
+       let okInput = Css_lexer.tokenize(input) |> Result.get_ok;
        let inputTokens = Css_lexer.to_string(okInput);
        let outputTokens =
          output

--- a/packages/ppx/test/native/Selector_test.re
+++ b/packages/ppx/test/native/Selector_test.re
@@ -395,6 +395,15 @@ let complex_tests = [
       CssJs.style([|CssJs.selector({js|& > *:not(:last-child)|js}, [||])|])
     ],
   ),
+  (
+    "&:has(.$(gap))",
+    [%expr [%cx {| &:has(.$(gap)) {} |}]],
+    [%expr
+      CssJs.style([|
+        CssJs.selector({js|&:has(.|js} ++ gap ++ {js|)|js}, [||]),
+      |])
+    ],
+  ),
 ];
 
 let stylesheet_tests = [

--- a/packages/renderer/dune
+++ b/packages/renderer/dune
@@ -8,7 +8,7 @@
  (name lexer_renderer)
  (public_name lexer-renderer)
  (modules lexer_renderer)
- (libraries styled-ppx.css-parser sedlex))
+ (libraries styled-ppx.css-parser))
 
 (executable
  (name spec_renderer)

--- a/packages/renderer/lexer_renderer.re
+++ b/packages/renderer/lexer_renderer.re
@@ -1,11 +1,3 @@
-let position_to_string = pos =>
-  Printf.sprintf(
-    "[%d,%d+%d]",
-    pos.Lexing.pos_lnum,
-    pos.Lexing.pos_bol,
-    pos.Lexing.pos_cnum - pos.Lexing.pos_bol,
-  );
-
 let render_help = () => {
   print_endline("");
   print_endline("");
@@ -29,28 +21,11 @@ let help =
     args,
   );
 
-let rec printUnlessIsEof = buffer => {
-  let (token, loc_start, loc_end) =
-    Css_lexer.get_next_tokens_with_location(buffer);
-  let pos_start = position_to_string(loc_start);
-  let pos_end = position_to_string(loc_end);
-  print_endline(
-    Tokens.token_to_debug(token)
-    ++ {| [|}
-    ++ pos_start
-    ++ {|..|}
-    ++ pos_end
-    ++ {|]|},
-  );
-
-  switch (token) {
-  | Css_lexer.Parser.EOF => ()
-  | _token => printUnlessIsEof(buffer)
-  };
-};
-
 switch (input, help) {
 | (Some(_), true)
 | (None, _) => render_help()
-| (Some(css), _) => css |> Sedlexing.Latin1.from_string |> printUnlessIsEof
+| (Some(css), _) =>
+  let okInput = Css_lexer.parse(css) |> Result.get_ok;
+  let debug = Css_lexer.to_debug(okInput);
+  print_endline(debug);
 };

--- a/packages/renderer/lexer_renderer.re
+++ b/packages/renderer/lexer_renderer.re
@@ -25,7 +25,7 @@ switch (input, help) {
 | (Some(_), true)
 | (None, _) => render_help()
 | (Some(css), _) =>
-  let okInput = Css_lexer.parse(css) |> Result.get_ok;
+  let okInput = Css_lexer.tokenize(css) |> Result.get_ok;
   let debug = Css_lexer.to_debug(okInput);
   print_endline(debug);
 };


### PR DESCRIPTION
There were a few cleanups left after https://github.com/davesnx/styled-ppx/pull/372 to keep working towards https://github.com/davesnx/styled-ppx/issues/432

- Unified lexing sedlexes
- Added locations on `Css_lexer.parse`, moved that inside the lexer.
- Unreachable doesn't failwith. Also, remove assert(false)
- Rename parse to tokenize