### PR TITLE
Style HTML tag

### DIFF
--- a/e2e/melange/debug.re
+++ b/e2e/melange/debug.re
@@ -2,9 +2,8 @@ let _ = [%cx {|
   justify-content: center;
 |}];
 
+print_endline("Rendered app:");
 print_endline(Ui_native.Ui.getStaticMarkup());
 
-print_endline("");
-print_endline("<style>");
-print_endline(CssJs.render_style_tag());
-print_endline("</style>");
+print_endline("\nStyle tag:");
+print_endline(ReactDOM.renderToStaticMarkup(<CssJs.style_tag />));

--- a/e2e/melange/dune
+++ b/e2e/melange/dune
@@ -12,6 +12,6 @@
  (name debug)
  (public_name e2e_melange_debug)
  (modules :standard \ index)
- (libraries ui_native styled-ppx.emotion_native styled-ppx.css_native)
+ (libraries ui_native server-reason-react.react server-reason-react.reactDom styled-ppx.emotion_native styled-ppx.css_native)
  (preprocess
   (pps styled-ppx)))

--- a/e2e/melange/src/native/ui.re
+++ b/e2e/melange/src/native/ui.re
@@ -1,6 +1,19 @@
+[%styled.global
+  {|
+  div {
+    background-color: green;
+  }
+
+  @media (min-width: 400px) {
+    div {
+      background-color: red;
+    }
+  }
+|}
+];
+
 let stack = [%cx "display: flex; flex-direction: column"];
 let stackGap = gap => [%cx "gap: $(gap)"];
