### PR TITLE
Add depext for @emotion/css >= 11.0.0

### DIFF
--- a/styled-ppx.opam
+++ b/styled-ppx.opam
@@ -43,3 +43,6 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/davesnx/styled-ppx.git"
+depexts: [
+  ["@emotion/css"] {npm-version = ">=11.0.0"}
+]


### PR DESCRIPTION
This way, running `opam exec opam-check-npm-deps` will return output for `styled-ppx` and warn you if your version of `@emotion/css` is absent or too old.