### PR TITLE
Improve CSS Spec parser

### DIFF
--- a/packages/css-property-parser/ppx/Generate.re
+++ b/packages/css-property-parser/ppx/Generate.re
@@ -15,7 +15,7 @@ module Make = (Builder: Ppxlib.Ast_builder.S) => {
       switch (value) {
       | Terminal(Delim(name), _) => value_of_delimiter(name)
       | Terminal(Keyword(name), _) => keyword_to_css(name)
-      | Terminal(Data_type(name), _) => value_name_of_css(name)
+      | Terminal(Data_type(name, _), _) => value_name_of_css(name)
       | Terminal(Property_type(name), _) =>
         property_value_name(name) |> value_name_of_css
       | Group(value, _) => variant_name(value)
@@ -107,7 +107,7 @@ module Make = (Builder: Ppxlib.Ast_builder.S) => {
       let (type_, is_constructor, params) =
         switch (kind) {
         | Keyword(_name) => (type_name, false, [])
-        | Data_type(name) =>
+        | Data_type(name, _) =>
           let name = value_name_of_css(name);
           let params = [ptyp_constr(txt @@ Lident(name), [])];
           (type_name, false, params);
@@ -127,7 +127,7 @@ module Make = (Builder: Ppxlib.Ast_builder.S) => {
         switch (kind) {
         | Delim(_)
         | Keyword(_) => ptyp_constr(txt @@ Lident("unit"), [])
-        | Data_type(name) =>
+        | Data_type(name, _) =>
           let name = value_name_of_css(name);
           ptyp_constr(txt @@ Lident(name), []);
         | Property_type(name) =>
@@ -468,7 +468,7 @@ module Make = (Builder: Ppxlib.Ast_builder.S) => {
         | Delim(delim) when delim == "," => evar("comma")
         | Delim(delim) => eapply(evar("delim"), [estring(delim)])
         | Keyword(name) => eapply(evar("keyword"), [estring(name)])
-        | Data_type(name) => value_name_of_css(name) |> evar
+        | Data_type(name, _) => value_name_of_css(name) |> evar
         | Property_type(name) =>
           property_value_name(name) |> value_name_of_css |> evar
         };

--- a/packages/css-spec-parser/lib/Ast.re
+++ b/packages/css-spec-parser/lib/Ast.re
@@ -1,10 +1,12 @@
-// TODO: range <length [0, infinity]
-// TODO: terminology
-// TODO: add css-wide keywords?
+[@deriving show({ with_path: false })]
+type range_bound =
+  | Int_bound(int)
+  | Infinity
+  | Neg_infinity;
 
-// TODO: maybe polymorphic variant?
-// TODO: best naming to no multiplier
-// TODO: can a value have two multipliers?
+[@deriving show({ with_path: false })]
+type range = (range_bound, range_bound);
+
 [@deriving show({ with_path: false })]
 type multiplier =
   | One /* */
@@ -13,13 +15,13 @@ type multiplier =
   | Optional /* ? */
   | Repeat(int, option(int)) /* {A} {A,B} {A,} */
   | Repeat_by_comma(int, option(int)) /* # #{A, B} */
-  | At_least_one /* ! */; // TODO: ! is only allowed for groups
+  | At_least_one /* ! */;
 
 [@deriving show({ with_path: false })]
 type terminal =
   | Delim(string) /* ',' */
   | Keyword(string) /* auto */
-  | Data_type(string) /* <color> */
+  | Data_type(string, option(range)) /* <color> or <number [0, 1]> */
   | Property_type(string) /* <'color'> */;
 
 [@deriving show({ with_path: false })]
@@ -29,23 +31,9 @@ type combinator =
   | Or /* a || b */
   | Xor; /* a | b */
 
-// TODO: non-terminals https://drafts.csswg.org/css-values-3/#component-types item 4
 [@deriving show({ with_path: false })]
 type value =
   | Terminal(terminal, multiplier)
   | Combinator(combinator, list(value))
   | Group(value, multiplier) /* [ A ] */
   | Function_call(string, value) /* F( A ) */;
-// TODO: does Function_call accepts multiplier?
-
-// the only case where At_least_one makes sense, is with static
-// A? || B? = A? && B?
-// [ A? || B? ]! = [ A? && B? ]! = A || B
-// A? | B? ... what would that mean? true | true ?
-// [ A? | B? ]! = A | B
-// [ A? B? ]! != A B
-
-// [ A? B? ]! != [ A B ]
-// [ A? && B? ]! == A || B
-// [ A? || B? ]! == A || B
-// [ A? | B? ]! == A | B

--- a/packages/css-spec-parser/lib/Css_spec_parser.re
+++ b/packages/css-spec-parser/lib/Css_spec_parser.re
@@ -62,7 +62,24 @@ let rec string_of_value = value => {
         switch (kind) {
         | Delim(d) => {|'|} ++ d ++ {|'|}
         | Keyword(name) => {|'|} ++ name ++ {|'|}
-        | Data_type(name) => "<" ++ name ++ ">"
+        | Data_type(name, range) =>
+          let range_str =
+            switch (range) {
+            | None => ""
+            | Some((min, max)) =>
+              let bound_to_string = (
+                fun
+                | Int_bound(n) => Int.to_string(n)
+                | Infinity => "\xe2\x88\x9e"
+                | Neg_infinity => "-\xe2\x88\x9e"
+              );
+              " ["
+              ++ bound_to_string(min)
+              ++ ", "
+              ++ bound_to_string(max)
+              ++ "]";
+            };
+          "<" ++ name ++ range_str ++ ">";
         | Property_type(name) => "<'" ++ name ++ "'>"
         };
       (full_name, Some(multiplier));
@@ -93,9 +110,7 @@ let rec string_of_value = value => {
   };
 };
 
-exception ParseError(string);
-
 let value_of_string = string =>
   try(Sedlexing.Utf8.from_string(string) |> provider |> value_of_lex) {
-  | _ => raise(ParseError(string))
+  | _ => None
   };

--- a/packages/css-spec-parser/lib/Tokens.re
+++ b/packages/css-spec-parser/lib/Tokens.re
@@ -2,7 +2,7 @@
 type token =
   // literals
   | LITERAL(string) // auto 'auto'
-  | DATA(string) // <number>
+  | DATA((string, option(Ast.range))) // <number> or <number [0, 1]>
   | PROPERTY(string) // <'color'>
   // combinators
   | DOUBLE_AMPERSAND // &&

--- a/packages/renderer/spec_renderer.re
+++ b/packages/renderer/spec_renderer.re
@@ -27,7 +27,7 @@ let render_terminal =
   fun
   | Delim(d) => sprintf("Delim(%s)", d)
   | Keyword(v) => sprintf("Keyword(%s)", v)
-  | Data_type(v) => sprintf("Data_type(%s)", v)
+  | Data_type(v, _) => sprintf("Data_type(%s)", v)
   | Property_type(v) => sprintf("Property_type(%s)", v);
 
 let rec render_value =


### PR DESCRIPTION
- Add range restriction support to Data_type (e.g. <number [0, 1]>) with new range_bound and range types, plus infinity handling
- Restrict ! (At_least_one) multiplier to groups only per CSS Values 4
- Implement stacked multipliers (+#, #?, {A}?, {A,B}?) desugaring to Group nodes during parsing
- Fix value_of_string to return option instead of raising ParseError
- Remove resolved TODO comments (terminology, css-wide keywords, polymorphic variants, naming, non-terminals, Function_call multiplier)
- Update downstream consumers (Generate.re, spec_renderer.re)