-
 module Cositas = [%styled.div
   (~lola=CssJs.px(0), ~id) => {|
   display: flex;

--- a/packages/emotion/native/Css.ml
+++ b/packages/emotion/native/Css.ml
@@ -209,16 +209,16 @@ let resolve_selectors rules =
   in
   rules |> List.map resolve_selector |> List.flatten
 
-let pp_keyframes hash keyframes =
+let pp_keyframes animationName keyframes =
   let pp_keyframe (percentage, rules) =
     Printf.sprintf "%i%% { %s }" percentage (render_declarations rules)
   in
   let definition = keyframes |> List.map pp_keyframe |> String.concat " " in
-  Printf.sprintf "@keyframes %s { %s }" hash definition
+  Printf.sprintf "@keyframes %s { %s }" animationName definition
 
 (* `resolved_rule` here means to print valid CSS, selectors are nested
    and properties aren't autoprefixed. This function transforms into correct CSS. *)
-let pp_rules hash rules =
+let pp_rules className rules =
   (* TODO: Refactor with partition or partition_map. List.filter_map is error prone.
      Ss might need to respect the order of definition, and this breaks the order *)
   let list_of_rules = rules |> resolve_selectors in
@@ -228,19 +228,25 @@ let pp_rules hash rules =
     |> List.flatten
     |> List.filter_map render_declaration
     |> String.concat " "
-    |> fun all -> Printf.sprintf ".%s { %s }" hash all
+    |> fun all -> Printf.sprintf ".%s { %s }" className all
   in
   let selectors =
     list_of_rules
-    |> List.filter_map (render_selectors hash)
+    |> List.filter_map (render_selectors className)
     |> String.concat " "
   in
   Printf.sprintf "%s %s" declarations selectors
 
 type declarations =
   | Globals of rule list
-  | Classnames of rule list
-  | Keyframes of (int * rule list) list
+  | Classnames of {
+      className : string;
+      styles : rule list;
+    }
+  | Keyframes of {
+      animationName : string;
+      keyframes : (int * rule list) list;
+    }
 
 module Stylesheet = struct
   module Hashes = Set.Make (String)
@@ -299,19 +305,19 @@ let keyframes_to_string keyframes =
   in
   keyframes |> List.map pp_keyframe |> String.concat ""
 
-let render_hash prefix hash styles =
+let render_hash hash styles =
   let is_label = function D ("label", value) -> Some value | _ -> None in
   match List.find_map is_label styles with
-  | None -> Printf.sprintf "%s-%s" prefix hash
-  | Some label -> Printf.sprintf "%s-%s-%s" prefix hash label
+  | None -> Printf.sprintf "%s" hash
+  | Some label -> Printf.sprintf "%s-%s" hash label
 
 let style (styles : rule list) =
   match styles with
   | [] -> ""
   | _ ->
-    let hash = Murmur2.default (rules_to_string styles) in
-    let className = render_hash "css" hash styles in
-    Stylesheet.push instance (className, Classnames styles);
+    let hash = render_hash (Murmur2.default (rules_to_string styles)) styles in
+    let className = Printf.sprintf "%s-%s" "css" hash in
+    Stylesheet.push instance (hash, Classnames { className; styles });
     className
 
 let global (styles : rule list) =
@@ -328,24 +334,40 @@ let keyframes (keyframes : (int * rule list) list) =
   | _ ->
     let hash = Murmur2.default (keyframes_to_string keyframes) in
     let animationName = Printf.sprintf "%s-%s" "animation" hash in
-    Stylesheet.push instance (animationName, Keyframes keyframes);
+    Stylesheet.push instance (hash, Keyframes { animationName; keyframes });
     animationName
 
 (** Deprecated: Use get_style_rules instead*)
 let render_style_tag () =
   Stylesheet.get_all instance
   |> List.fold_left
-       (fun accumulator (hash, rules) ->
+       (fun accumulator (_, rules) ->
          match rules with
          | Globals rules ->
            Printf.sprintf "%s %s" accumulator (rules_to_string rules)
-         | Classnames rules ->
-           let rules = pp_rules hash rules |> String.trim in
+         | Classnames { className; styles } ->
+           let rules = pp_rules className styles |> String.trim in
            Printf.sprintf "%s %s" accumulator rules
-         | Keyframes keyframes ->
-           let rules = pp_keyframes hash keyframes |> String.trim in
+         | Keyframes { animationName; keyframes } ->
+           let rules = pp_keyframes animationName keyframes |> String.trim in
            Printf.sprintf "%s %s" accumulator rules)
        ""
   |> String.trim
 
 let get_string_style_rules = render_style_tag
+
+let get_string_style_hashes () =
+  Stylesheet.get_all instance
+  |> List.fold_left
+       (fun accumulator (hash, _) ->
+         Printf.sprintf "%s %s" accumulator hash |> String.trim)
+       ""
+
+let style_tag ?key:_ ?children:_ () =
+  React.createElement "style"
+    [
+      String ("data-emotion", "css " ^ get_string_style_hashes ());
+      Bool ("data-s", true);
+      DangerouslyInnerHtml (get_string_style_rules ());
+    ]
+    []

--- a/packages/emotion/native/Css.ml
+++ b/packages/emotion/native/Css.ml
@@ -316,12 +316,11 @@ let style (styles : rule list) =
 
 let global (styles : rule list) =
   match styles with
-  | [] -> "";
+  | [] -> ""
   | _ ->
     let hash = Murmur2.default (rules_to_string styles) in
     Stylesheet.push instance (hash, Globals styles);
     hash
-    
 
 let keyframes (keyframes : (int * rule list) list) =
   match keyframes with
@@ -332,6 +331,7 @@ let keyframes (keyframes : (int * rule list) list) =
     Stylesheet.push instance (animationName, Keyframes keyframes);
     animationName
 
+(** Deprecated: Use get_style_rules instead*)
 let render_style_tag () =
   Stylesheet.get_all instance
   |> List.fold_left
@@ -347,3 +347,5 @@ let render_style_tag () =
            Printf.sprintf "%s %s" accumulator rules)
        ""
   |> String.trim
+
+let get_string_style_rules = render_style_tag

--- a/packages/emotion/native/CssJs.ml
+++ b/packages/emotion/native/CssJs.ml
@@ -350,7 +350,7 @@ let style (styles : rule array) =
 
 let global (styles : rule array) =
   match styles with
-  | [||] -> "";
+  | [||] -> ""
   | _ ->
     let hash = Murmur2.default (rules_to_string (Array.to_list styles)) in
     Stylesheet.push instance (hash, Globals styles);
@@ -365,13 +365,15 @@ let keyframes (keyframes : (int * rule array) array) =
     Stylesheet.push instance (animationName, Keyframes keyframes);
     animationName
 
+(** Deprecated: Use get_style_rules instead*)
 let render_style_tag () =
   Stylesheet.get_all instance
   |> List.fold_left
        (fun accumulator (hash, rules) ->
          match rules with
-         | Globals rules -> 
-           Printf.sprintf "%s %s" accumulator (rules_to_string (Array.to_list rules))
+         | Globals rules ->
+           Printf.sprintf "%s %s" accumulator
+             (rules_to_string (Array.to_list rules))
          | Classnames rules ->
            let rules = pp_rules hash rules |> String.trim in
            Printf.sprintf "%s %s" accumulator rules
@@ -380,3 +382,5 @@ let render_style_tag () =
            Printf.sprintf "%s %s" accumulator rules)
        ""
   |> String.trim
+
+let get_string_style_rules = render_style_tag

--- a/packages/emotion/native/CssJs.ml
+++ b/packages/emotion/native/CssJs.ml
@@ -240,17 +240,17 @@ let resolve_selectors rules =
   in
   rules |> List.map resolve_selector |> List.flatten
 
-let pp_keyframes hash keyframes =
+let pp_keyframes animationName keyframes =
   let pp_keyframe (percentage, rules) =
     Printf.sprintf "%i%% { %s }" percentage (render_declarations rules)
   in
   let definition =
     keyframes |> Array.map pp_keyframe |> Array.to_list |> String.concat " "
   in
-  Printf.sprintf "@keyframes %s { %s }" hash definition
+  Printf.sprintf "@keyframes %s { %s }" animationName definition
 
 (* Removes nesting on selectors, run the autoprefixer. *)
-let pp_rules hash rules =
+let pp_rules className rules =
   (* TODO: Refactor with partition or partition_map. List.filter_map is error prone.
      Ss might need to respect the order of definition, and this breaks the order *)
   let list_of_rules = rules |> Array.to_list |> resolve_selectors in
@@ -260,11 +260,11 @@ let pp_rules hash rules =
     |> List.flatten
     |> List.filter_map render_declaration
     |> String.concat " "
-    |> fun all -> Printf.sprintf ".%s { %s }" hash all
+    |> fun all -> Printf.sprintf ".%s { %s }" className all
   in
   let selectors =
     list_of_rules
-    |> List.filter_map (render_selectors hash)
+    |> List.filter_map (render_selectors className)
     |> String.concat " "
   in
   Printf.sprintf "%s %s" declarations selectors
@@ -296,8 +296,14 @@ let rec rules_to_string rules =
 
 type declarations =
   | Globals of rule array
-  | Classnames of rule array
-  | Keyframes of (int * rule array) array
+  | Classnames of {
+      className : string;
+      styles : rule array;
+    }
+  | Keyframes of {
+      animationName : string;
+      keyframes : (int * rule array) array;
+    }
 
 module Stylesheet = struct
   module Hashes = Set.Make (String)
@@ -330,11 +336,11 @@ let keyframes_to_string keyframes =
   in
   keyframes |> Array.map pp_keyframe |> Array.to_list |> String.concat ""
 
-let render_hash prefix hash styles =
+let render_hash hash styles =
   let is_label = function D ("label", value) -> Some value | _ -> None in
   match Array.find_map is_label styles with
-  | None -> Printf.sprintf "%s-%s" prefix hash
-  | Some label -> Printf.sprintf "%s-%s-%s" prefix hash label
+  | None -> Printf.sprintf "%s" hash
+  | Some label -> Printf.sprintf "%s-%s" hash label
 
 let instance = Stylesheet.make ()
 let flush () = Stylesheet.flush instance
@@ -343,9 +349,13 @@ let style (styles : rule array) =
   match styles with
   | [||] -> ""
   | _ ->
-    let hash = Murmur2.default (rules_to_string (Array.to_list styles)) in
-    let className = render_hash "css" hash styles in
-    Stylesheet.push instance (className, Classnames styles);
+    let hash =
+      render_hash
+        (Murmur2.default (rules_to_string (Array.to_list styles)))
+        styles
+    in
+    let className = Printf.sprintf "%s-%s" "css" hash in
+    Stylesheet.push instance (hash, Classnames { className; styles });
     className
 
 let global (styles : rule array) =
@@ -362,25 +372,41 @@ let keyframes (keyframes : (int * rule array) array) =
   | _ ->
     let hash = Murmur2.default (keyframes_to_string keyframes) in
     let animationName = Printf.sprintf "%s-%s" "animation" hash in
-    Stylesheet.push instance (animationName, Keyframes keyframes);
+    Stylesheet.push instance (hash, Keyframes { animationName; keyframes });
     animationName
 
 (** Deprecated: Use get_style_rules instead*)
 let render_style_tag () =
   Stylesheet.get_all instance
   |> List.fold_left
-       (fun accumulator (hash, rules) ->
+       (fun accumulator (_, rules) ->
          match rules with
          | Globals rules ->
            Printf.sprintf "%s %s" accumulator
              (rules_to_string (Array.to_list rules))
-         | Classnames rules ->
-           let rules = pp_rules hash rules |> String.trim in
+         | Classnames { className; styles } ->
+           let rules = pp_rules className styles |> String.trim in
            Printf.sprintf "%s %s" accumulator rules
-         | Keyframes keyframes ->
-           let rules = pp_keyframes hash keyframes |> String.trim in
+         | Keyframes { animationName; keyframes } ->
+           let rules = pp_keyframes animationName keyframes |> String.trim in
            Printf.sprintf "%s %s" accumulator rules)
        ""
   |> String.trim
 
 let get_string_style_rules = render_style_tag
+
+let get_string_style_hashes () =
+  Stylesheet.get_all instance
+  |> List.fold_left
+       (fun accumulator (hash, _) ->
+         Printf.sprintf "%s %s" accumulator hash |> String.trim)
+       ""
+
+let style_tag ?key:_ ?children:_ () =
+  React.createElement "style"
+    [
+      String ("data-emotion", "css " ^ get_string_style_hashes ());
+      Bool ("data-s", true);
+      DangerouslyInnerHtml (get_string_style_rules ());
+    ]
+    []

--- a/packages/emotion/native/dune
+++ b/packages/emotion/native/dune
@@ -1,5 +1,5 @@
 (library
  (name emotion_native)
  (public_name styled-ppx.emotion_native)
- (libraries styled-ppx.css_native styled-ppx.murmur2)
+ (libraries server-reason-react.react styled-ppx.css_native styled-ppx.murmur2)
  (wrapped false))

--- a/packages/emotion/test/dune
+++ b/packages/emotion/test/dune
@@ -5,6 +5,7 @@
   alcotest
   fmt
   server-reason-react.js
+  server-reason-react.reactDom
   styled-ppx.css_native
   styled-ppx.emotion_native
   styled-ppx.murmur2)

--- a/packages/emotion/test/test_css_js_styles.ml
+++ b/packages/emotion/test/test_css_js_styles.ml
@@ -4,21 +4,21 @@ let assert_string left right =
 let assert_not_equal_string left right =
   Alcotest.check (Alcotest.neg Alcotest.string) "should not be equal" right left
 
-let render_style_tag () =
-  let content = CssJs.render_style_tag () in
+let get_string_style_rules () =
+  let content = CssJs.get_string_style_rules () in
   let _ = CssJs.flush () in
   content
 
 let one_property () =
   let className = CssJs.style [| CssJs.display `block |] in
-  let css = render_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css (Printf.sprintf ".%s { display: block; }" className)
 
 let multiple_properties () =
   let className =
     CssJs.style [| CssJs.display `block; CssJs.fontSize (`px 10) |]
   in
-  let css = render_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf ".%s { display: block; font-size: 10px; }" className)
 
@@ -29,7 +29,7 @@ let multiple_declarations () =
   let className2 =
     CssJs.style [| CssJs.display `block; CssJs.fontSize (`px 99) |]
   in
-  let css = render_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf
        ".%s { display: block; font-size: 10px; } .%s { display: block; \
@@ -40,12 +40,12 @@ let label () =
   let className =
     CssJs.style [| CssJs.label "className"; CssJs.display `block |]
   in
-  let css = render_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css (Printf.sprintf ".%s { display: block; }" className)
 
 let label_with_ppx () =
   let className = [%cx {| display: block; |}] in
-  let css = render_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css (Printf.sprintf ".%s { display: block; }" className)
 
 let selector_with_ppx () =
@@ -58,7 +58,7 @@ let selector_with_ppx () =
     }
   |}]
   in
-  let css = render_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf ".%s { color: #FF0000; } .%s  > * { color: #0000FF; }"
        className className)
@@ -107,14 +107,14 @@ let avoid_hash_collision () =
       }
     |}]
   in
