### PR TITLE
Try removing skip_whitespace

### DIFF
--- a/packages/parser/lib/Lexer.re
+++ b/packages/parser/lib/Lexer.re
@@ -158,6 +158,9 @@ let is_tag =
   | "a"
   | "abbr"
   | "address"
+  | "animate"
+  | "animateMotion"
+  | "animateTransform"
   | "area"
   | "article"
   | "aside"
@@ -172,27 +175,59 @@ let is_tag =
   | "button"
   | "canvas"
   | "caption"
+  | "circle"
   | "cite"
+  | "clipPath"
   | "code"
   | "col"
   | "colgroup"
   | "data"
   | "datalist"
   | "dd"
+  | "defs"
   | "del"
+  | "desc"
   | "details"
   | "dfn"
   | "dialog"
   | "div"
   | "dl"
   | "dt"
+  | "ellipse"
   | "em"
   | "embed"
+  | "feBlend"
+  | "feColorMatrix"
+  | "feComponentTransfer"
+  | "feComposite"
+  | "feConvolveMatrix"
+  | "feDiffuseLighting"
+  | "feDisplacementMap"
+  | "feDistantLight"
+  | "feDropShadow"
+  | "feFlood"
+  | "feFuncA"
+  | "feFuncB"
+  | "feFuncG"
+  | "feFuncR"
+  | "feGaussianBlur"
+  | "feImage"
+  | "feMerge"
+  | "feMergeNode"
+  | "feMorphology"
+  | "feOffset"
+  | "fePointLight"
+  | "feSpecularLighting"
+  | "feSpotLight"
+  | "feTile"
+  | "feTurbulence"
   | "fieldset"
   | "figcaption"
   | "figure"
   | "footer"
+  | "foreignObject"
   | "form"
+  | "g"
   | "h1"
   | "h2"
   | "h3"
@@ -206,6 +241,7 @@ let is_tag =
   | "html"
   | "i"
   | "iframe"
+  | "image"
   | "img"
   | "input"
   | "ins"
@@ -213,15 +249,20 @@ let is_tag =
   | "label"
   | "legend"
   | "li"
+  | "line"
+  | "linearGradient"
   | "link"
   | "main"
   | "map"
   | "mark"
+  | "marker"
   | "math"
   | "menu"
   | "menuitem"
   | "meta"
+  | "metadata"
   | "meter"
+  | "mpath"
   | "nav"
   | "noscript"
   | "object"
@@ -231,11 +272,17 @@ let is_tag =
   | "output"
   | "p"
   | "param"
+  | "path"
+  | "pattern"
   | "picture"
+  | "polygon"
+  | "polyline"
   | "pre"
   | "progress"
   | "q"
+  | "radialGradient"
   | "rb"
+  | "rect"
   | "rp"
   | "rt"
   | "rtc"
@@ -245,21 +292,27 @@ let is_tag =
   | "script"
   | "section"
   | "select"
+  | "set"
   | "slot"
   | "small"
   | "source"
   | "span"
+  | "stop"
   | "strong"
   | "style"
   | "sub"
   | "summary"
   | "sup"
   | "svg"
+  | "switch"
+  | "symbol"
   | "table"
   | "tbody"
   | "td"
   | "template"
+  | "text"
   | "textarea"
+  | "textPath"
   | "tfoot"
   | "th"
   | "thead"
@@ -267,10 +320,13 @@ let is_tag =
   | "title"
   | "tr"
   | "track"
+  | "tspan"
   | "u"
   | "ul"
+  | "use"
   | "var"
   | "video"
+  | "view"
   | "wbr" => true
   | _ => false;
 
@@ -541,8 +597,6 @@ let handle_tokenizer_error = lexbuf => {
     };
 };
 
