### PR TITLE
Global styles for native server on emotion

### DIFF
--- a/packages/emotion/native/Css.ml
+++ b/packages/emotion/native/Css.ml
@@ -238,6 +238,7 @@ let pp_rules hash rules =
   Printf.sprintf "%s %s" declarations selectors
 
 type declarations =
+  | Globals of rule list
   | Classnames of rule list
   | Keyframes of (int * rule list) list
 
@@ -313,6 +314,15 @@ let style (styles : rule list) =
     Stylesheet.push instance (className, Classnames styles);
     className
 
+let global (styles : rule list) =
+  match styles with
+  | [] -> "";
+  | _ ->
+    let hash = Murmur2.default (rules_to_string styles) in
+    Stylesheet.push instance (hash, Globals styles);
+    hash
+    
+
 let keyframes (keyframes : (int * rule list) list) =
   match keyframes with
   | [] -> ""
@@ -327,6 +337,8 @@ let render_style_tag () =
   |> List.fold_left
        (fun accumulator (hash, rules) ->
          match rules with
+         | Globals rules ->
+           Printf.sprintf "%s %s" accumulator (rules_to_string rules)
          | Classnames rules ->
            let rules = pp_rules hash rules |> String.trim in
            Printf.sprintf "%s %s" accumulator rules

--- a/packages/emotion/native/CssJs.ml
+++ b/packages/emotion/native/CssJs.ml
@@ -295,6 +295,7 @@ let rec rules_to_string rules =
   Buffer.contents buff
 
 type declarations =
+  | Globals of rule array
   | Classnames of rule array
   | Keyframes of (int * rule array) array
 
@@ -347,6 +348,14 @@ let style (styles : rule array) =
     Stylesheet.push instance (className, Classnames styles);
     className
 
+let global (styles : rule array) =
+  match styles with
+  | [||] -> "";
+  | _ ->
+    let hash = Murmur2.default (rules_to_string (Array.to_list styles)) in
+    Stylesheet.push instance (hash, Globals styles);
+    hash
+
 let keyframes (keyframes : (int * rule array) array) =
   match keyframes with
   | [||] -> ""
@@ -361,6 +370,8 @@ let render_style_tag () =
   |> List.fold_left
        (fun accumulator (hash, rules) ->
          match rules with
+         | Globals rules -> 
+           Printf.sprintf "%s %s" accumulator (rules_to_string (Array.to_list rules))
          | Classnames rules ->
            let rules = pp_rules hash rules |> String.trim in
            Printf.sprintf "%s %s" accumulator rules

--- a/packages/emotion/test/test_css_js_styles.ml
+++ b/packages/emotion/test/test_css_js_styles.ml
@@ -254,6 +254,13 @@ let keyframe () =
         %s; }"
        animationName className animationName animationName)
 
+let global () =
+  let _ =
+    CssJs.global [| CssJs.selector "html" [| CssJs.lineHeight (`abs 1.15) |] |]
+  in
+  let css = render_style_tag () in
+  assert_string css (Printf.sprintf "html{line-height:1.15;}")
+
 let duplicated_styles_unique () =
   let className1 = CssJs.style [| CssJs.flexGrow 1. |] in
   let className2 = CssJs.style [| CssJs.flexGrow 1. |] in
@@ -298,6 +305,7 @@ let tests =
       case "selector_ampersand_at_the_middle" selector_ampersand_at_the_middle;
       case "selector_params" selector_params;
       case "keyframe" keyframe;
+      case "global" global;
       case "duplicated_styles_unique" duplicated_styles_unique;
       case "selector_with_ppx" selector_with_ppx;
       case "avoid_hash_collision" avoid_hash_collision;

--- a/packages/emotion/test/test_css_styles.ml
+++ b/packages/emotion/test/test_css_styles.ml
@@ -165,6 +165,11 @@ let keyframe () =
         %s; }"
        animationName className animationName animationName)
 
+let global () =
+  let _ = Css.global [ Css.selector "html" [ Css.lineHeight (`abs 1.15) ] ] in
+  let css = render_style_tag () in
+  assert_string css (Printf.sprintf "html{line-height:1.15;}")
+
 let duplicated_styles_unique () =
   let className1 = Css.style [ Css.flexGrow 1. ] in
   let className2 = Css.style [ Css.flexGrow 1. ] in
@@ -205,6 +210,7 @@ let tests =
       case "selector_ampersand_at_the_middle" selector_ampersand_at_the_middle;
       case "selector_params" selector_params;
       case "keyframe" keyframe;
+      case "global" global;
       case "duplicated_styles_unique" duplicated_styles_unique;
       case "hover_selector" hover_selector;
     ] )


### PR DESCRIPTION
## Why

The global styling wasn't available on the server side.

## How

- Create a `global` function to handle global styles on the server side;
- The `global` provides its hash to a future SSR style tag delivery.