-  let _css = render_style_tag () in
+  let _css = get_string_style_rules () in
   assert_not_equal_string className1 className2;
   assert_not_equal_string className2 className3;
   assert_not_equal_string className1 className3
 
 let float_values () =
   let className = CssJs.style [| CssJs.padding (`rem 10.) |] in
-  let css = render_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css (Printf.sprintf ".%s { padding: 10rem; }" className)
 
 let selector_one_nesting () =
@@ -125,7 +125,7 @@ let selector_one_nesting () =
         CssJs.selector "a" [| CssJs.color CssJs.rebeccapurple |];
       |]
   in
-  let css = render_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf ".%s { color: #F0F8FF; } .%s a { color: #663399; }"
        className className)
@@ -141,7 +141,7 @@ let selector_nested () =
           |];
       |]
   in
-  let css = render_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf
        ".%s { color: #F0F8FF; } .%s a { display: block; } .%s a div { display: \
@@ -172,7 +172,7 @@ let selector_nested_x10 () =
           |];
       |]
   in
-  let css = render_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf
        ".%s { display: flex; } .%s a { display: block; } .%s a div { display: \
@@ -188,7 +188,7 @@ let selector_ampersand () =
         CssJs.selector "& .div" [| CssJs.fontSize (`px 24) |];
       |]
   in
