### PR TITLE
fix usage of sedlex and upgrade to sedlex 3.5

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -32,7 +32,7 @@
    (ppx_deriving (>= 5.0))
    (ppx_deriving_yojson (>= 3.7.0))
    (ppxlib (and (>= 0.27.0) (<= 0.34.0)))
-   (sedlex (>= 3.2))
+   (sedlex (>= 3.5))
    (melange (>= 3.0.0))
    (server-reason-react (>= 0.3.1))
    (reason-react (>= 0.14.0))

--- a/packages/css-spec-parser/lib/Lexer.re
+++ b/packages/css-spec-parser/lib/Lexer.re
@@ -4,7 +4,7 @@ open Tokens;
 // TODO: is rgb(255 255 255/0) valid?
 let whitespace = [%sedlex.regexp? Plus(' ' | '\t' | '\n')];
 let digit = [%sedlex.regexp? '0' .. '9'];
-let number = [%sedlex.regexp? (Opt('+' | '-'), digit | "∞")];
+let number = [%sedlex.regexp? (Opt('+' | '-'), digit | Utf8("∞"))];
 let range_restriction = [%sedlex.regexp? ('[', number, ',', number, ']')];
 
 let stop_literal = [%sedlex.regexp?

--- a/packages/parser/lib/Lexer.re
+++ b/packages/parser/lib/Lexer.re
@@ -44,7 +44,24 @@ let escape = [%sedlex.regexp? '\\'];
 
 let alpha = [%sedlex.regexp? 'a' .. 'z' | 'A' .. 'Z'];
 
-let non_ascii = [%sedlex.regexp? '\160' .. '\255'];
+
+// https://drafts.csswg.org/css-syntax-3/#non-ascii-ident-code-point
+let non_ascii = [%sedlex.regexp?
+  0x00B7
+| 0x00C0 .. 0x00D6
+| 0x00D8 .. 0x00F6
+| 0x00F8 .. 0x037D
+| 0x037F .. 0x1FFF
+| 0x200C
+| 0x200D
+| 0x203F
+| 0x2040
+| 0x2070 .. 0x218F
+| 0x2C00 .. 0x2FEF
+| 0x3001 .. 0xD7FF
+| 0xF900 .. 0xFDCF
+| 0xFDF0 .. 0xFFFD
+| Compl (0x0000 .. 0x10000)]
 
 let ident_start = [%sedlex.regexp? '_' | alpha | '$' | non_ascii | escape];
 
@@ -106,10 +123,8 @@ let at_rule_without_body = [%sedlex.regexp?
 let at_rule = [%sedlex.regexp? ("@", ident)];
 let at_keyframes = [%sedlex.regexp? ("@", "keyframes")];
 
-let non_ascii_code_point = [%sedlex.regexp? Sub(any, '\000' .. '\128')]; // greater than \u0080
-
 let identifier_start_code_point = [%sedlex.regexp?
-  alpha | non_ascii | non_ascii_code_point | '_'
+  alpha | non_ascii | '_'
 ];
 let starts_with_a_valid_escape = [%sedlex.regexp? ('\\', Sub(any, '\n'))];
 

--- a/styled-ppx.opam
+++ b/styled-ppx.opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_deriving" {>= "5.0"}
   "ppx_deriving_yojson" {>= "3.7.0"}
   "ppxlib" {>= "0.27.0" & <= "0.34.0"}
-  "sedlex" {>= "3.2"}
+  "sedlex" {>= "3.5"}
   "melange" {>= "3.0.0"}
   "server-reason-react" {>= "0.3.1"}
   "reason-react" {>= "0.14.0"}


### PR DESCRIPTION
The upcoming release of sedlex (https://github.com/ocaml/opam-repository/pull/27959) revealed a bug in styled-ppx.
Utf8 literals in sedlex patterns was previously not working. 
The non_ascii pattern also triggered a compile time error with sedlex 3.5.
Its definition was suspicious and I attempted to fix it according to the spec.

See the opam release https://github.com/ocaml/opam-repository/pull/27959

See the sedlex PR adding support for utf8 litterals and adding more checks https://github.com/ocaml-community/sedlex/pull/127