-let skip_whitespace = ref(false);
-
 let rec get_next_token = lexbuf => {
   switch%sedlex (lexbuf) {
   | eof => Parser.EOF
@@ -550,12 +604,8 @@ let rec get_next_token = lexbuf => {
   | "/*" => discard_comments(lexbuf)
   | '.' => DOT
   | ';' => SEMI_COLON
-  | '}' =>
-    skip_whitespace.contents = false;
-    RIGHT_BRACE;
-  | '{' =>
-    skip_whitespace.contents = true;
-    LEFT_BRACE;
+  | '}' => RIGHT_BRACE
+  | '{' => LEFT_BRACE
   | "::" => DOUBLE_COLON
   | ':' => COLON
   | '(' => LEFT_PAREN
@@ -563,9 +613,7 @@ let rec get_next_token = lexbuf => {
   | '[' => LEFT_BRACKET
   | ']' => RIGHT_BRACKET
   | '%' => PERCENT
-  | '&' =>
-    skip_whitespace.contents = false;
-    AMPERSAND;
+  | '&' => AMPERSAND
   | '*' => ASTERISK
   | ',' => COMMA
   | variable =>
@@ -582,33 +630,18 @@ let rec get_next_token = lexbuf => {
   | all_media_type => ALL_MEDIA_TYPE(lexeme(lexbuf))
   | screen_media_type => SCREEN_MEDIA_TYPE(lexeme(lexbuf))
   | print_media_type => PRINT_MEDIA_TYPE(lexeme(lexbuf))
-  | at_media =>
-    skip_whitespace.contents = false;
-    AT_MEDIA(lexeme(~skip=1, lexbuf));
-  | at_keyframes =>
-    skip_whitespace.contents = false;
-    AT_KEYFRAMES(lexeme(~skip=1, lexbuf));
-  | at_container =>
-    skip_whitespace.contents = false;
-    AT_CONTAINER(lexeme(~skip=1, lexbuf));
-  | at_rule_without_body =>
-    skip_whitespace.contents = false;
-    AT_RULE_STATEMENT(lexeme(~skip=1, lexbuf));
-  | at_rule =>
-    skip_whitespace.contents = false;
-    AT_RULE(lexeme(~skip=1, lexbuf));
+  | at_media => AT_MEDIA(lexeme(~skip=1, lexbuf))
+  | at_keyframes => AT_KEYFRAMES(lexeme(~skip=1, lexbuf))
+  | at_container => AT_CONTAINER(lexeme(~skip=1, lexbuf))
+  | at_rule_without_body => AT_RULE_STATEMENT(lexeme(~skip=1, lexbuf))
+  | at_rule => AT_RULE(lexeme(~skip=1, lexbuf))
   /* NOTE: should be placed above ident, otherwise pattern with
    * '-[0-9a-z]{1,6}' cannot be matched */
   | (_u, '+', unicode_range) => UNICODE_RANGE(lexeme(lexbuf))
   | ('#', name) => HASH(lexeme(~skip=1, lexbuf))
   /* TODO: get_dimension and handle_numeric should be the same */
   | number => get_dimension(lexeme(lexbuf), lexbuf)
-  | whitespaces =>
-    if (skip_whitespace^) {
-      get_next_token(lexbuf);
-    } else {
-      WS;
-    }
+  | whitespaces => WS
   | ("-", ident) => IDENT(lexeme(lexbuf))
   /* --variable */
   | ("-", "-", ident) => IDENT(lexeme(lexbuf))

--- a/packages/parser/lib/Lexer.re
+++ b/packages/parser/lib/Lexer.re
@@ -647,6 +647,7 @@ let rec get_next_token = lexbuf => {
     consume_ident_like(lexbuf) |> handle_tokenizer_error(lexbuf);
   /* --variable */
   | ("-", "-", ident) => IDENT(lexeme(lexbuf))
+  | escape
   | identifier_start_code_point =>
     let _ = Sedlexing.backtrack(lexbuf);
     consume_ident_like(lexbuf) |> handle_tokenizer_error(lexbuf);

--- a/packages/parser/lib/Lexer.re
+++ b/packages/parser/lib/Lexer.re
@@ -642,7 +642,9 @@ let rec get_next_token = lexbuf => {
   /* TODO: get_dimension and handle_numeric should be the same */
   | number => get_dimension(lexeme(lexbuf), lexbuf)
   | whitespaces => WS
-  | ("-", ident) => IDENT(lexeme(lexbuf))
+  | ("-", ident) =>
+    Sedlexing.rollback(lexbuf);
+    consume_ident_like(lexbuf) |> handle_tokenizer_error(lexbuf);
   /* --variable */
   | ("-", "-", ident) => IDENT(lexeme(lexbuf))
   | identifier_start_code_point =>

--- a/packages/parser/lib/Lexer.rei
+++ b/packages/parser/lib/Lexer.rei
@@ -1,9 +1,6 @@
 /** Signals a lexing error at the provided source location. */
 exception LexingError((Lexing.position, Lexing.position, string));
 
-/** Makes the lexer be aware of whitespaces or not */
-let skip_whitespace: ref(bool);
-
 type token_with_location = {
   txt: result(Tokens.token, (Tokens.token, Tokens.error)),
   loc: Ast.loc,

--- a/packages/parser/lib/Parser.mly
+++ b/packages/parser/lib/Parser.mly
@@ -430,7 +430,7 @@ style_rule:
     }
   }
 
-values: xs = nonempty_list(loc(skip_ws(value))) { xs }
+values: xs = list(loc(skip_ws(value))) { xs }
 prelude_any: xs = list(loc(skip_ws(value))) { Paren_block xs }
 
 declarations:
@@ -556,7 +556,7 @@ attribute_selector:
   | LEFT_BRACKET; WS?
     i = wq_name WS?
     m = attr_matcher; WS?
-    v = IDENT WS?
+    v = wq_name WS?
     RIGHT_BRACKET {
     Attribute(
       To_equal({

--- a/packages/parser/lib/Parser.mly
+++ b/packages/parser/lib/Parser.mly
@@ -85,7 +85,7 @@ skip_ws_left (X): WS? x = X; { x }
 
 /* TODO: Remove empty_brace_block */
 /* {} */
-empty_brace_block: pair(LEFT_BRACE, RIGHT_BRACE) { [] }
+empty_brace_block: LEFT_BRACE WS? RIGHT_BRACE { [] }
 
 /* TODO: Remove SEMI_COLON? from brace_block(X) */
 /* { ... } */
@@ -602,10 +602,6 @@ type_selector:
   | AMPERSAND; { Ampersand } /* & {} https://drafts.csswg.org/css-nesting/#nest-selector */
   | ASTERISK; { Universal } /* * {} */
   | v = INTERPOLATION { Variable v } /* $(Module.value) {} */
-  /* TODO: type_selector should work with IDENTs, but there's a bunch of grammar
-    conflicts with IDENT on value and others, we replaced with TAG, a
-    list of valid HTML tags that does the job done, but this should be fixed. */
-  | type_ = IDENT; { Type type_ } /* a {} */
   | type_ = TAG; { Type type_ } /* a {} */
 
 /* <simple-selector> = <type-selector> | <subclass-selector> */

--- a/packages/parser/lib/driver.re
+++ b/packages/parser/lib/driver.re
@@ -2,9 +2,7 @@ module Location = Ppxlib.Location;
 
 let menhir = MenhirLib.Convert.Simplified.traditional2revised;
 
-let parse = (~loc: Ppxlib.location, skip_whitespaces, lexbuf, parser) => {
-  Lexer.skip_whitespace.contents = skip_whitespaces;
-
+let parse = (~loc: Ppxlib.location, lexbuf, parser) => {
   let last_token = ref((Parser.EOF, Lexing.dummy_pos, Lexing.dummy_pos));
 
   let next_token = () => {
@@ -31,21 +29,21 @@ let parse = (~loc: Ppxlib.location, skip_whitespaces, lexbuf, parser) => {
 
 let last_buffer = ref(None);
 
-let parse_string = (~skip_whitespace, ~loc, parser, string) => {
+let parse_string = (~loc, parser, string) => {
   let buffer = Sedlexing.Latin1.from_string(string);
   last_buffer := Some(Sedlexing.Latin1.from_string(string));
-  parse(~loc, skip_whitespace, buffer, parser);
+  parse(~loc, buffer, parser);
 };
 
 let parse_declaration_list = (~loc, input: string) => {
-  parse_string(~loc, ~skip_whitespace=false, Parser.declaration_list, input);
+  parse_string(~loc, Parser.declaration_list, input);
 };
 
 let parse_declaration = (~loc, input: string) =>
-  parse_string(~loc, ~skip_whitespace=true, Parser.declaration, input);
+  parse_string(~loc, Parser.declaration, input);
 
 let parse_stylesheet = (~loc, input: string) =>
-  parse_string(~loc, ~skip_whitespace=false, Parser.stylesheet, input);
+  parse_string(~loc, Parser.stylesheet, input);
 
 let parse_keyframes = (~loc, input: string) =>
-  parse_string(~loc, ~skip_whitespace=false, Parser.keyframes, input);
+  parse_string(~loc, Parser.keyframes, input);

--- a/packages/parser/test/Lexer_test.re
+++ b/packages/parser/test/Lexer_test.re
@@ -6,6 +6,9 @@ module Parser = Styled_ppx_css_parser.Parser;
 
 let success_tests =
   [
+    ({|inset-3\.5|}, [IDENT("inset-3.5")]),
+    ({|-inset-3\.5|}, [IDENT("-inset-3.5")]),
+    ({|inset-1\/3|}, [IDENT("inset-1/3")]),
     (" \n\t ", [WS]),
     ({|"something"|}, [STRING("something")]),
     ({|'tuturu'|}, [STRING("tuturu")]),

--- a/packages/parser/test/Lexer_test.re
+++ b/packages/parser/test/Lexer_test.re
@@ -9,6 +9,7 @@ let success_tests =
     ({|inset-3\.5|}, [IDENT("inset-3.5")]),
     ({|-inset-3\.5|}, [IDENT("-inset-3.5")]),
     ({|inset-1\/3|}, [IDENT("inset-1/3")]),
+    ({|\32xl\:container|}, [IDENT("2xl:container")]),
     (" \n\t ", [WS]),
     ({|"something"|}, [STRING("something")]),
     ({|'tuturu'|}, [STRING("tuturu")]),

--- a/packages/ppx/test/css-support/media-interp-location-error.t/run.t
+++ b/packages/ppx/test/css-support/media-interp-location-error.t/run.t
@@ -13,10 +13,10 @@ If this test fail means that the module is not in sync with the ppx
   > EOF
 
   $ dune build
-  File "input.re", line 2, characters 11-20:
-  Error: Parse error while reading token '('
+  File "input.re", line 2, characters 19-21:
+  Error: Parse error while reading token '2'
   [1]
 
   $ dune describe pp ./input.re | sed '1,/^];$/d'
   
-  let _className = [%ocaml.error "Parse error while reading token '('"];
+  let _className = [%ocaml.error "Parse error while reading token '2'"];

--- a/packages/ppx/test/css-support/non-valid-value-location-error-nested.t/run.t
+++ b/packages/ppx/test/css-support/non-valid-value-location-error-nested.t/run.t
@@ -13,7 +13,7 @@ If this test fail means that the module is not in sync with the ppx
   > EOF
 
   $ dune build
-  File "input.re", line 6, characters 10-18:
+  File "input.re", line 6, characters 11-18:
   Error: Property 'color' has an invalid value: 'cositas',
          Expected 'function color-mix'. Got 'ident cositas' instead.
   [1]

--- a/packages/ppx/test/native/Selector_test.re
+++ b/packages/ppx/test/native/Selector_test.re
@@ -612,6 +612,22 @@ let nested_tests = [
       |])
     ],
   ),
+  (
+    ".a .b { .a .b {} .a.b {} .a .b {} }",
+    [%expr [%cx ".a .b { .a .b {} .a.b {} .a .b {} }"]],
+    [%expr
+      CSS.style([|
+        CSS.selectorMany(
+          [|{js|.a .b|js}|],
+          [|
+            CSS.selectorMany([|{js|.a .b|js}|], [||]),
+            CSS.selectorMany([|{js|.a.b|js}|], [||]),
+            CSS.selectorMany([|{js|.a .b|js}|], [||]),
+          |],
+        ),
+      |])
+    ],
+  ),
 ];
 
 let comments_tests = [

--- a/packages/runtime/test/test_styles.ml
+++ b/packages/runtime/test/test_styles.ml
@@ -1191,6 +1191,47 @@ let ampersand_everywhere_global =
      .lola{font-size:5px;}.lola .foo .foo:focus .foo .foo \
      .lola{font-size:6px;}"
 
+let css_variable =
+  test "css_variable" @@ fun () ->
+  [%global
+    {|
+      :root {
+        --bs-dropdown-bg: #343a40;
+        --bs-dropdown-border-color: var(--bs-border-color-translucent, black);
+        --bs-dropdown-box-shadow: ;
+      }
+    |}];
+  let css = get_string_style_rules () in
+  assert_string css
+    ":root{--bs-dropdown-bg:#343a40;--bs-dropdown-border-color:var(--bs-border-color-translucent, \
+     black);--bs-dropdown-box-shadow:;}"
+
+let attribute_selector =
+  test "attribute_selector" @@ fun () ->
+  [%global
+    {|
+      [list]:not([type=date]):not([type=datetime-local]):not([type=month]):not([type=week]):not([type=time])::-webkit-calendar-picker-indicator {
+        display: none !important;
+      }
+
+      button,
+      [type=button],
+      [type=reset],
+      [type=submit] {
+        -webkit-appearance: button;
+      }
+      button:not(:disabled),
+      [type=button]:not(:disabled),
+      [type=reset]:not(:disabled),
+      [type=submit]:not(:disabled) {
+        cursor: pointer;
+      }
+    |}];
+  let css = get_string_style_rules () in
+  assert_string css
+    "[list]:not([type=date]):not([type=datetime-local]):not([type=month]):not([type=week]):not([type=time])::-webkit-calendar-picker-indicator{display:none \
+     !important;}button{-webkit-appearance:button;}[type=button]{-webkit-appearance:button;}[type=reset]{-webkit-appearance:button;}[type=submit]{-webkit-appearance:button;}button:not(:disabled){cursor:pointer;}[type=button]:not(:disabled){cursor:pointer;}[type=reset]:not(:disabled){cursor:pointer;}[type=submit]:not(:disabled){cursor:pointer;}"
+
 let tests =
   ( "CSS",
     [
@@ -1251,4 +1292,6 @@ let tests =
       mq_and_selectors_2;
       global_with_selector;
       ampersand_everywhere_global;
+      css_variable;
+      attribute_selector;
     ] )

--- a/packages/runtime/test/test_styles.ml
+++ b/packages/runtime/test/test_styles.ml
@@ -146,7 +146,8 @@ let selector_nested =
         CSS.margin @@ CSS.px 10;
         CSS.selectorMany [| "a" |]
           [|
-            CSS.display `block; CSS.selectorMany [| "div" |] [| CSS.display `none |];
+            CSS.display `block;
+            CSS.selectorMany [| "div" |] [| CSS.display `none |];
           |];
       |]
   in
@@ -444,7 +445,8 @@ let keyframe =
 
 let global =
   test "global" @@ fun () ->
-  CSS.global [| CSS.selectorMany [| "html" |] [| CSS.lineHeight (`abs 1.15) |] |];
+  CSS.global
+    [| CSS.selectorMany [| "html" |] [| CSS.lineHeight (`abs 1.15) |] |];
   let css = get_string_style_rules () in
   assert_string css (Printf.sprintf "html{line-height:1.15;}")
 
@@ -559,7 +561,7 @@ let functional_pseudo =
   let css = get_string_style_rules () in
   assert_string css
     (Printf.sprintf
-       ".%s .foo:is(ol, ul, menu:unsupported):is(ol, ul) { color: #008000; } \
+       ".%s .foo:is(ol, ul, menu:unsupported) :is(ol, ul) { color: #008000; } \
         .%s .foo:is(ol, ul) :is(ol, ul) ol { list-style-type: lower-greek; \
         color: #D2691E; } .%s .foo p:not(.irrelevant) { font-weight: 700; } \
         .%s .foo p > :not(strong, b.important) { color: #8B008B; } .%s \
@@ -568,7 +570,7 @@ let functional_pseudo =
         lower-greek; color: #D2691E; } .%s .foo:is(h1, h2, h3):has(+ :is(h2, \
         h3, h4)) { margin: 0 0 0.25rem 0; } .%s .foo body:has(video, audio) { \
         color: #FF0000; } .%s .foo body:has(video):has(audio) { color: \
-        #FF0000; } .%s .bar:is(ol, ul, menu:unsupported):is(ol, ul) { color: \
+        #FF0000; } .%s .bar:is(ol, ul, menu:unsupported) :is(ol, ul) { color: \
         #008000; } .%s .bar:is(ol, ul) :is(ol, ul) ol { list-style-type: \
         lower-greek; color: #D2691E; } .%s .bar p:not(.irrelevant) { \
         font-weight: 700; } .%s .bar p > :not(strong, b.important) { color: \
@@ -756,7 +758,8 @@ let selector_with_empty_interp =
 
 let style_tag =
   test "style_tag" @@ fun () ->
-  CSS.global [| CSS.selectorMany [| "html" |] [| CSS.lineHeight (`abs 1.15) |] |];
+  CSS.global
+    [| CSS.selectorMany [| "html" |] [| CSS.lineHeight (`abs 1.15) |] |];
   let animationName =
     CSS.keyframes
       [|


### PR DESCRIPTION
Maybe can remove? this PR should fix this bug

input
```
.a .b { .a .b {} .a.b {} .a .b {} }
```
output
```
.a .b { .a.b {} .a.b {} .a .b {} }
```