-  let css = render_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf ".%s { font-size: 42px; } .%s  .div { font-size: 24px; }"
        className className)
@@ -201,7 +201,7 @@ let selector_ampersand_at_the_middle () =
         CssJs.selector "& div &" [| CssJs.fontSize (`px 24) |];
       |]
   in
-  let css = render_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf ".%s { font-size: 42px; } .%s  div .%s { font-size: 24px; }"
        className className className)
@@ -214,7 +214,7 @@ let media_queries () =
         CssJs.media "(max-width: 768px)" [| CssJs.width (`px 300) |];
       |]
   in
-  let css = render_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf
        ".%s { max-width: 800px; } @media (max-width: 768px) { .%s { width: \
@@ -228,7 +228,7 @@ let selector_params () =
         CssJs.maxWidth (`px 800); CssJs.firstChild [| CssJs.width (`px 300) |];
       |]
   in
-  let css = render_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf
        ".%s { max-width: 800px; } .%s:first-child { width: 300px; }" className
@@ -243,7 +243,7 @@ let keyframe () =
       |]
   in
   let className = CssJs.style [| CssJs.animationName animationName |] in
-  let css = render_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf
        "@keyframes %s { 0%% { -webkit-transform: rotate(0deg); -moz-transform: \
@@ -258,13 +258,13 @@ let global () =
   let _ =
     CssJs.global [| CssJs.selector "html" [| CssJs.lineHeight (`abs 1.15) |] |]
   in
-  let css = render_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css (Printf.sprintf "html{line-height:1.15;}")
 
 let duplicated_styles_unique () =
   let className1 = CssJs.style [| CssJs.flexGrow 1. |] in
   let className2 = CssJs.style [| CssJs.flexGrow 1. |] in
-  let css = render_style_tag () in
+  let css = get_string_style_rules () in
   assert_string className1 className2;
   assert_string css (Printf.sprintf ".%s { flex-grow: 1; }" className1)
 
@@ -279,7 +279,7 @@ let hover_selector () =
           [| CssJs.color (`rgba (255, 255, 255, `num 0.7)) |];
       |]
   in
-  let css = render_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf
        ".%s { color: rgb(255, 255, 255); } .%s:hover { color: rgba(255, 255, \

--- a/packages/emotion/test/test_css_js_styles.ml
+++ b/packages/emotion/test/test_css_js_styles.ml
@@ -286,6 +286,44 @@ let hover_selector () =
         255, 0.7); } .%s:hover { color: rgba(255, 255, 255, 0.7); }"
        className className className)
 
+let hashes () =
+  let global =
+    CssJs.global [| CssJs.selector "html" [| CssJs.lineHeight (`abs 1.15) |] |]
+  in
+  let className = CssJs.style [| CssJs.display `block |] in
+  let classNameHash = String.sub className 4 (String.length className - 4) in
+  let hashes = CssJs.get_string_style_hashes () in
+  let _ = CssJs.flush () in
+  assert_string hashes (Printf.sprintf "%s %s" global classNameHash)
+
+let style_tag () =
+  let global =
+    CssJs.global [| CssJs.selector "html" [| CssJs.lineHeight (`abs 1.15) |] |]
+  in
+  let animationName =
+    CssJs.keyframes
+      [|
+        0, [| CssJs.transform (`rotate (`deg 0.)) |];
+        100, [| CssJs.transform (`rotate (`deg (-360.))) |];
+      |]
+  in
+  let animationNameHash =
+    String.sub animationName 10 (String.length animationName - 10)
+  in
+  let className = CssJs.style [| CssJs.display `block |] in
+  let classNameHash = String.sub className 4 (String.length className - 4) in
+  let css = CssJs.style_tag () |> ReactDOM.renderToString in
+  let _ = CssJs.flush () in
+  assert_string css
+    (Printf.sprintf
+       "<style data-emotion=\"css %s %s %s\" data-s>html{line-height:1.15;} \
+        @keyframes %s { 0%% { -webkit-transform: rotate(0deg); -moz-transform: \
+        rotate(0deg); -ms-transform: rotate(0deg); transform: rotate(0deg); } \
+        100%% { -webkit-transform: rotate(-360deg); -moz-transform: \
+        rotate(-360deg); -ms-transform: rotate(-360deg); transform: \
+        rotate(-360deg); } } .%s { display: block; }</style>"
+       global animationNameHash classNameHash animationName className)
+
 let case title fn = Alcotest.test_case title `Quick fn
 
 let tests =
@@ -310,4 +348,6 @@ let tests =
       case "selector_with_ppx" selector_with_ppx;
       case "avoid_hash_collision" avoid_hash_collision;
       case "hover_selector" hover_selector;
+      case "hashes" hashes;
+      case "style_tag" style_tag;
     ] )

