### PR TITLE
Fix closing bracket in `drop-shadow` property when we stringify `Color`

### DIFF
--- a/packages/css/js/Css_Js_Core.ml
+++ b/packages/css/js/Css_Js_Core.ml
@@ -1839,10 +1839,10 @@ let string_of_filter x =
     ^ {js| |js}
     ^ Length.toString c
     ^ {js| |js}
-    ^
-    (match d with
-    | #Color.t as c -> Color.toString c
-    | #Var.t as v -> Var.toString v ^ {js|)|js})
+    ^ (match d with
+      | #Color.t as c -> Color.toString c
+      | #Var.t as v -> Var.toString v)
+    ^ {js|)|js}
   | `grayscale v -> ({js|grayscale(|js} ^ Std.Float.toString v) ^ {js|%)|js}
   | `hueRotate v -> ({js|hue-rotate(|js} ^ Angle.toString v) ^ {js|)|js}
   | `invert v -> ({js|invert(|js} ^ Std.Float.toString v) ^ {js|%)|js}

--- a/packages/css/js/Css_Legacy_Core.ml
+++ b/packages/css/js/Css_Legacy_Core.ml
@@ -1730,10 +1730,10 @@ let string_of_filter x =
     ^ {js| |js}
     ^ Length.toString c
     ^ {js| |js}
-    ^
-    (match d with
-    | #Color.t as c -> Color.toString c
-    | #Var.t as v -> Var.toString v ^ {js|)|js})
+    ^ (match d with
+      | #Color.t as c -> Color.toString c
+      | #Var.t as v -> Var.toString v)
+    ^ {js|)|js}
   | `grayscale v -> {js|grayscale(|js} ^ Std.Float.toString v ^ {js|%)|js}
   | `hueRotate v -> {js|hue-rotate(|js} ^ Angle.toString v ^ {js|)|js}
   | `invert v -> {js|invert(|js} ^ Std.Float.toString v ^ {js|%)|js}

--- a/packages/css/native/Css_Js_Core.ml
+++ b/packages/css/native/Css_Js_Core.ml
@@ -1790,10 +1790,10 @@ let string_of_filter x =
     ^ {js| |js}
     ^ Length.toString c
     ^ {js| |js}
-    ^
-    (match d with
-    | #Color.t as c -> Color.toString c
-    | #Var.t as v -> Var.toString v ^ {js|)|js})
+    ^ (match d with
+      | #Color.t as c -> Color.toString c
+      | #Var.t as v -> Var.toString v)
+    ^ {js|)|js}
   | `grayscale v -> ({js|grayscale(|js} ^ Std.Float.toString v) ^ {js|%)|js}
   | `hueRotate v -> ({js|hue-rotate(|js} ^ Angle.toString v) ^ {js|)|js}
   | `invert v -> ({js|invert(|js} ^ Std.Float.toString v) ^ {js|%)|js}

--- a/packages/css/native/Css_Legacy_Core.ml
+++ b/packages/css/native/Css_Legacy_Core.ml
@@ -1679,10 +1679,10 @@ let string_of_filter x =
     ^ {js| |js}
     ^ Length.toString c
     ^ {js| |js}
-    ^
-    (match d with
-    | #Color.t as c -> Color.toString c
-    | #Var.t as v -> Var.toString v ^ {js|)|js})
+    ^ (match d with
+      | #Color.t as c -> Color.toString c
+      | #Var.t as v -> Var.toString v)
+    ^ {js|)|js}
   | `grayscale v -> {js|grayscale(|js} ^ Std.Float.toString v ^ {js|%)|js}
   | `hueRotate v -> {js|hue-rotate(|js} ^ Angle.toString v ^ {js|)|js}
   | `invert v -> {js|invert(|js} ^ Std.Float.toString v ^ {js|%)|js}


### PR DESCRIPTION
Fix closing bracket in `drop-shadow` property when we stringify Color.