### PR TITLE
Handle var() globally

### DIFF
--- a/packages/css-property-parser/lib/Parser.re
+++ b/packages/css-property-parser/lib/Parser.re
@@ -138,7 +138,7 @@ and cf_mixing_image = [%value.rec "[ <extended-percentage> ]? && <image>"]
 and class_selector = [%value.rec "'.' <ident-token>"]
 and clip_source = [%value.rec "<url>"]
 and color = [%value.rec
-  "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hex-color> | <named-color> | 'currentColor' | <deprecated-system-color> | <interpolation> | <var()> | <color-mix()>"
+  "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hex-color> | <named-color> | 'currentColor' | <deprecated-system-color> | <interpolation> | <color-mix()>"
 ]
 and color_stop = [%value.rec "<color-stop-length> | <color-stop-angle>"]
 and color_stop_angle = [%value.rec "[ <extended-angle> ]{1,2}"]

--- a/packages/ppx/test/css-support/random.t/run.t
+++ b/packages/ppx/test/css-support/random.t/run.t
@@ -57,7 +57,7 @@ If this test fail means that the module is not in sync with the ppx
   CSS.unsafe({js|breakInside|js}, {js|avoid|js});
   CSS.unsafe({js|caretColor|js}, {js|#e15a46|js});
   CSS.unsafe({js|color|js}, {js|inherit|js});
-  CSS.color(`var({js|--color-link|js}));
+  CSS.unsafe({js|color|js}, {js|var(--color-link)|js});
   CSS.columnWidth(`pxFloat(125.));
   CSS.columnWidth(`auto);
   
@@ -150,6 +150,6 @@ If this test fail means that the module is not in sync with the ppx
   
   CSS.style([|CSS.aspectRatio(`ratio((16, 9)))|]);
   
-  CSS.color(`var({js|--color-link|js}));
+  CSS.unsafe({js|color|js}, {js|var(--color-link)|js});
 
   $ dune build

--- a/packages/ppx/test/native/Static_test.re
+++ b/packages/ppx/test/native/Static_test.re
@@ -787,7 +787,12 @@ let properties_static_css_tests = [
   (
     [%css "color: var(--main-c)"],
     [%expr [%css "color: var(--main-c)"]],
-    [%expr CSS.color(`var({js|--main-c|js}))],
+    [%expr CSS.unsafe({js|color|js}, {js|var(--main-c)|js})],
+  ),
+  (
+    [%css "transition-property: var(--a) random 10px var(--b)"],
+    [%expr [%css "transition-property: var(--a) random 10px var(--b)"]],
+    [%expr CSS.unsafe({js|transitionProperty|js}, {js|var(--a) random 10px var(--b)|js})],
   ),
   (
     [%css "box-shadow: 12px 12px 2px 1px rgba(0, 0, 255, 0.2)"],
@@ -1249,7 +1254,7 @@ let properties_static_css_tests = [
   (
     [%css {|color: var(--color-link);|}],
     [%expr [%css {|color: var(--color-link);|}]],
-    [%expr CSS.color(`var({js|--color-link|js}))],
+    [%expr CSS.unsafe({js|color|js}, {js|var(--color-link)|js})],
   ),
   // unsupported
   /*


### PR DESCRIPTION
Closes #417, we handle this the same way as cascading values.
If we detect the use of var(), it will be unsafe and the value will be rendered as string.