--- a/packages/emotion/test/test_css_styles.ml
+++ b/packages/emotion/test/test_css_styles.ml
@@ -1,26 +1,26 @@
 let assert_string left right =
   Alcotest.check Alcotest.string "should be equal" right left
 
-let render_string_style_tag () =
-  let content = Css.render_string_style_tag () in
+let get_string_style_rules () =
+  let content = Css.get_string_style_rules () in
   let _ = Css.flush () in
   content
 
 let one_property () =
   let className = Css.style [ Css.display `block ] in
-  let css = render_string_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css (Printf.sprintf ".%s { display: block; }" className)
 
 let multiple_properties () =
   let className = Css.style [ Css.display `block; Css.fontSize (`px 10) ] in
-  let css = render_string_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf ".%s { display: block; font-size: 10px; }" className)
 
 let multiple_declarations () =
   let className1 = Css.style [ Css.display `block; Css.fontSize (`px 10) ] in
   let className2 = Css.style [ Css.display `block; Css.fontSize (`px 99) ] in
-  let css = render_string_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf
        ".%s { display: block; font-size: 10px; } .%s { display: block; \
@@ -29,12 +29,12 @@ let multiple_declarations () =
 
 let label () =
   let className = Css.style [ Css.label "className"; Css.display `block ] in
-  let css = render_string_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css (Printf.sprintf ".%s { display: block; }" className)
 
 let float_values () =
   let className = Css.style [ Css.padding (`rem 10.) ] in
-  let css = render_string_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css (Printf.sprintf ".%s { padding: 10rem; }" className)
 
 let selector_one_nesting () =
@@ -45,7 +45,7 @@ let selector_one_nesting () =
         Css.selector "a" [ Css.color Css.rebeccapurple ];
       ]
   in
-  let css = render_string_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf ".%s { color: #F0F8FF; } .%s a { color: #663399; }"
        className className)
@@ -59,7 +59,7 @@ let selector_nested () =
           [ Css.display `block; Css.selector "div" [ Css.display `none ] ];
       ]
   in
-  let css = render_string_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf
        ".%s { color: #F0F8FF; } .%s a { display: block; } .%s a div { display: \
@@ -90,7 +90,7 @@ let selector_nested_x10 () =
           ];
       ]
   in
-  let css = render_string_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf
        ".%s { display: flex; } .%s a { display: block; } .%s a div { display: \
@@ -103,7 +103,7 @@ let selector_ampersand () =
     Css.style
       [ Css.fontSize (`px 42); Css.selector "& .div" [ Css.fontSize (`px 24) ] ]
   in
-  let css = render_string_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf ".%s { font-size: 42px; } .%s  .div { font-size: 24px; }"
        className className)
@@ -115,7 +115,7 @@ let selector_ampersand_at_the_middle () =
         Css.fontSize (`px 42); Css.selector "& div &" [ Css.fontSize (`px 24) ];
       ]
   in
-  let css = render_string_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf ".%s { font-size: 42px; } .%s  div .%s { font-size: 24px; }"
        className className className)
@@ -128,7 +128,7 @@ let media_queries () =
         Css.media "(max-width: 768px)" [ Css.width (`px 300) ];
       ]
   in
-  let css = render_string_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf
        ".%s { max-width: 800px; } @media (max-width: 768px) { .%s { width: \
@@ -139,7 +139,7 @@ let selector_params () =
   let className =
     Css.style [ Css.maxWidth (`px 800); Css.firstChild [ Css.width (`px 300) ] ]
   in
-  let css = render_string_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf
        ".%s { max-width: 800px; } .%s:first-child { width: 300px; }" className
@@ -154,7 +154,7 @@ let keyframe () =
       ]
   in
   let className = Css.style [ Css.animationName animationName ] in
-  let css = render_string_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf
        "@keyframes %s { 0%% { -webkit-transform: rotate(0deg); -moz-transform: \
@@ -167,13 +167,13 @@ let keyframe () =
 
 let global () =
   let _ = Css.global [ Css.selector "html" [ Css.lineHeight (`abs 1.15) ] ] in
-  let css = render_string_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css (Printf.sprintf "html{line-height:1.15;}")
 
 let duplicated_styles_unique () =
   let className1 = Css.style [ Css.flexGrow 1. ] in
   let className2 = Css.style [ Css.flexGrow 1. ] in
-  let css = render_string_style_tag () in
+  let css = get_string_style_rules () in
   assert_string className1 className2;
   assert_string css (Printf.sprintf ".%s { flex-grow: 1; }" className1)
 
@@ -185,12 +185,61 @@ let hover_selector () =
         Css.selector "&:hover" [ Css.color (`rgba (255, 255, 255, `num 0.7)) ];
       ]
   in
-  let css = render_string_style_tag () in
+  let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf
        ".%s { color: rgb(255, 255, 255); } .%s:hover { color: rgba(255, 255, \
         255, 0.7); }"
        className className)
+
+let hashes () =
+  let global =
+    Css.global [ Css.selector "html" [ Css.lineHeight (`abs 1.15) ] ]
+  in
+  let animationName =
+    Css.keyframes
+      [
+        0, [ Css.transform (`rotate (`deg 0.)) ];
+        100, [ Css.transform (`rotate (`deg (-360.))) ];
+      ]
+  in
+  let animationNameHash =
+    String.sub animationName 10 (String.length animationName - 10)
+  in
+  let className = Css.style [ Css.display `block ] in
+  let classNameHash = String.sub className 4 (String.length className - 4) in
+  let hashes = Css.get_string_style_hashes () in
+  let _ = Css.flush () in
+  assert_string hashes
+    (Printf.sprintf "%s %s %s" global animationNameHash classNameHash)
+
+let style_tag () =
+  let global =
+    Css.global [ Css.selector "html" [ Css.lineHeight (`abs 1.15) ] ]
+  in
+  let animationName =
+    Css.keyframes
+      [
+        0, [ Css.transform (`rotate (`deg 0.)) ];
+        100, [ Css.transform (`rotate (`deg (-360.))) ];
+      ]
+  in
+  let animationNameHash =
+    String.sub animationName 10 (String.length animationName - 10)
+  in
+  let className = Css.style [ Css.display `block ] in
+  let classNameHash = String.sub className 4 (String.length className - 4) in
+  let css = ReactDOM.renderToString (Css.style_tag ~children: "" ()) in
+  let _ = Css.flush () in
+  assert_string css
+    (Printf.sprintf
+       "<style data-emotion=\"css %s %s %s\" data-s>html{line-height:1.15;} \
+        @keyframes %s { 0%% { -webkit-transform: rotate(0deg); -moz-transform: \
+        rotate(0deg); -ms-transform: rotate(0deg); transform: rotate(0deg); } \
+        100%% { -webkit-transform: rotate(-360deg); -moz-transform: \
+        rotate(-360deg); -ms-transform: rotate(-360deg); transform: \
+        rotate(-360deg); } } .%s { display: block; }</style>"
+       global animationNameHash classNameHash animationName className)
 
 let case title fn = Alcotest.test_case title `Quick fn
 
@@ -213,4 +262,6 @@ let tests =
       case "global" global;
       case "duplicated_styles_unique" duplicated_styles_unique;
       case "hover_selector" hover_selector;
+      case "hashes" hashes;
+      case "style_tag" style_tag;
     ] )

