### PR TITLE
Transform with variable handle unsafe interpolation

### DIFF
--- a/packages/ppx/src/declarations_to_emotion.re
+++ b/packages/ppx/src/declarations_to_emotion.re
@@ -3007,7 +3007,7 @@ let transition_delay =
   );
 let transition =
   unsupportedValue(Parser.property_transition, (~loc) =>
-    [%expr CssJs.transition]
+    [%expr CssJs.transitionList]
   );
 
 let render_keyframes_name = (~loc) =>

--- a/packages/ppx/src/declarations_to_emotion.re
+++ b/packages/ppx/src/declarations_to_emotion.re
@@ -74,9 +74,7 @@ let render_variable = (~loc, name) =>
 
 let transform_with_variable = (parser, mapper, value_to_expr) =>
   emit(
-    /* This Xor is defined here for those properties that aren't defined with
-       <interpolation> as a valid definition */
-    Combinator.combine_xor_first([
+    Combinator.first([
       /* If the entire CSS value is interpolated, we treat it as a `Variable */
       Rule.Match.map(Standard.interpolation, data => `Variable(data)),
       /* Otherwise it's a regular CSS `Value and match the parser */

--- a/packages/ppx/src/declarations_to_string.re
+++ b/packages/ppx/src/declarations_to_string.re
@@ -291,7 +291,7 @@ let found = ({ast_of_string, string_to_expr, _}) => {
 
 let transform_with_variable = (parser, mapper, value_to_expr) =>
   emit(
-    Combinator.combine_xor_first([
+    Combinator.first([
       /* If the CSS value is an interpolation, we treat as one `
          ariable */
       Rule.Match.map(Standard.interpolation, data => `Variable(data)),

--- a/packages/ppx/src/declarations_to_string.re
+++ b/packages/ppx/src/declarations_to_string.re
@@ -291,7 +291,7 @@ let found = ({ast_of_string, string_to_expr, _}) => {
 
 let transform_with_variable = (parser, mapper, value_to_expr) =>
   emit(
-    Combinator.combine_xor([
+    Combinator.combine_xor_first([
       /* If the CSS value is an interpolation, we treat as one `
          ariable */
       Rule.Match.map(Standard.interpolation, data => `Variable(data)),

--- a/packages/ppx/test/native/Interpolation_test.re
+++ b/packages/ppx/test/native/Interpolation_test.re
@@ -172,6 +172,17 @@ let tests =
       [%expr [%css "animation-play-state: paused"]],
       [%expr CssJs.animationPlayState(`paused)],
     ),
+    (
+      "column-gap: $(Size.px30);",
+      [%expr [%css "column-gap: $(Size.px30)"]],
+      [%expr CssJs.unsafe({js|columnGap|js}, Size.px30)],
+    ),
+    (
+      "padding-inline: $(Size.px30);",
+      [%expr [%css "padding-inline: $(Size.px30)"]],
+      // This is because padding-inline is not inside the properties list on declarations_to_emotion.re
+      [%expr CssJs.unsafe({js|paddingInline|js}, {js|$(Size.px30)|js})],
+    ),
   ]
   |> List.map(item => {
        let (title, input, expected) = item;

--- a/packages/reason-css-parser/lib/Combinator.re
+++ b/packages/reason-css-parser/lib/Combinator.re
@@ -53,7 +53,7 @@ let combine_xor =
       value;
     };
 
-let combine_xor_first =
+let first =
   fun
   | [] => failwith("xor doesn't makes sense without a single value")
   | [left, ...rules] => {

--- a/packages/reason-css-parser/lib/Combinator.re
+++ b/packages/reason-css-parser/lib/Combinator.re
@@ -19,6 +19,19 @@ let rec match_longest = ((left_key, left_rule), rules) =>
     };
   };
 
+let rec match_first = ((left_key, left_rule), rules) =>
+  switch (rules) {
+  | [] =>
+    let.bind_match value = left_rule;
+    return_match((left_key, value));
+  | [new_left, ...rules] =>
+    let.bind_data value = left_rule;
+    switch (value) {
+    | Ok(value) => return_match((left_key, value))
+    | Error(_) => match_first(new_left, rules)
+    };
+  };
+
 let combine_static = rules => {
   let rec match_everything = (values, rules) =>
     switch (rules) {
@@ -37,6 +50,16 @@ let combine_xor =
       let rules: list((unit, Rule.rule('a))) =
         List.map(rule => ((), rule), rules);
       let.map_match ((), value) = match_longest(((), left), rules);
+      value;
+    };
+
+let combine_xor_first =
+  fun
+  | [] => failwith("xor doesn't makes sense without a single value")
+  | [left, ...rules] => {
+      let rules: list((unit, Rule.rule('a))) =
+        List.map(rule => ((), rule), rules);
+      let.map_match ((), value) = match_first(((), left), rules);
       value;
     };
 

--- a/packages/reason-css-parser/lib/Combinator.rei
+++ b/packages/reason-css-parser/lib/Combinator.rei
@@ -5,6 +5,8 @@ let combine_static: combinator('a, list('a));
 
 let combine_xor: combinator('a, 'a);
 
+let combine_xor_first: combinator('a, 'a);
+
 let combine_and: combinator('a, list('a));
 
 let combine_or: combinator('a, list(option('a)));

--- a/packages/reason-css-parser/lib/Combinator.rei
+++ b/packages/reason-css-parser/lib/Combinator.rei
@@ -5,7 +5,7 @@ let combine_static: combinator('a, list('a));
 
 let combine_xor: combinator('a, 'a);
 
-let combine_xor_first: combinator('a, 'a);
+let first: combinator('a, 'a);
 
 let combine_and: combinator('a, list('a));
 


### PR DESCRIPTION
Fixes #412
1. `Combinator.combine_xor` will match the longest rule, so although `Standard.interpolation` matches the value, it will select the parser rule. Added `Combinator.combine_xor_first`, which will select the first successful rule.
2. Pass the interpolation expression using `Unsafe_interpolation` exn so we can render them at `render_when_unsupported_features`