### PR TITLE
Remove space between keyframe rules

### DIFF
--- a/packages/runtime/native/CSS.ml
+++ b/packages/runtime/native/CSS.ml
@@ -412,8 +412,7 @@ end
 
 let keyframes_to_string keyframes =
   let buffer = Buffer.create 1024 in
-  Array.iteri keyframes ~f:(fun i (percentage, rules) ->
-      if i > 0 then Buffer.add_char buffer ' ';
+  Array.iter keyframes ~f:(fun (percentage, rules) ->
       Buffer.add_string buffer (string_of_int percentage);
       Buffer.add_string buffer "%{";
       Buffer.add_string buffer (rules_to_string rules);


### PR DESCRIPTION
## Problem

Consider the following OCaml code:

```ocaml
let loading = [%keyframe {|
  0% { background-position: 1rem 0 ; }
  100% { background-position: 0 0 ; }
|}]
```

In this example, the `loading` animation's name generated on the server is `animation-1fwlinh`, but on the client, it appears as `animation-1qwy1ey`, leading to a mismatch.

## Description

While working with Server-Side Rendering (SSR) and hydration, I encountered a hard-to-diagnose issue:

```
Warning: Prop `className` did not match. Server: "css-ygijhp css-1j1ftdp css-1tyndxa css-1nns36c css-1y1tzge" Client: "css-ygijhp css-1ip10c0 css-1tyndxa css-1nns36c css-1y1tzge"
```

Initially, I suspected the problem was related to a misused `switch%platform`. After extensive debugging, I discovered that the root cause was the difference in how animation names are generated between the server and client environments. The discrepancy arises from an extra space added between keyframe rules when processed natively, compared to the behavior in `emotion`.

The key issue lies in the following keyframe rule:

```ocaml
let loading = [%keyframe {|
  0% { background-position: 1rem 0 ; }
  100% { background-position: 0 0 ; }
|}]
```

This produces the following string for hashing: "0%{transform:rotate(0deg);} 100%{transform:rotate(-360deg);}"

As a result, the generated animation name on the server is `animation-1fwlinh`, but on the client, it is `animation-1qwy1ey`, causing the class name mismatch.

To resolve the issue, I found that removing the space between keyframe rules in the CSS resolves the mismatch:

```diff
- 0%{transform:rotate(0deg);} 100%{transform:rotate(-360deg);}
+ 0%{transform:rotate(0deg);}100%{transform:rotate(-360deg);}
```

This change ensures that the animation name is consistent between server and client: `animation-1qwy1ey`.

This slight difference in spacing affects the hash generated for the animation name, which explains the discrepancy between SSR and client-side rendering.

To make sure it was the behavior I checked the emotion code and there was no space for keyframes as we can see on those files: 
https://github.com/emotion-js/emotion/blob/e310c6e6a9f0b4f55030831ef65cd07c7105ae01/packages/css/src/create-instance.ts#L111-L122
https://github.com/emotion-js/emotion/blob/e310c6e6a9f0b4f55030831ef65cd07c7105ae01/packages/serialize/src/index.ts#L385-L470
On loop, like ours, there is no space added: https://github.com/emotion-js/emotion/blob/e310c6e6a9f0b4f55030831ef65cd07c7105ae01/packages/serialize/src/index.ts#L418-L431