--- a/packages/emotion/test/test_css_styles.ml
+++ b/packages/emotion/test/test_css_styles.ml
@@ -1,26 +1,26 @@
 let assert_string left right =
   Alcotest.check Alcotest.string "should be equal" right left
 
-let render_style_tag () =
-  let content = Css.render_style_tag () in
+let render_string_style_tag () =
+  let content = Css.render_string_style_tag () in
   let _ = Css.flush () in
   content
 
 let one_property () =
   let className = Css.style [ Css.display `block ] in
-  let css = render_style_tag () in
+  let css = render_string_style_tag () in
   assert_string css (Printf.sprintf ".%s { display: block; }" className)
 
 let multiple_properties () =
   let className = Css.style [ Css.display `block; Css.fontSize (`px 10) ] in
-  let css = render_style_tag () in
+  let css = render_string_style_tag () in
   assert_string css
     (Printf.sprintf ".%s { display: block; font-size: 10px; }" className)
 
 let multiple_declarations () =
   let className1 = Css.style [ Css.display `block; Css.fontSize (`px 10) ] in
   let className2 = Css.style [ Css.display `block; Css.fontSize (`px 99) ] in
-  let css = render_style_tag () in
+  let css = render_string_style_tag () in
   assert_string css
     (Printf.sprintf
        ".%s { display: block; font-size: 10px; } .%s { display: block; \
@@ -29,12 +29,12 @@ let multiple_declarations () =
 
 let label () =
   let className = Css.style [ Css.label "className"; Css.display `block ] in
-  let css = render_style_tag () in
+  let css = render_string_style_tag () in
   assert_string css (Printf.sprintf ".%s { display: block; }" className)
 
 let float_values () =
   let className = Css.style [ Css.padding (`rem 10.) ] in
-  let css = render_style_tag () in
+  let css = render_string_style_tag () in
   assert_string css (Printf.sprintf ".%s { padding: 10rem; }" className)
 
 let selector_one_nesting () =
@@ -45,7 +45,7 @@ let selector_one_nesting () =
         Css.selector "a" [ Css.color Css.rebeccapurple ];
       ]
   in
-  let css = render_style_tag () in
+  let css = render_string_style_tag () in
   assert_string css
     (Printf.sprintf ".%s { color: #F0F8FF; } .%s a { color: #663399; }"
        className className)
@@ -59,7 +59,7 @@ let selector_nested () =
           [ Css.display `block; Css.selector "div" [ Css.display `none ] ];
       ]
   in
-  let css = render_style_tag () in
+  let css = render_string_style_tag () in
   assert_string css
     (Printf.sprintf
        ".%s { color: #F0F8FF; } .%s a { display: block; } .%s a div { display: \
@@ -90,7 +90,7 @@ let selector_nested_x10 () =
           ];
       ]
   in
-  let css = render_style_tag () in
+  let css = render_string_style_tag () in
   assert_string css
     (Printf.sprintf
        ".%s { display: flex; } .%s a { display: block; } .%s a div { display: \
@@ -103,7 +103,7 @@ let selector_ampersand () =
     Css.style
       [ Css.fontSize (`px 42); Css.selector "& .div" [ Css.fontSize (`px 24) ] ]
   in
-  let css = render_style_tag () in
+  let css = render_string_style_tag () in
   assert_string css
     (Printf.sprintf ".%s { font-size: 42px; } .%s  .div { font-size: 24px; }"
        className className)
@@ -115,7 +115,7 @@ let selector_ampersand_at_the_middle () =
         Css.fontSize (`px 42); Css.selector "& div &" [ Css.fontSize (`px 24) ];
       ]
   in
-  let css = render_style_tag () in
+  let css = render_string_style_tag () in
   assert_string css
     (Printf.sprintf ".%s { font-size: 42px; } .%s  div .%s { font-size: 24px; }"
        className className className)
@@ -128,7 +128,7 @@ let media_queries () =
         Css.media "(max-width: 768px)" [ Css.width (`px 300) ];
       ]
   in
-  let css = render_style_tag () in
+  let css = render_string_style_tag () in
   assert_string css
     (Printf.sprintf
        ".%s { max-width: 800px; } @media (max-width: 768px) { .%s { width: \
@@ -139,7 +139,7 @@ let selector_params () =
   let className =
     Css.style [ Css.maxWidth (`px 800); Css.firstChild [ Css.width (`px 300) ] ]
   in
-  let css = render_style_tag () in
+  let css = render_string_style_tag () in
   assert_string css
     (Printf.sprintf
        ".%s { max-width: 800px; } .%s:first-child { width: 300px; }" className
@@ -154,7 +154,7 @@ let keyframe () =
       ]
   in
   let className = Css.style [ Css.animationName animationName ] in
-  let css = render_style_tag () in
+  let css = render_string_style_tag () in
   assert_string css
     (Printf.sprintf
        "@keyframes %s { 0%% { -webkit-transform: rotate(0deg); -moz-transform: \
@@ -167,13 +167,13 @@ let keyframe () =
 
 let global () =
   let _ = Css.global [ Css.selector "html" [ Css.lineHeight (`abs 1.15) ] ] in
-  let css = render_style_tag () in
+  let css = render_string_style_tag () in
   assert_string css (Printf.sprintf "html{line-height:1.15;}")
 
 let duplicated_styles_unique () =
   let className1 = Css.style [ Css.flexGrow 1. ] in
   let className2 = Css.style [ Css.flexGrow 1. ] in
-  let css = render_style_tag () in
+  let css = render_string_style_tag () in
   assert_string className1 className2;
   assert_string css (Printf.sprintf ".%s { flex-grow: 1; }" className1)
 
@@ -185,7 +185,7 @@ let hover_selector () =
         Css.selector "&:hover" [ Css.color (`rgba (255, 255, 255, `num 0.7)) ];
       ]
   in
-  let css = render_style_tag () in
+  let css = render_string_style_tag () in
   assert_string css
     (Printf.sprintf
        ".%s { color: rgb(255, 255, 255); } .%s:hover { color: rgba(255, 255, \


### PR DESCRIPTION
## Why

As mentioned by @purefunctor it would be nice to have full SSR support on styled-ppx:
![image](https://github.com/davesnx/styled-ppx/assets/35539594/09c0316c-a1e1-4918-b7c6-586facb62821)

That way the user doesn't need to create a function to handle it and it will work out of the box by the library.

## How

- Deprecating `render_style_tag `since it doesn't render a tag but the style rules;
  - This avoids breaking change needs.
- Creating `get_string_style_rules ` based on `render_style_tag`;
- Creating `get_string_style_hashes` to get all hashes;
- Creating the `render_style_html_tag` to deliver a full SSR-supported style tag.
  - Example: `<style data-s data-emotion="css className1">.css-className1 { display: block; }</style>`

### Attention, this branch is a extension of this one: https://github.com/davesnx/styled-ppx/pull/468
 
### Screenshot

The screenshot below shows how the emotion handles it well, only creating on client size only client styles the universal styles were not recreated.

![Captura de Tela 2024-04-25 às 14 54 14](https://github.com/davesnx/styled-ppx/assets/35539594/57d54e2e-8021-41d1-8777-55f8cc60705a)
